### PR TITLE
NO-ISSUE: Clear favorites before and after favorites e2e test

### DIFF
--- a/frontend/e2e/clients/kubernetes-client.ts
+++ b/frontend/e2e/clients/kubernetes-client.ts
@@ -347,6 +347,21 @@ export default class KubernetesClient {
     );
   }
 
+  async clearConsoleFavorites(username = 'kubeadmin'): Promise<void> {
+    const namespace = 'openshift-console-user-settings';
+    const configMapName = `user-settings-${username}`;
+    try {
+      await this.k8sApi.patchNamespacedConfigMap({
+        name: configMapName,
+        namespace,
+        body: { data: { 'console.favorites': null } },
+        contentType: k8s.PatchStrategy.MergePatch,
+      } as any);
+    } catch {
+      // ConfigMap may not exist yet — nothing to clear
+    }
+  }
+
   async setupConsoleUserSettings(username = 'kubeadmin', defaultNamespace?: string): Promise<void> {
     const namespace = 'openshift-console-user-settings';
     const configMapName = `user-settings-${username}`;

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -2,6 +2,14 @@ import { test, expect } from '../../../fixtures';
 import { warmupSPA } from '../../../pages/base-page';
 
 test.describe('Favorites', { tag: ['@admin'] }, () => {
+  test.beforeEach(async ({ k8sClient }) => {
+    await k8sClient.clearConsoleFavorites();
+  });
+
+  test.afterEach(async ({ k8sClient }) => {
+    await k8sClient.clearConsoleFavorites();
+  });
+
   test('adds, displays, removes, and limits favorites', async ({ page }) => {
     const sidebar = page.locator('#page-sidebar');
 


### PR DESCRIPTION
The 'limit reached' step adds 10 favorites and never removes them, so a successful run (or a mid-run failure followed by a retry) leaves the console.favorites ConfigMap key populated. Subsequent runs then fail at the first step, which expects an empty favorites list.

Add clearConsoleFavorites() to KubernetesClient and call it in beforeEach and afterEach so the test always starts and ends with a clean slate.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved favorites test reliability by resetting console favorites before and after each test.
  * Ensured favorites tests run with a clean state, including adding, displaying, removing, and enforcing favorites limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->