### PR TITLE
CONSOLE-5424: Add minimize action for toast notifications

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -14,6 +14,7 @@ table in [Console dynamic plugins README](./README.md).
 
 - **Deprecated**: The use of multiple predicates in the `useResolvedExtensions` hook is deprecated ([#16115], [CONSOLE-5065])
 - **Type breaking**: Replace `ExtensionTypeGuard` with `ExtensionPredicate` from `@openshift/dynamic-plugin-sdk` ([#16115], [CONSOLE-5065])
+- Add minimize action for toast notifications via new `ToastOptions.minimizable`, `ToastOptions.actions[].minimize`, and `ToastContextValues.minimizeToast` ([CONSOLE-5424], [#16762])
 
 ## 4.23.0-prerelease.4 - 2026-07-14
 
@@ -252,6 +253,7 @@ table in [Console dynamic plugins README](./README.md).
 [CONSOLE-5356]: https://issues.redhat.com/browse/CONSOLE-5356
 [CONSOLE-5361]: https://issues.redhat.com/browse/CONSOLE-5361
 [CONSOLE-5415]: https://issues.redhat.com/browse/CONSOLE-5415
+[CONSOLE-5424]: https://issues.redhat.com/browse/CONSOLE-5424
 [OCPBUGS-19048]: https://issues.redhat.com/browse/OCPBUGS-19048
 [OCPBUGS-30077]: https://issues.redhat.com/browse/OCPBUGS-30077
 [OCPBUGS-31355]: https://issues.redhat.com/browse/OCPBUGS-31355
@@ -346,3 +348,4 @@ table in [Console dynamic plugins README](./README.md).
 [#16636]: https://github.com/openshift/console/pull/16636
 [#16726]: https://github.com/openshift/console/pull/16726
 [#16750]: https://github.com/openshift/console/pull/16750
+[#16762]: https://github.com/openshift/console/pull/16762

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -3212,7 +3212,7 @@ const Component: React.FC = (props) => {
 
 ### Returns
 
-A toast context object with an `addToast` function for adding a toast to the screen and a `removeToast` function for removing a toast from the screen.
+A context object with an addToast function for adding a toast to the screen, a<br/>removeToast function for removing it from the screen, and a minimizeToast function for<br/>hiding a drawer-persisted toast from the screen while keeping it unread in the notification drawer.
 
 
 ### Source

--- a/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.23.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.23.md
@@ -61,34 +61,63 @@ The UI displays tabs in priority order from highest to lowest. Default built-in 
 
 ### Improved control over toast notifications
 
-When displaying toast notifications using `useToast` hook, Console supports persisting toasts in the
-notification drawer with read/unread state and management actions. Toast notifications that opt in to
-drawer persistence are subject to a visible cap (default 3) with an overflow link to the notification
-drawer. Existing toast consumers are unaffected — by default, toasts remain on-screen only.
+When displaying toast notifications using the `useToast` hook, Console supports persisting toasts in the
+notification drawer with read/unread state, management actions, and minimizing toasts back to the
+drawer. Toast notifications that opt in to drawer persistence are subject to a visible cap (default 3)
+with an overflow link to the notification drawer. Existing toast consumers are unaffected: by default,
+toasts remain on-screen only.
 
-`ToastOptions` supports new optional properties for better control over toast notifications:
+`ToastOptions` supports optional properties for this control:
 
-- `persistInDrawer` (default `false`) to persist the toast in the notification drawer when set to `true`.
-  Drawer-persisted toasts default to participating in the visible toast cap and overflow link.
-- `skipOverflow` (default `true`) to control whether a toast participates in the visible toast cap.
-  When `persistInDrawer` is `true`, defaults to `false` unless explicitly set to `true`.
-  Use `persistInDrawer: true` with `skipOverflow: true` for always-visible drawer-persisted toasts
-  (e.g. long-running upload progress).
-- `drawerGroup` to group toast notifications into named sections in the notification drawer. When omitted,
-  toasts appear in the built-in default group, displayed as "Other Alerts" (translated by Console). Custom
-  `drawerGroup` values are shown as-is; plugins are responsible for translating their own group names if needed.
+- `persistInDrawer` (default `false`) to persist the toast in the notification drawer with read/unread
+  state. Drawer-persisted toasts default to counting toward the visible cap and overflow link.
+- `skipOverflow` (default `true`) to exclude the toast from the visible cap (default 3) and overflow
+  link. Defaults to `false` when `persistInDrawer` is `true`, unless set explicitly. Combine
+  `persistInDrawer: true` with `skipOverflow: true` for always-visible drawer-persisted toasts.
+- `drawerGroup` to group the toast into a named drawer section. Omitted toasts use the built-in group,
+  displayed as "Other Alerts" (translated by Console). Custom values are shown as-is; plugins are
+  responsible for translating their own group names.
+- `minimizable` (default `false`) to add a Minus icon button, for toasts that aren't `dismissible`, that
+  minimizes the toast: hides it on-screen and keeps it unread in the drawer, without invoking `onClose`.
+  Requires `persistInDrawer: true`.
+- `actions` to add buttons or links to the toast, each with a `label` and `callback`. Set `dismiss: true`
+  on an action to also dismiss the toast when clicked, or `minimize: true` to minimize it instead. A
+  `minimize: true` action renders as a text link at its position in the array, useful for `dismissible`
+  toasts where the Minus icon isn't shown.
 
-### Example: persisting and grouping toasts in the notification drawer
+`useToast` also returns `minimizeToast(id)` for minimizing a toast programmatically.
+
+#### Example: Persist, group, and minimize a toast
 
 ```tsx
 const { addToast } = useToast();
 
 addToast({
-  title: 'Upload complete',
-  variant: 'success',
-  content: 'disk.img uploaded successfully.',
+  title: 'Uploading disk.img',
+  variant: 'info',
+  content: <UploadProgressContent />,
+  dismissible: false,
+  timeout: false,
   persistInDrawer: true,
-  drawerGroup: 'Uploads',
+  skipOverflow: true,
+  drawerGroup: 'Uploads', // translate custom group names in your own plugin, e.g. t('Uploads')
+  minimizable: true,
+});
+```
+
+#### Example: Order a minimize action for a dismissible toast
+
+```tsx
+addToast({
+  title: 'Import failed',
+  variant: 'danger',
+  content: 'disk.img could not be imported.',
+  dismissible: true,
+  persistInDrawer: true,
+  actions: [
+    { label: 'Retry', callback: retryImport },
+    { label: 'Minimize', minimize: true, callback: () => {} },
+  ],
 });
 ```
 

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -1014,7 +1014,9 @@ export const useActivePerspective: UseActivePerspective = require('@console/dyna
 
 /**
  * Hook that provides toast functionality for displaying alerts.
- * @returns A toast context object with an `addToast` function for adding a toast to the screen and a `removeToast` function for removing a toast from the screen.
+ * @returns A context object with an addToast function for adding a toast to the screen, a 
+ * removeToast function for removing it from the screen, and a minimizeToast function for 
+ * hiding a drawer-persisted toast from the screen while keeping it unread in the notification drawer.
  * @example
  * ```tsx
  * const Component: React.FC = (props) => {

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -637,6 +637,13 @@ export type ToastOptions = {
     callback: () => void;
     /** If `true`, executing this action will dismiss the toast. */
     dismiss?: boolean;
+    /**
+     * If `true`, executing this action minimizes the toast: hides it from the on-screen alert group
+     * while keeping it unread in the notification drawer, without invoking `onClose` or canceling the
+     * underlying operation. Has no effect when the toast isn't persisted in the drawer
+     * (`persistInDrawer: true`). Takes precedence over `dismiss` when both are `true`.
+     */
+    minimize?: boolean;
     /** Sets the base component to render. defaults to button */
     component?: ElementType<any> | ComponentType<any>;
     /** The data test id */
@@ -671,6 +678,12 @@ export type ToastOptions = {
    * Defaults to `false`.
    */
   persistInDrawer?: boolean;
+  /**
+   * When `true` and `dismissible` is `false`, shows a Minimize icon button in the close button's slot.
+   * Minimizing hides the toast on-screen while keeping it unread in the drawer, without invoking
+   * `onClose`. No-op when `persistInDrawer` isn't `true`. Defaults to `false`.
+   */
+  minimizable?: boolean;
 };
 
 export type ToastContextValues = {
@@ -678,6 +691,12 @@ export type ToastContextValues = {
   addToast: (options: ToastOptions) => string;
   /** Remove a toast alert. */
   removeToast: (id: string) => void;
+  /**
+   * Minimize a toast: hide it from the on-screen alert group while keeping it unread in the
+   * notification drawer history. Does not invoke `onClose`. No-op if the toast is not persisted
+   * in the drawer (`persistInDrawer: true`).
+   */
+  minimizeToast: (id: string) => void;
 };
 
 export type UseToast = () => ToastContextValues;

--- a/frontend/packages/console-shared/locales/en/console-shared.json
+++ b/frontend/packages/console-shared/locales/en/console-shared.json
@@ -159,6 +159,7 @@
   "Limits": "Limits",
   "Loading": "Loading",
   "Loading {{title}} status": "Loading {{title}} status",
+  "Minimize alert: {{title}}": "Minimize alert: {{title}}",
   "More info": "More info",
   "N/A": "N/A",
   "Name": "Name",

--- a/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
+++ b/frontend/packages/console-shared/src/components/toast/ToastProvider.tsx
@@ -6,7 +6,9 @@ import {
   AlertActionCloseButton,
   AlertActionLink,
   AlertVariant,
+  Button,
 } from '@patternfly/react-core';
+import { RhUiMinusIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
 import type {
   ToastOptions,
@@ -116,6 +118,22 @@ export const ToastProvider: FC<ToastProviderProps> = ({
     );
   }, []);
 
+  const minimizeToast = useCallback((id: string) => {
+    let canMinimize = false;
+    setToasts((state) => {
+      const toast = state.find((item) => item.id === id);
+      canMinimize = toast?.persistInDrawer === true;
+      return canMinimize ? state.filter((item) => item.id !== id) : state;
+    });
+    if (canMinimize) {
+      setNotifications((state) =>
+        state.map((notification) =>
+          notification.id === id ? { ...notification, isRead: false } : notification,
+        ),
+      );
+    }
+  }, []);
+
   const clearNotification = useCallback(
     (id: string) => {
       setNotifications((state) => {
@@ -170,8 +188,9 @@ export const ToastProvider: FC<ToastProviderProps> = ({
     () => ({
       addToast,
       removeToast,
+      minimizeToast,
     }),
-    [addToast, removeToast],
+    [addToast, removeToast, minimizeToast],
   );
 
   const notificationHistoryController = useMemo(
@@ -214,49 +233,69 @@ export const ToastProvider: FC<ToastProviderProps> = ({
             overflowMessage={overflowMessage}
             onOverflowClick={onOverflowClick}
           >
-            {visibleToasts.map((toast) => (
-              <Alert
-                key={toast.id}
-                title={toast.title}
-                variant={toast.variant}
-                timeout={toast.timeout}
-                onTimeout={() => removeToast(toast.id)}
-                data-test={toast.dataTest || `${toast.title} alert`}
-                actionClose={
-                  toast.dismissible ? (
-                    <AlertActionCloseButton
-                      onClose={() => {
-                        toast.onClose && toast.onClose();
-                        removeToast(toast.id);
-                      }}
-                    />
-                  ) : undefined
-                }
-                actionLinks={
-                  toast.actions?.length > 0 ? (
-                    <>
-                      {toast.actions.map((action) => (
-                        <AlertActionLink
-                          key={action.label}
-                          onClick={() => {
-                            if (action.dismiss) {
-                              removeToast(toast.id);
+            {visibleToasts.map((toast) => {
+              const minimizeAsIconButton =
+                toast.minimizable && toast.persistInDrawer && !toast.dismissible;
+
+              return (
+                <Alert
+                  key={toast.id}
+                  title={toast.title}
+                  variant={toast.variant}
+                  timeout={toast.timeout}
+                  onTimeout={() => removeToast(toast.id)}
+                  data-test={toast.dataTest || `${toast.title} alert`}
+                  actionClose={
+                    toast.dismissible ? (
+                      <AlertActionCloseButton
+                        onClose={() => {
+                          toast.onClose && toast.onClose();
+                          removeToast(toast.id);
+                        }}
+                      />
+                    ) : minimizeAsIconButton ? (
+                      <Button
+                        variant="plain"
+                        aria-label={t('Minimize alert: {{title}}', { title: toast.title })}
+                        icon={<RhUiMinusIcon />}
+                        onClick={() => minimizeToast(toast.id)}
+                        data-test={
+                          toast.dataTest ? `${toast.dataTest}-minimize` : 'toast-minimize-action'
+                        }
+                      />
+                    ) : undefined
+                  }
+                  actionLinks={
+                    toast.actions?.length > 0 ? (
+                      <>
+                        {toast.actions.map((action) => (
+                          <AlertActionLink
+                            key={action.label}
+                            onClick={() => {
+                              if (action.minimize) {
+                                minimizeToast(toast.id);
+                              } else if (action.dismiss) {
+                                removeToast(toast.id);
+                              }
+                              action.callback();
+                            }}
+                            component={action.component}
+                            data-test={
+                              action.dataTest ||
+                              (action.minimize ? 'toast-minimize-action-link' : 'toast-action')
                             }
-                            action.callback();
-                          }}
-                          component={action.component}
-                          data-test={action.dataTest || 'toast-action'}
-                        >
-                          {action.label}
-                        </AlertActionLink>
-                      ))}
-                    </>
-                  ) : undefined
-                }
-              >
-                {toast.content}
-              </Alert>
-            ))}
+                          >
+                            {action.label}
+                          </AlertActionLink>
+                        ))}
+                      </>
+                    ) : undefined
+                  }
+                >
+                  {toast.content}
+                </Alert>
+              );
+            })}
           </AlertGroup>
         ) : null}
       </NotificationHistoryContext.Provider>

--- a/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
+++ b/frontend/packages/console-shared/src/components/toast/__tests__/ToastProvider.spec.tsx
@@ -624,4 +624,422 @@ describe('ToastProvider', () => {
       expect(toastClose).toHaveBeenCalled();
     });
   });
+
+  it('should minimize a non-dismissible drawer-persisted toast as an icon button without invoking onClose and keep it unread in history', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'upload-progress',
+        title: 'Uploading disk.img',
+        variant: AlertVariant.info,
+        content: 'in progress',
+        dismissible: false,
+        timeout: false,
+        persistInDrawer: true,
+        skipOverflow: true,
+        minimizable: true,
+        onClose,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Uploading disk.img')).toBeVisible();
+      expect(notificationHistoryContext.notifications).toHaveLength(1);
+      expect(notificationHistoryContext.notifications[0].isRead).toBe(false);
+    });
+
+    act(() => {
+      notificationHistoryContext.markNotificationRead('upload-progress');
+    });
+
+    await waitFor(() => {
+      expect(notificationHistoryContext.notifications[0].isRead).toBe(true);
+    });
+
+    // Non-dismissible toasts have no close button, so Minimize renders as an icon
+    // button in that slot instead of a text action link.
+    expect(screen.queryByRole('button', { name: 'Minimize' })).not.toBeInTheDocument();
+    const minimizeButton = screen.getByRole('button', {
+      name: 'Minimize alert: Uploading disk.img',
+    });
+    await user.click(minimizeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Uploading disk.img')).not.toBeInTheDocument();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(notificationHistoryContext.notifications).toHaveLength(1);
+    expect(notificationHistoryContext.notifications[0].isRead).toBe(false);
+  });
+
+  it('should minimize a dismissible drawer-persisted toast via an explicit minimize action, alongside the close button', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'dismissible-minimizable',
+        title: 'dismissible minimizable toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        dismissible: true,
+        persistInDrawer: true,
+        actions: [{ label: 'Minimize', minimize: true, callback: jest.fn() }],
+        onClose,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('dismissible minimizable toast')).toBeVisible();
+    });
+
+    // This toast never sets `minimizable`, so Minimize only comes from the
+    // explicit `actions[].minimize` entry, rendered as a text link.
+    expect(
+      screen.queryByRole('button', { name: 'Minimize alert: dismissible minimizable toast' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+
+    const minimizeLink = screen.getByRole('button', { name: 'Minimize' });
+    await user.click(minimizeLink);
+
+    await waitFor(() => {
+      expect(screen.queryByText('dismissible minimizable toast')).not.toBeInTheDocument();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(notificationHistoryContext.notifications).toHaveLength(1);
+    expect(notificationHistoryContext.notifications[0].isRead).toBe(false);
+  });
+
+  it('should render the minimize action at the position specified in the actions array', async () => {
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'ordered-actions',
+        title: 'ordered actions toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        persistInDrawer: true,
+        actions: [
+          { label: 'View details', callback: jest.fn() },
+          { label: 'Minimize', minimize: true, callback: jest.fn() },
+          { label: 'Retry', callback: jest.fn() },
+        ],
+      });
+    });
+
+    let buttons: HTMLElement[];
+    await waitFor(() => {
+      buttons = screen.getAllByRole('button', {
+        name: /^(View details|Minimize|Retry)$/,
+      });
+      expect(buttons).toHaveLength(3);
+    });
+
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      'View details',
+      'Minimize',
+      'Retry',
+    ]);
+  });
+
+  it('should still invoke a minimize action callback in addition to minimizing', async () => {
+    const user = userEvent.setup();
+    const minimizeCallback = jest.fn();
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'minimize-with-callback',
+        title: 'minimize with callback toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        persistInDrawer: true,
+        actions: [{ label: 'Minimize', minimize: true, callback: minimizeCallback }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('minimize with callback toast')).toBeVisible();
+    });
+
+    const minimizeLink = screen.getByRole('button', { name: 'Minimize' });
+    await user.click(minimizeLink);
+
+    await waitFor(() => {
+      expect(screen.queryByText('minimize with callback toast')).not.toBeInTheDocument();
+    });
+    expect(minimizeCallback).toHaveBeenCalledTimes(1);
+    expect(notificationHistoryContext.notifications).toHaveLength(1);
+  });
+
+  it('should render an explicit minimize action even without persistInDrawer, but clicking it has no effect', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'no-drawer-minimize-action',
+        title: 'no drawer minimize action toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        actions: [{ label: 'Minimize', minimize: true, callback: jest.fn() }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('no drawer minimize action toast')).toBeVisible();
+    });
+
+    const minimizeLink = screen.getByRole('button', { name: 'Minimize' });
+    await user.click(minimizeLink);
+
+    await waitFor(() => {
+      // No-op: `minimizeToast` only takes effect for `persistInDrawer: true` toasts.
+      expect(screen.getByText('no drawer minimize action toast')).toBeVisible();
+    });
+  });
+
+  it('should not minimize a toast that is not persisted in the drawer', async () => {
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'ephemeral-toast',
+        title: 'ephemeral toast',
+        variant: AlertVariant.info,
+        content: 'on screen only',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('ephemeral toast')).toBeVisible();
+    });
+
+    act(() => {
+      toastContext.minimizeToast('ephemeral-toast');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('ephemeral toast')).toBeVisible();
+    });
+    expect(notificationHistoryContext.notifications).toHaveLength(0);
+  });
+
+  it('should not reset a notification to unread when its toast was already cleared from the visible stack', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <ToastProvider maxDisplayed={1}>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'stale-notification',
+        title: 'stale notification toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        persistInDrawer: true,
+      });
+    });
+
+    act(() => {
+      notificationHistoryContext.markNotificationRead('stale-notification');
+    });
+
+    act(() => {
+      toastContext.addToast({
+        title: 'overflow toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        persistInDrawer: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('View 1 more notification')).toBeVisible();
+    });
+
+    // Clears the visible toast stack (e.g. via the overflow link) while notification
+    // history, including the already-read entry below, is left untouched.
+    await user.click(screen.getByText('View 1 more notification'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('stale notification toast')).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      toastContext.minimizeToast('stale-notification');
+    });
+
+    expect(notificationHistoryContext.notifications).toHaveLength(2);
+    expect(
+      notificationHistoryContext.notifications.find((n) => n.id === 'stale-notification').isRead,
+    ).toBe(true);
+  });
+
+  it('should not render an automatic Minimize icon button when minimizable or persistInDrawer is missing, or no actions are given', async () => {
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'minimizable-no-drawer',
+        title: 'minimizable without drawer',
+        variant: AlertVariant.info,
+        content: 'description',
+        minimizable: true,
+      });
+      toastContext.addToast({
+        id: 'drawer-not-minimizable',
+        title: 'drawer toast not minimizable',
+        variant: AlertVariant.info,
+        content: 'description',
+        persistInDrawer: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('minimizable without drawer')).toBeVisible();
+      expect(screen.getByText('drawer toast not minimizable')).toBeVisible();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Minimize' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Minimize alert:/ })).not.toBeInTheDocument();
+  });
+
+  it('should render both the icon button and an explicit minimize action when both are configured', async () => {
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'both-minimize-controls',
+        title: 'explicit action toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        dismissible: false,
+        persistInDrawer: true,
+        minimizable: true,
+        actions: [{ label: 'Custom minimize', minimize: true, callback: jest.fn() }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('explicit action toast')).toBeVisible();
+    });
+
+    // Each mechanism is controlled independently: `minimizable` alone gates the icon
+    // button, so consumers who only want the action link simply omit `minimizable`.
+    expect(
+      screen.getByRole('button', { name: 'Minimize alert: explicit action toast' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Custom minimize' })).toBeInTheDocument();
+  });
+
+  it('should not render the icon button when minimizable is not set, even with an explicit minimize action', async () => {
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'action-only-minimize',
+        title: 'action only toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        dismissible: false,
+        persistInDrawer: true,
+        actions: [{ label: 'Custom minimize', minimize: true, callback: jest.fn() }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('action only toast')).toBeVisible();
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'Minimize alert: action only toast' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Custom minimize' })).toBeInTheDocument();
+  });
+
+  it('should minimize a toast via an action with a custom label, without invoking onClose and keeping it unread', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    renderWithProviders(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      toastContext.addToast({
+        id: 'custom-label-minimize',
+        title: 'custom label minimize toast',
+        variant: AlertVariant.info,
+        content: 'description',
+        persistInDrawer: true,
+        actions: [{ label: 'Hide for now', minimize: true, callback: jest.fn() }],
+        onClose,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('custom label minimize toast')).toBeVisible();
+      expect(notificationHistoryContext.notifications).toHaveLength(1);
+      expect(notificationHistoryContext.notifications[0].isRead).toBe(false);
+    });
+
+    const minimizeLink = screen.getByRole('button', { name: 'Hide for now' });
+    await user.click(minimizeLink);
+
+    await waitFor(() => {
+      expect(screen.queryByText('custom label minimize toast')).not.toBeInTheDocument();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(notificationHistoryContext.notifications).toHaveLength(1);
+    expect(notificationHistoryContext.notifications[0].isRead).toBe(false);
+  });
 });

--- a/frontend/packages/console-shared/src/components/toast/__tests__/useToast.spec.tsx
+++ b/frontend/packages/console-shared/src/components/toast/__tests__/useToast.spec.tsx
@@ -7,5 +7,6 @@ describe('useToast', () => {
     const { result } = renderHook(() => useToast(), { wrapper: ToastProvider });
     expect(typeof result.current.addToast).toBe('function');
     expect(typeof result.current.removeToast).toBe('function');
+    expect(typeof result.current.minimizeToast).toBe('function');
   });
 });


### PR DESCRIPTION
# [RFE-9433](https://redhat.atlassian.net/browse/RFE-9433): Add minimize action for toast notifications

**Jira ticket:** [CONSOLE-5424](https://issues.redhat.com/browse/CONSOLE-5424)

**Analysis / Root cause**:

[CONSOLE-5361](https://issues.redhat.com/browse/CONSOLE-5361) added drawer persistence and an overflow cap for toasts, but gave users no direct way to hide a single toast from the on-screen alert group without either dismissing it (which cancels/loses the underlying operation via `onClose`) or waiting for the overflow cap to push it off-screen. Long-running, non-dismissible toasts (e.g. upload progress) had no "get this out of my way, but keep it running and keep the history" action. This follow-up was tracked separately as [RFE-9433](https://redhat.atlassian.net/browse/RFE-9433) in the [CONSOLE-5361](https://redhat.atlassian.net/browse/CONSOLE-5361) PR description.

**Solution description**:

This PR adds a **Minimize** action for toast notifications. Minimizing hides a toast from the on-screen `AlertGroup` while keeping its notification-drawer entry (marked unread), without invoking `onClose`/`onRemove` and without canceling whatever operation the toast represents.

Consumers can surface Minimize in two independent ways, and can combine both on the same toast:

- **Automatic icon button** (`minimizable: true`): for toasts that aren't `dismissible`, Console renders a Minus icon button in the close-button slot, since there's no close button to collide with there. This is the only control for the icon button — if you don't want it, just leave `minimizable` unset.
- **Explicit action** (`minimize: true` on an entry in `actions`): renders as a text action link at whatever position the consumer places it in the `actions` array, so they control the order relative to their own actions. `label` and `callback` are required, same as any other action — use a no-op callback if you don't need one. This is the only option for `dismissible` toasts, since the close button already occupies the icon slot.

Both mechanisms only take effect when the toast is persisted in the drawer (`persistInDrawer: true`) — there is no drawer entry to fall back to otherwise. **Existing toast consumers are unaffected** — `minimizable` and `actions[].minimize` both default to off, preserving pre-PR behavior.

### Core behavior

- **`ToastProvider.minimizeToast(id)`** hides the toast from the visible on-screen stack and marks its drawer notification unread, without invoking `onClose`/`onRemove` and without removing the drawer history entry.
- No-op when the toast isn't `persistInDrawer: true` — there is no drawer entry to recover it from.
- Exposed via `useToast().minimizeToast`, alongside the existing `addToast`/`removeToast`.

### Plugin API (`ToastOptions`)

| Option | Default | Purpose |
|--------|---------|---------|
| `minimizable` | `false` | When `true` and `dismissible` is `false`, shows a Minus icon button in the close button's slot that minimizes the toast. This is the only control for the icon button — omit it to use just the action-link version |
| `actions[].minimize` | `false` | When `true` on an action entry, clicking it minimizes the toast instead of the normal callback/dismiss flow. Renders as a text link at that action's exact position. `label`/`callback` are still required, same as any other action |

Constraints:

- Minimize has no effect unless `persistInDrawer: true` — there's no drawer entry to fall back to otherwise.
- `minimizable` and `actions[].minimize` are independent; both render if both are configured on the same toast, and there's no separate "disable" flag — leaving `minimizable` unset is how you get only the action-link version.
- `actions[].minimize` takes precedence over `dismiss` when both are set on the same action; the action's `callback` is still invoked in addition to minimizing (use a no-op if you don't need one).

### Architecture

- **`ToastProvider`** - new `minimizeToast` callback; `actionClose`/`actionLinks` rendering updated to support the icon button and/or action-link variants.
- **`console-types.ts`** (SDK) - `ToastOptions.minimizable`, `ToastOptions.actions[].minimize`, `ToastContextValues.minimizeToast`.

### SDK / docs

- `CHANGELOG-core.md`, `release-notes/4.23.md`, `docs/api.md`, and `core-api.ts` JSDoc updated.

### Usage examples

Automatic icon button — non-dismissible, always-visible toast (e.g. upload progress):

```tsx
import { useToast } from '@openshift-console/dynamic-plugin-sdk';

const { addToast } = useToast();

addToast({
  title: 'Uploading disk.img',
  variant: 'info',
  content: <UploadProgressContent />,
  dismissible: false,
  timeout: false,
  persistInDrawer: true,
  skipOverflow: true,
  minimizable: true,
});
```

Explicit action, ordered relative to other actions, on a dismissible toast:

```tsx
addToast({
  title: 'Import failed',
  variant: 'danger',
  content: 'disk.img could not be imported.',
  dismissible: true,
  persistInDrawer: true,
  actions: [
    { label: 'Retry', callback: retryImport },
    { label: 'Minimize', minimize: true, callback: () => {} },
  ],
});
```

Explicit action with a custom label:

```tsx
addToast({
  title: 'Uploading disk.img',
  variant: 'info',
  content: <UploadProgressContent />,
  persistInDrawer: true,
  actions: [{ label: 'Hide for now', minimize: true, callback: () => {} }],
});
```

Combining the icon button and an explicit action — both controls render, since the two are independent:

```tsx
addToast({
  title: 'Uploading disk.img',
  variant: 'info',
  content: <UploadProgressContent />,
  dismissible: false,
  persistInDrawer: true,
  minimizable: true,
  actions: [{ label: 'Hide for now', minimize: true, callback: () => {} }],
});
```

## Demo

### 1. Automatic icon button (no `actions`)

```tsx
addToast({
  persistInDrawer: true,
  dismissible: false,
  minimizable: true,
});
```

**What to look for:**

- A Minus icon button renders in the close-button slot (no close/X button, since `dismissible: false`).
- Clicking it hides the toast from the on-screen alert group immediately.
- The toast's notification-drawer entry stays, marked unread.
- `onClose`/`onRemove` are not invoked — any underlying operation (e.g. upload) is unaffected.



https://github.com/user-attachments/assets/3b193b01-8227-4dcb-af4f-d7c5fe575746




### 2. Explicit `minimize` action, ordered among other actions

```tsx
addToast({
  persistInDrawer: true,
  dismissible: true,
  actions: [
    { label: 'Retry', callback: retryImport },
    { label: 'Hide for now', minimize: true, callback: () => {} },
  ],
});
```

**What to look for:**

- The toast shows its normal close (X) button alongside the action links.
- The Minimize action renders as a text link at the position specified in the `actions` array (here, after "Retry"), with whatever `label` was provided.
- Clicking it hides the toast and keeps it unread in the drawer, without invoking `onClose`.


https://github.com/user-attachments/assets/bc80af2e-69ef-478a-b31e-61349d47680b



### 3. Combining the icon button and an explicit action

```tsx
addToast({
  persistInDrawer: true,
  dismissible: false,
  minimizable: true,
  actions: [{ label: 'Hide for now', minimize: true, callback: () => {} }],
});
```

**What to look for:**

- `minimizable` and `actions[].minimize` are independent controls: when both are configured, both render (the icon button and the action link) — there's no implicit suppression either way.
- To show only the action-link version, simply leave `minimizable` unset.
- The masthead notification badge and drawer unread count update the same way regardless of which control was used to minimize.

https://github.com/user-attachments/assets/70531416-d098-46eb-aaf0-72786539a869


**Test setup:**

1. Build and run Console from this branch (`yarn dev` in `frontend/`).
2. Hard refresh the browser after core changes.
3. Optional: load a dynamic plugin that uses `useToast` (e.g. KubeVirt) to exercise plugin toasts with `minimizable` and `actions[].minimize`.

**Test cases:**

- [ ] Toast with `minimizable: true, persistInDrawer: true, dismissible: false` → Minus icon button renders in the close-button slot; clicking it hides the toast, keeps it unread in the drawer, and does not invoke `onClose`.
- [ ] Toast with `dismissible: true` → the Minus icon is never shown (close button occupies that slot); add an action with `label`/`minimize: true`/`callback` to `actions` to get a text link instead.
- [ ] Toast with `actions: [{ label: 'Hide for now', minimize: true, callback: () => {} }]` → link renders with that label; clicking minimizes (hides, keeps unread, no `onClose`).
- [ ] Toast with multiple actions and a `minimize: true` entry placed in the middle of the array → the Minimize link renders at that exact position relative to the other actions.
- [ ] Toast with a `minimize: true` action that also has a non-no-op `callback` → clicking invokes both the minimize behavior and the callback.
- [ ] Toast with `minimizable: true` and an explicit `actions[].minimize` action → both the icon button and the action link render (the two are independent, neither suppresses the other).
- [ ] Toast with an `actions[].minimize` action and no `minimizable` → only the action link renders; no icon button appears.
- [ ] Toast with an `actions[].minimize` action but no `persistInDrawer` → the link still renders, but clicking it has no effect (toast stays visible; there is no drawer entry).
- [ ] Calling `useToast().minimizeToast(id)` directly → same behavior as clicking the UI control.
- [ ] Minimized toast remains marked unread in the drawer; masthead badge count/variant reflect it.

**Browser conformance**:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

- Unit tests: 42 tests in `packages/console-shared/src/components/toast/` (ToastProvider, toastDisplayUtils, toastNotificationUtils, useToast).
- English i18n strings added via `console-shared.json` (`Minimize alert: {{title}}`, for the icon button's aria-label); other locales via Memsource.
- **Backward compatible:** existing `addToast` callers (Console core and dynamic plugins) are unaffected. `minimizable` and `actions[].minimize` both default to off/false, matching pre-PR behavior.
- Follow-up to [CONSOLE-5361](https://issues.redhat.com/browse/CONSOLE-5361) / [RFE-9430](https://redhat.atlassian.net/browse/RFE-9430); implements [RFE-9433](https://redhat.atlassian.net/browse/RFE-9433) as scoped there.

## Reviewers and assignees

- @vojtechszocs
- CNV consumer: Gal Kremer (RFE reporter/requester per [RFE-9433](https://redhat.atlassian.net/browse/RFE-9433))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added toast “minimize” support for drawer-persisted notifications, reducing on-screen visibility while keeping items unread in the drawer.
  - Non-dismissible toasts can show a minimize icon; dismissible toasts can minimize via configured actions (without triggering close behavior).
  - Toast API now includes programmatic minimization support.
- **Documentation**
  - Updated toast and hook API docs plus the 4.23 release notes with minimization options, rules, and new examples.
- **Tests**
  - Expanded automated coverage for minimize UI rendering, action ordering, callback/close interactions, and unread/persistence edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->