### PR TITLE
NO-ISSUE: Skip knative Cypress tests when techPreview is enabled

### DIFF
--- a/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
+++ b/frontend/packages/knative-plugin/integration-tests/support/commands/hooks.ts
@@ -1,7 +1,21 @@
 import { checkErrors } from '@console/cypress-integration-tests/support';
 import { installKnativeOperatorUsingCLI } from '@console/dev-console/integration-tests/support/pages';
 
-before(() => {
+before(function () {
+  // Skip all knative tests on techPreview clusters: the Developer perspective is
+  // disabled by default and the htpasswd IDP doesn't exist, so create-user.sh would
+  // need to create it before login can succeed. Knative topology tests also depend
+  // on the Developer perspective being active.
+  // cy.exec() returns a Cypress Chainable, not a true Promise — it has no .catch() method.
+  // Cypress's command queue manages error handling; this disable is required.
+  // eslint-disable-next-line promise/catch-or-return
+  cy.exec('oc get featuregate cluster -o jsonpath={.spec.featureSet}', {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.stdout.trim() === 'TechPreviewNoUpgrade') {
+      this.skip();
+    }
+  });
   cy.exec('../../../../contrib/create-user.sh');
   const bridgePasswordIDP: string = Cypress.expose('BRIDGE_HTPASSWD_IDP') || 'test';
   const bridgePasswordUsername: string = Cypress.expose('BRIDGE_HTPASSWD_USERNAME') || 'test';


### PR DESCRIPTION
On techPreview clusters (TechPreviewNoUpgrade feature gate), the Developer perspective is disabled by default and the htpasswd IDP doesn't exist. The knative tests depend on both: they log in via htpasswd and navigate to the topology view. Without a skip guard they time out waiting for topology elements that are never rendered.

Add the same featuregate check used in the dev-console hooks to skip all knative tests early when TechPreviewNoUpgrade is detected.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Knative integration tests now automatically skip when the cluster is configured with the `TechPreviewNoUpgrade` feature set, preventing unsupported test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->