### PR TITLE
NO-ISSUE: Add TechPreview and feature-gate E2E test filtering infrastructure

### DIFF
--- a/docs/superpowers/plans/2026-07-16-techpreview-e2e-test-filtering.md
+++ b/docs/superpowers/plans/2026-07-16-techpreview-e2e-test-filtering.md
@@ -1,0 +1,454 @@
+# Tech Preview E2E Test Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate `test-prow-e2e-techpreview.sh` and `test-prow-playwright-e2e-techpreview.sh` with filtering logic so CI only runs tests that explicitly require TechPreview or a specific named feature gate.
+
+**Architecture:** Two Playwright fixtures (`techPreviewOnly`, `requireFeatureGate`) are added to the shared fixture file so any test can opt-in with a tag + fixture call. The CI scripts pass `--grep "@tech-preview|@feature-gate"` to select those tests. Cypress gets a shared `before()` guard module that skips the suite unless the cluster is in the expected state; the Cypress script runs only packages that contain TechPreview/feature-gate suites.
+
+**Tech Stack:** Playwright (`@playwright/test`), Cypress, Bash, `@kubernetes/client-node` (already a dependency), OpenShift `config.openshift.io/v1 FeatureGate` cluster CR.
+
+## Global Constraints
+
+- All commands run from repo root unless stated otherwise.
+- Playwright commands run from `frontend/`.
+- `getClusterCustomResource(group, version, plural, name)` already exists on `KubernetesClient` at `frontend/e2e/clients/kubernetes-client.ts:548` — do not add a duplicate.
+- Tag names are lowercase with `@` prefix: `@tech-preview`, `@feature-gate`.
+- `fixtures/index.ts` exports a single `test` object via `base.extend()` — all new fixtures must be added to that same chain, not in separate files.
+- Never import from package index files (e.g. `@console/shared`); import from specific paths.
+- Run `cd frontend && yarn tsc --noEmit` after every TypeScript change to catch type errors before committing.
+
+---
+
+### Task 1: Playwright fixtures — `techPreviewOnly` + `requireFeatureGate`
+
+**Files:**
+- Modify: `frontend/e2e/fixtures/index.ts`
+
+**Interfaces:**
+- Produces:
+  - `techPreviewOnly: void` — test fixture; no parameters; skips the test if `SERVER_FLAGS.techPreview` is falsy
+  - `requireFeatureGate: (gateName: string) => Promise<void>` — test fixture; call with a gate name string to skip if that gate is not in the cluster's enabled list
+
+- [ ] **Step 1: Add `techPreviewOnly` and `requireFeatureGate` to `TestFixtures` type**
+
+Open `frontend/e2e/fixtures/index.ts`. Replace the existing `TestFixtures` type:
+
+```ts
+type TestFixtures = {
+  cleanup: CleanupFixture;
+  techPreviewOnly: void;
+  requireFeatureGate: (gateName: string) => Promise<void>;
+};
+```
+
+- [ ] **Step 2: Add `techPreviewOnly` fixture implementation to `base.extend()`**
+
+Inside `base.extend<TestFixtures, WorkerFixtures>({ … })`, add after the `cleanup` fixture:
+
+```ts
+  techPreviewOnly: async ({ page }, use) => {
+    const isTechPreview = await page.evaluate(() => window.SERVER_FLAGS.techPreview);
+    test.skip(!isTechPreview, 'This test requires a TechPreviewNoUpgrade cluster');
+    await use();
+  },
+```
+
+- [ ] **Step 3: Add `requireFeatureGate` fixture implementation to `base.extend()`**
+
+Add after `techPreviewOnly`:
+
+```ts
+  requireFeatureGate: async ({ k8sClient }, use) => {
+    await use(async (gateName: string) => {
+      let enabled: string[] = [];
+      try {
+        const fg = await k8sClient.getClusterCustomResource(
+          'config.openshift.io',
+          'v1',
+          'featuregates',
+          'cluster',
+        );
+        const featureSet: string = (fg as any)?.spec?.featureSet ?? '';
+        const sections: any[] = (fg as any)?.status?.featureGates ?? [];
+        const section = sections.find((s: any) => s.featureSet === featureSet);
+        enabled = (section?.enabled ?? []).map((g: any) => String(g.name));
+      } catch {
+        // If the CR can't be read, skip rather than fail
+      }
+      test.skip(
+        !enabled.includes(gateName),
+        `Feature gate '${gateName}' is not enabled on this cluster`,
+      );
+    });
+  },
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+cd frontend && yarn tsc --noEmit
+```
+
+Expected: no errors. If errors appear, check that `test` (the extended object) is in scope where `test.skip` is called — it should be because `base.extend` returns `test` which is re-used as the export.
+
+> **Note:** `test.skip` inside a fixture body is valid in Playwright and causes the test to be reported as skipped. Do not use `base.skip`; use `test.skip` (the exported object from `base.extend`).
+
+- [ ] **Step 5: Verify the fixture names appear in the exported `test` type**
+
+```bash
+cd frontend && node -e "const {test} = require('./e2e/fixtures'); console.log(typeof test)"
+```
+
+Expected: `function` (no import errors). If this fails with a module error, run `yarn build` first or rely on the `tsc --noEmit` check above — the runtime check is optional.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/e2e/fixtures/index.ts
+git commit -m "NO-ISSUE: Add techPreviewOnly and requireFeatureGate Playwright fixtures"
+```
+
+---
+
+### Task 2: Example TechPreview Playwright test
+
+Write the first test that uses `@tech-preview` + `techPreviewOnly` so the tag/fixture pattern is validated end-to-end, and CI has at least one test to run. This test verifies that the OLMv1 Software Catalog page is reachable on TechPreview clusters (where OLMv1 replaces the OLMv0 OperatorHub).
+
+**Files:**
+- Create: `frontend/e2e/tests/olm/olmv1-catalog.spec.ts`
+
+**Interfaces:**
+- Consumes: `test`, `expect` from `../../fixtures` (Task 1); `{ tag: ['@admin', '@tech-preview'] }` Playwright annotation
+
+- [ ] **Step 1: Create `frontend/e2e/tests/olm/olmv1-catalog.spec.ts`**
+
+```ts
+import { test, expect } from '../../fixtures';
+
+test.describe('OLMv1 Software Catalog', { tag: ['@admin', '@tech-preview'] }, () => {
+  test('Software Catalog page is accessible on TechPreview clusters', async ({
+    page,
+    techPreviewOnly,
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/k8s\/cluster\/clusterserviceversions|\/software-catalog/, {
+      timeout: 30_000,
+    });
+  });
+});
+```
+
+> **Why this test:** It is intentionally minimal — its only job is to confirm the fixture system works and give the CI job something to run. Richer OLMv1 tests should live here or in sibling spec files as the feature matures.
+
+- [ ] **Step 2: Verify the test appears in the tagged list**
+
+```bash
+cd frontend && node_modules/.bin/playwright test --list --grep "@tech-preview" 2>&1 | head -30
+```
+
+Expected: the new test `OLMv1 Software Catalog › Software Catalog page is accessible …` appears in the output. If it doesn't, check that the tag spelling matches exactly.
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+cd frontend && yarn tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/e2e/tests/olm/olmv1-catalog.spec.ts
+git commit -m "NO-ISSUE: Add OLMv1 catalog smoke test as first @tech-preview Playwright test"
+```
+
+---
+
+### Task 3: Playwright CI scripts
+
+Populate `test-prow-playwright-e2e-techpreview.sh` and add a `feature-gate` scenario to `test-prow-playwright-e2e.sh`.
+
+**Files:**
+- Modify: `test-prow-playwright-e2e-techpreview.sh`
+- Modify: `test-prow-playwright-e2e.sh`
+
+**Interfaces:**
+- Consumes: `./integration-tests/test-playwright-e2e.sh` (existing inner script)
+- Produces:
+  - `test-prow-playwright-e2e-techpreview.sh` — runs `--grep "@tech-preview|@feature-gate"` tests
+  - `test-prow-playwright-e2e.sh` — new `feature-gate` scenario that runs `--grep @feature-gate` tests
+
+- [ ] **Step 1: Populate `test-prow-playwright-e2e-techpreview.sh`**
+
+Replace the current 3-line stub with:
+
+```bash
+#!/usr/bin/env bash
+#
+# Prow / CI entrypoint for Playwright E2E against a TechPreview OpenShift cluster console.
+# Runs only tests tagged @tech-preview or @feature-gate.
+# Mirrors test-prow-playwright-e2e.sh: same env setup, same artifact handling.
+#
+# Usage:
+#   ./test-prow-playwright-e2e-techpreview.sh [playwright test args...]
+#
+# Environment (typical Prow / installer):
+#   ARTIFACT_DIR, INSTALLER_DIR, KUBEADMIN_PASSWORD_FILE  — same as test-prow-playwright-e2e.sh
+#
+
+set -exuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${REPO_ROOT}"
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
+
+if [ -z "$ARTIFACT_DIR" ]; then
+  echo "Error: ARTIFACT_DIR is not set" >&2
+  exit 1
+fi
+case "$ARTIFACT_DIR" in
+  /) echo "Error: ARTIFACT_DIR must not be '/'" >&2; exit 1 ;;
+  /*) ;;
+  *) echo "Error: ARTIFACT_DIR must be an absolute path, got: $ARTIFACT_DIR" >&2; exit 1 ;;
+esac
+
+export ARTIFACT_DIR INSTALLER_DIR
+mkdir -p "${ARTIFACT_DIR}"
+
+# don't log kubeadmin-password
+set +x
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+
+./contrib/create-user.sh
+
+pushd frontend
+
+./integration-tests/test-playwright-e2e.sh -- --grep "@tech-preview|@feature-gate" "$@"
+
+env NO_SANDBOX=true yarn test-puppeteer-csp
+
+popd
+```
+
+- [ ] **Step 2: Make the script executable**
+
+```bash
+chmod +x test-prow-playwright-e2e-techpreview.sh
+```
+
+- [ ] **Step 3: Add `feature-gate` scenario to `test-prow-playwright-e2e.sh`**
+
+In `test-prow-playwright-e2e.sh`, the `if/elif` block currently reads:
+
+```bash
+if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
+  ./integration-tests/test-playwright-e2e.sh "$@"
+elif [ "$SCENARIO" == "smoke" ]; then
+  # End of script flags before Playwright's --project (test-playwright-e2e.sh only parses -c).
+  ./integration-tests/test-playwright-e2e.sh -- --project=smoke "$@"
+else
+  echo "error: unknown scenario '$SCENARIO' (use: e2e, release, or smoke)" >&2
+  exit 1
+fi
+```
+
+Add a `feature-gate` branch and update the error message:
+
+```bash
+if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
+  ./integration-tests/test-playwright-e2e.sh "$@"
+elif [ "$SCENARIO" == "smoke" ]; then
+  # End of script flags before Playwright's --project (test-playwright-e2e.sh only parses -c).
+  ./integration-tests/test-playwright-e2e.sh -- --project=smoke "$@"
+elif [ "$SCENARIO" == "feature-gate" ]; then
+  # Run only tests tagged @feature-gate; the requireFeatureGate fixture skips any
+  # test whose gate is not enabled on this cluster.
+  ./integration-tests/test-playwright-e2e.sh -- --grep @feature-gate "$@"
+else
+  echo "error: unknown scenario '$SCENARIO' (use: e2e, release, smoke, or feature-gate)" >&2
+  exit 1
+fi
+```
+
+- [ ] **Step 4: Verify script syntax**
+
+```bash
+bash -n test-prow-playwright-e2e-techpreview.sh && echo "OK"
+bash -n test-prow-playwright-e2e.sh && echo "OK"
+```
+
+Expected: `OK` for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test-prow-playwright-e2e-techpreview.sh test-prow-playwright-e2e.sh
+git commit -m "NO-ISSUE: Populate Playwright techpreview CI script and add feature-gate scenario"
+```
+
+---
+
+### Task 4: Cypress tech-preview guard + techpreview script
+
+Create the shared Cypress guard module and populate `test-prow-e2e-techpreview.sh`.
+
+**Files:**
+- Create: `frontend/integration-tests/support/tech-preview-guard.ts`
+- Modify: `test-prow-e2e-techpreview.sh`
+
+**Interfaces:**
+- Produces:
+  - default export: `before()` hook that skips the entire suite unless `oc get featuregate cluster` returns `TechPreviewNoUpgrade`
+  - named export `requireFeatureGate(gateName: string): void` — registers a `before()` hook that skips unless the named gate is in the cluster's enabled list
+
+- [ ] **Step 1: Create `frontend/integration-tests/support/tech-preview-guard.ts`**
+
+```ts
+/**
+ * Cypress support helpers for TechPreview and per-feature-gate guards.
+ *
+ * Usage (in a Cypress package's support entry point):
+ *
+ *   // Skip entire suite unless cluster is TechPreviewNoUpgrade:
+ *   import './tech-preview-guard';
+ *
+ *   // Skip entire suite unless a specific feature gate is enabled:
+ *   import { requireFeatureGate } from './tech-preview-guard';
+ *   requireFeatureGate('OLMv1');
+ */
+
+before(function () {
+  cy.exec('oc get featuregate cluster -o jsonpath={.spec.featureSet}', {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.stdout.trim() !== 'TechPreviewNoUpgrade') {
+      this.skip();
+    }
+  });
+});
+
+export function requireFeatureGate(gateName: string): void {
+  before(function () {
+    cy.exec(
+      "oc get featuregate cluster -o jsonpath='{range .status.featureGates[*]}{range .enabled[*]}{.name}{\"\\n\"}{end}{end}'",
+      { failOnNonZeroExit: false },
+    ).then((result) => {
+      const enabled = result.stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (!enabled.includes(gateName)) {
+        this.skip();
+      }
+    });
+  });
+}
+```
+
+> **Note:** Importing this file as a side-effect (`import './tech-preview-guard'`) registers the TechPreview `before()` hook. Call `requireFeatureGate('GateName')` *in addition* if the test needs a specific gate beyond the global TechPreview flag.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd frontend && yarn tsc --noEmit
+```
+
+Expected: no errors. The file uses only Cypress globals (`cy`, `before`) which are declared by `@types/cypress`.
+
+- [ ] **Step 3: Populate `test-prow-e2e-techpreview.sh`**
+
+Replace the current 3-line stub with:
+
+```bash
+#!/usr/bin/env bash
+#
+# Prow / CI entrypoint for Cypress E2E against a TechPreview OpenShift cluster console.
+# Runs only Cypress packages that contain TechPreview or feature-gate suites.
+# Mirrors test-prow-e2e.sh: same env setup, same CSP check.
+#
+# Usage:
+#   ./test-prow-e2e-techpreview.sh
+#
+# Environment (typical Prow / installer):
+#   ARTIFACT_DIR, INSTALLER_DIR, KUBEADMIN_PASSWORD_FILE  — same as test-prow-e2e.sh
+#
+# Adding a new TechPreview Cypress package:
+#   1. Import tech-preview-guard in the package's Cypress support entry point.
+#   2. Add '-p <package>' to the invocation below.
+#
+
+set -exuo pipefail
+
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
+
+# don't log kubeadmin-password
+set +x
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+
+./contrib/create-user.sh
+
+pushd frontend
+
+# olm: OLMv1 UI is active on TechPreview clusters; OLMv1-specific tests live here.
+# Add further packages as TechPreview / feature-gate Cypress tests are written.
+./integration-tests/test-cypress.sh -p olm -h true
+
+env NO_SANDBOX=true yarn test-puppeteer-csp
+
+popd
+```
+
+- [ ] **Step 4: Make the Cypress script executable**
+
+```bash
+chmod +x test-prow-e2e-techpreview.sh
+```
+
+- [ ] **Step 5: Verify both script syntaxes**
+
+```bash
+bash -n test-prow-e2e-techpreview.sh && echo "OK"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/integration-tests/support/tech-preview-guard.ts test-prow-e2e-techpreview.sh
+git commit -m "NO-ISSUE: Add Cypress TechPreview guard and populate Cypress techpreview CI script"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| `techPreviewOnly` Playwright fixture | Task 1 |
+| `requireFeatureGate` Playwright fixture | Task 1 |
+| `getClusterCustomResource` on KubernetesClient | Already exists at `kubernetes-client.ts:548` — no task needed |
+| `@tech-preview` tag + example test | Task 2 |
+| `test-prow-playwright-e2e-techpreview.sh` populated | Task 3 |
+| `test-prow-playwright-e2e.sh` `feature-gate` scenario | Task 3 |
+| Cypress `tech-preview-guard.ts` with global TechPreview guard | Task 4 |
+| Cypress `requireFeatureGate` helper | Task 4 |
+| `test-prow-e2e-techpreview.sh` populated | Task 4 |
+| Feature gate graduation is transparent (no test change needed) | Handled by fixture logic in Task 1 |
+
+**Placeholder scan:** No TBD, TODO, or "similar to" references. All code blocks are complete.
+
+**Type consistency:**
+- `requireFeatureGate: (gateName: string) => Promise<void>` — declared in `TestFixtures`, implemented in `base.extend()`, and called with `await requireFeatureGate('GateName')` in tests. Consistent.
+- `techPreviewOnly: void` — declared in `TestFixtures`, destructured as `{ techPreviewOnly }` in tests. Consistent with the existing `cleanup` pattern.
+- `k8sClient` is a `WorkerFixtures` member already defined in the same `base.extend()` — available as a dependency in the `requireFeatureGate` fixture body. Consistent.

--- a/docs/superpowers/specs/2026-07-16-techpreview-e2e-test-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-16-techpreview-e2e-test-filtering-design.md
@@ -1,55 +1,74 @@
 # Tech Preview E2E Test Filtering Design
 
 **Date:** 2026-07-16  
-**Status:** Approved
+**Status:** Approved (updated to include per-feature-gate support)
 
 ## Goal
 
 Populate `test-prow-e2e-techpreview.sh` and `test-prow-playwright-e2e-techpreview.sh` so that CI
 jobs running against `TechPreviewNoUpgrade` clusters execute only the tests that specifically
-require tech preview to be enabled, and skip everything else.
+require tech preview or a specific feature gate to be enabled, and skip everything else.
 
-The regular `test-prow-e2e.sh` / `test-prow-playwright-e2e.sh` already skip tech-preview-sensitive
-tests via `test.skip(isTechPreview, …)`. The tech-preview scripts are the inverse: they run only
-what the regular scripts would skip.
+A test can declare one of two levels of dependency:
+
+- **TechPreview overall** — the entire `TechPreviewNoUpgrade` feature set must be on.
+- **Specific feature gate** — a named gate (e.g. `OLMv1`, `NodeSwap`) must be enabled. Tests at
+  this level run on *any* cluster where the gate is enabled, regardless of whether the gate is in
+  TechPreview or has graduated to GA.
+
+This lets a test continue to run correctly after its feature gate graduates without changing the
+test itself.
 
 ## Background
 
 - `SERVER_FLAGS.techPreview` (boolean) — set by the server when the cluster's FeatureGate
   `featureSet` is `TechPreviewNoUpgrade`.
+- The OpenShift FeatureGate CR (`config.openshift.io/v1`, cluster-scoped) tracks individual gate
+  states. `.status.featureGates[]` lists enabled/disabled gates per feature set; the current
+  cluster's active gates are the ones corresponding to `.spec.featureSet`.
 - `oc get featuregate cluster -o jsonpath={.spec.featureSet}` returns `TechPreviewNoUpgrade` on
-  tech-preview clusters.
+  tech-preview clusters, or empty string on standard clusters.
 - Playwright already uses `{ tag: […] }` annotations (`@admin`, `@smoke`, etc.) and supports
   `--grep` for tag-based filtering.
 - Cypress uses a `before()` / `cy.exec` pattern (see
   `frontend/packages/dev-console/integration-tests/support/commands/hooks.ts`) to skip entire
   suites based on the cluster's feature set.
+- `KubernetesClient` (`frontend/e2e/clients/kubernetes-client.ts`) exposes `customObjectsApi` but
+  only has `getCustomResource` (namespaced); a `getClusterCustomResource` method needs to be added.
+
+## Tag Convention
+
+| Tag | Meaning |
+|-----|---------|
+| `@tech-preview` | Test requires `SERVER_FLAGS.techPreview === true` (TechPreviewNoUpgrade overall) |
+| `@feature-gate` | Test requires a specific named feature gate; fixture determines which and enforces it |
+
+Both tags are included in the techpreview scripts. The `@feature-gate` tag is also included in the
+regular scripts so tests naturally start passing there as gates graduate to GA — no script change
+needed at graduation time.
+
+Example:
+
+```ts
+// Requires TechPreview overall
+test.describe('OLMv1 catalog', { tag: ['@admin', '@tech-preview'] }, () => { … });
+
+// Requires a specific feature gate (runs on TP and GA once the gate graduates)
+test.describe('NodeSwap scheduling', { tag: ['@admin', '@feature-gate'] }, () => { … });
+```
 
 ## Playwright Design
 
-### Tag convention
-
-Any test that **requires** `TechPreviewNoUpgrade` carries the `@tech-preview` tag:
-
-```ts
-test.describe('OLMv1 catalog', { tag: ['@admin', '@tech-preview'] }, () => { … });
-```
-
-This is consistent with the existing `@admin`, `@smoke`, `@regression`, `@dev-console` tags
-already in use.
-
 ### `techPreviewOnly` fixture
 
-Added directly to the `TestFixtures` type and `base.extend()` chain in
-`frontend/e2e/fixtures/index.ts`. This is a safety net: if a tagged test is accidentally run
-against a regular cluster it fails fast with a clear message instead of a confusing assertion
-error. No new file is needed.
+Added to the `TestFixtures` type and `base.extend()` chain in `frontend/e2e/fixtures/index.ts`.
+Reads `SERVER_FLAGS.techPreview` from the page and skips if the cluster is not on TechPreview.
 
 ```ts
-// In TestFixtures:
 type TestFixtures = {
   cleanup: CleanupFixture;
   techPreviewOnly: void;
+  requireFeatureGate: (gateName: string) => Promise<void>;
 };
 
 // In base.extend():
@@ -60,31 +79,84 @@ techPreviewOnly: async ({ page }, use) => {
 },
 ```
 
-Tests opt in by destructuring the fixture — since all tests already import `test` from
-`../../fixtures`, no extra import is needed:
+### `requireFeatureGate` fixture
+
+Also added to `fixtures/index.ts`. Returns a callable that a test invokes with the gate name it
+needs. Queries the FeatureGate cluster CR via `KubernetesClient` and skips if the gate is not in
+the enabled list for the cluster's active feature set.
 
 ```ts
-test('OLMv1 catalog is visible', async ({ page, techPreviewOnly }) => { … });
+requireFeatureGate: async ({ k8sClient }, use) => {
+  await use(async (gateName: string) => {
+    const fg = await k8sClient.getClusterCustomResource(
+      'config.openshift.io', 'v1', 'featuregates', 'cluster',
+    );
+    const featureSet: string = fg?.spec?.featureSet ?? '';
+    const section = (fg?.status?.featureGates ?? []).find(
+      (s: any) => s.featureSet === featureSet,
+    );
+    const enabled: string[] = (section?.enabled ?? []).map((g: any) => g.name);
+    test.skip(!enabled.includes(gateName), `Feature gate '${gateName}' is not enabled on this cluster`);
+  });
+},
+```
+
+Usage in a test:
+
+```ts
+test('NodeSwap pod scheduling', async ({ page, requireFeatureGate }) => {
+  await requireFeatureGate('NodeSwap');
+  // … rest of test
+});
+```
+
+### `KubernetesClient.getClusterCustomResource`
+
+A new method on `KubernetesClient` using the existing `customObjectsApi` to fetch cluster-scoped
+custom resources (FeatureGate, ClusterVersion, etc.):
+
+```ts
+async getClusterCustomResource(
+  group: string,
+  version: string,
+  plural: string,
+  name: string,
+): Promise<any> {
+  return this.coApi.getClusterCustomObject({ group, version, plural, name });
+}
 ```
 
 ### `test-prow-playwright-e2e-techpreview.sh`
 
-Mirrors `test-prow-playwright-e2e.sh` exactly (same env setup, same artifact copy trap) with one
-difference: it passes `--grep @tech-preview` to Playwright so only tagged tests run.
+Mirrors `test-prow-playwright-e2e.sh` (same env setup, same artifact copy trap) but passes a grep
+filter so only TechPreview or feature-gate tests run:
 
 ```bash
-./integration-tests/test-playwright-e2e.sh -- --grep @tech-preview "$@"
+./integration-tests/test-playwright-e2e.sh -- --grep "@tech-preview|@feature-gate" "$@"
 ```
 
-No new `playwright.config.ts` project is needed. The existing projects (`olm`, `console`, etc.)
-already cover the correct `testDir` paths; `--grep` filters within them.
+No new `playwright.config.ts` project needed.
+
+### `test-prow-playwright-e2e.sh` (regular script — minor addition)
+
+The regular script gains a `--grep @feature-gate` path so that feature-gate tests also run there.
+On standard clusters, the `requireFeatureGate` fixture skips any test whose gate is not yet
+enabled; as gates graduate the tests pass automatically.
+
+```bash
+# In the e2e/release branch of the regular script:
+./integration-tests/test-playwright-e2e.sh -- --grep @feature-gate "$@"
+```
+
+This is added as a new scenario or combined with the existing `e2e` scenario — exact wiring to
+be decided at implementation time based on CI job structure.
 
 ## Cypress Design
 
-### Inverted guard hook
+### Inverted guard hook — TechPreview overall
 
-A new shared support helper at
-`frontend/integration-tests/support/tech-preview-guard.ts`:
+A new shared support helper at `frontend/integration-tests/support/tech-preview-guard.ts`.
+Skips the entire Cypress suite if the cluster is *not* on TechPreview:
 
 ```ts
 before(function () {
@@ -98,48 +170,83 @@ before(function () {
 });
 ```
 
-Cypress packages that contain tech-preview tests import this file in their support entry point.
-Initially this is just the `olm` package (for OLMv1 UI tests).
+### Inverted guard hook — specific feature gate
+
+An additional helper (same file or a companion `feature-gate-guard.ts`) that accepts a gate name
+and skips the suite unless that gate appears in the enabled list:
+
+```ts
+export function requireFeatureGate(gateName: string): void {
+  before(function () {
+    cy.exec(
+      `oc get featuregate cluster -o jsonpath='{.status.featureGates[*].enabled[*].name}'`,
+      { failOnNonZeroExit: false },
+    ).then((result) => {
+      const enabled = result.stdout.split(/\s+/).filter(Boolean);
+      if (!enabled.includes(gateName)) {
+        this.skip();
+      }
+    });
+  });
+}
+```
+
+Cypress packages call this in their support entry point alongside the TechPreview guard.
 
 ### `test-prow-e2e-techpreview.sh`
 
-Mirrors `test-prow-e2e.sh` (same env setup, same `create-user.sh` and CSP check) but calls only
-the Cypress packages that have tech-preview suites:
+Mirrors `test-prow-e2e.sh` (same env setup, same `create-user.sh` and CSP check) but runs only
+the Cypress packages that have TechPreview or feature-gate suites:
 
 ```bash
 ./integration-tests/test-cypress.sh -p olm -h true
 ```
 
-Additional packages are added here as tech-preview Cypress tests are written.
+Additional packages are added here as tech-preview / feature-gate Cypress tests are written.
 
 ## File Inventory
 
 | File | Action |
 |------|--------|
-| `test-prow-playwright-e2e-techpreview.sh` | Populate (mirrors playwright script + `--grep @tech-preview`) |
-| `test-prow-e2e-techpreview.sh` | Populate (mirrors cypress script + tech-preview packages only) |
-| `frontend/e2e/fixtures/index.ts` | Add `techPreviewOnly` to `TestFixtures` type and `base.extend()` |
-| `frontend/integration-tests/support/tech-preview-guard.ts` | Create — inverted Cypress `before()` guard |
+| `test-prow-playwright-e2e-techpreview.sh` | Populate (mirrors playwright script + `--grep "@tech-preview\|@feature-gate"`) |
+| `test-prow-e2e-techpreview.sh` | Populate (mirrors cypress script + TP/feature-gate packages only) |
+| `frontend/e2e/fixtures/index.ts` | Add `techPreviewOnly` and `requireFeatureGate` fixtures |
+| `frontend/e2e/clients/kubernetes-client.ts` | Add `getClusterCustomResource` method |
+| `frontend/integration-tests/support/tech-preview-guard.ts` | Create — TechPreview Cypress guard + `requireFeatureGate` helper |
 
 ## How Tests Participate
 
-### Playwright (new or existing test)
+### Playwright — TechPreview overall
 
 1. Add `@tech-preview` to the `test.describe` or `test()` tags.
 2. Add `techPreviewOnly` to the fixture destructuring list.
 3. Remove any manual `test.skip(isTechPreview, …)` guard — the fixture handles it.
 
-### Cypress (new or existing test)
+### Playwright — specific feature gate
 
-1. Add `import '../../../integration-tests/support/tech-preview-guard'` (or equivalent relative
-   path) to the package's support entry point.
-2. Add the package name to the `test-prow-e2e-techpreview.sh` invocation list.
+1. Add `@feature-gate` to the tags.
+2. Call `await requireFeatureGate('GateName')` as the first line of the test body.
 
-## What This Does Not Cover
+### Cypress — TechPreview overall
 
-- **Per-feature-gate granularity:** A specific feature gate beyond the top-level `techPreview`
-  flag (e.g., `NodeSwap`) is not handled. Future work could add per-gate fixtures
-  (`nodeSwapOnly`, etc.) following the same pattern.
-- **Playwright project isolation:** Running tech-preview tests in a dedicated Playwright project
-  (e.g., `--project=tech-preview`) is not needed now but is a natural extension if the suite grows
-  large enough to warrant a separate setup/teardown dependency chain.
+1. Import `tech-preview-guard` in the package's support entry point.
+2. Add the package to `test-prow-e2e-techpreview.sh`.
+
+### Cypress — specific feature gate
+
+1. Call `requireFeatureGate('GateName')` in the package's support entry point (or individual spec
+   `before()` if only some tests in the package need it).
+2. Add the package to `test-prow-e2e-techpreview.sh`.
+
+## Lifecycle: Feature Gate Graduation
+
+When a gate graduates from TechPreview to GA:
+
+- **Playwright**: no test change needed. The `requireFeatureGate` fixture will find the gate in the
+  enabled list on GA clusters, and the test already runs via `--grep @feature-gate` in the regular
+  script.
+- **Cypress**: no test change needed. The `requireFeatureGate` guard passes on GA clusters once the
+  gate is in the enabled list.
+- **What does change**: the gate may move from `.status.featureGates[featureSet=TechPreviewNoUpgrade].enabled`
+  to being enabled by default (not listed as disabled in any feature set). The fixture and guard
+  both check the enabled list, so this is transparent.

--- a/docs/superpowers/specs/2026-07-16-techpreview-e2e-test-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-16-techpreview-e2e-test-filtering-design.md
@@ -1,0 +1,145 @@
+# Tech Preview E2E Test Filtering Design
+
+**Date:** 2026-07-16  
+**Status:** Approved
+
+## Goal
+
+Populate `test-prow-e2e-techpreview.sh` and `test-prow-playwright-e2e-techpreview.sh` so that CI
+jobs running against `TechPreviewNoUpgrade` clusters execute only the tests that specifically
+require tech preview to be enabled, and skip everything else.
+
+The regular `test-prow-e2e.sh` / `test-prow-playwright-e2e.sh` already skip tech-preview-sensitive
+tests via `test.skip(isTechPreview, …)`. The tech-preview scripts are the inverse: they run only
+what the regular scripts would skip.
+
+## Background
+
+- `SERVER_FLAGS.techPreview` (boolean) — set by the server when the cluster's FeatureGate
+  `featureSet` is `TechPreviewNoUpgrade`.
+- `oc get featuregate cluster -o jsonpath={.spec.featureSet}` returns `TechPreviewNoUpgrade` on
+  tech-preview clusters.
+- Playwright already uses `{ tag: […] }` annotations (`@admin`, `@smoke`, etc.) and supports
+  `--grep` for tag-based filtering.
+- Cypress uses a `before()` / `cy.exec` pattern (see
+  `frontend/packages/dev-console/integration-tests/support/commands/hooks.ts`) to skip entire
+  suites based on the cluster's feature set.
+
+## Playwright Design
+
+### Tag convention
+
+Any test that **requires** `TechPreviewNoUpgrade` carries the `@tech-preview` tag:
+
+```ts
+test.describe('OLMv1 catalog', { tag: ['@admin', '@tech-preview'] }, () => { … });
+```
+
+This is consistent with the existing `@admin`, `@smoke`, `@regression`, `@dev-console` tags
+already in use.
+
+### `techPreviewOnly` fixture
+
+Added directly to the `TestFixtures` type and `base.extend()` chain in
+`frontend/e2e/fixtures/index.ts`. This is a safety net: if a tagged test is accidentally run
+against a regular cluster it fails fast with a clear message instead of a confusing assertion
+error. No new file is needed.
+
+```ts
+// In TestFixtures:
+type TestFixtures = {
+  cleanup: CleanupFixture;
+  techPreviewOnly: void;
+};
+
+// In base.extend():
+techPreviewOnly: async ({ page }, use) => {
+  const isTechPreview = await page.evaluate(() => window.SERVER_FLAGS.techPreview);
+  test.skip(!isTechPreview, 'This test requires a TechPreviewNoUpgrade cluster');
+  await use();
+},
+```
+
+Tests opt in by destructuring the fixture — since all tests already import `test` from
+`../../fixtures`, no extra import is needed:
+
+```ts
+test('OLMv1 catalog is visible', async ({ page, techPreviewOnly }) => { … });
+```
+
+### `test-prow-playwright-e2e-techpreview.sh`
+
+Mirrors `test-prow-playwright-e2e.sh` exactly (same env setup, same artifact copy trap) with one
+difference: it passes `--grep @tech-preview` to Playwright so only tagged tests run.
+
+```bash
+./integration-tests/test-playwright-e2e.sh -- --grep @tech-preview "$@"
+```
+
+No new `playwright.config.ts` project is needed. The existing projects (`olm`, `console`, etc.)
+already cover the correct `testDir` paths; `--grep` filters within them.
+
+## Cypress Design
+
+### Inverted guard hook
+
+A new shared support helper at
+`frontend/integration-tests/support/tech-preview-guard.ts`:
+
+```ts
+before(function () {
+  cy.exec('oc get featuregate cluster -o jsonpath={.spec.featureSet}', {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.stdout.trim() !== 'TechPreviewNoUpgrade') {
+      this.skip();
+    }
+  });
+});
+```
+
+Cypress packages that contain tech-preview tests import this file in their support entry point.
+Initially this is just the `olm` package (for OLMv1 UI tests).
+
+### `test-prow-e2e-techpreview.sh`
+
+Mirrors `test-prow-e2e.sh` (same env setup, same `create-user.sh` and CSP check) but calls only
+the Cypress packages that have tech-preview suites:
+
+```bash
+./integration-tests/test-cypress.sh -p olm -h true
+```
+
+Additional packages are added here as tech-preview Cypress tests are written.
+
+## File Inventory
+
+| File | Action |
+|------|--------|
+| `test-prow-playwright-e2e-techpreview.sh` | Populate (mirrors playwright script + `--grep @tech-preview`) |
+| `test-prow-e2e-techpreview.sh` | Populate (mirrors cypress script + tech-preview packages only) |
+| `frontend/e2e/fixtures/index.ts` | Add `techPreviewOnly` to `TestFixtures` type and `base.extend()` |
+| `frontend/integration-tests/support/tech-preview-guard.ts` | Create — inverted Cypress `before()` guard |
+
+## How Tests Participate
+
+### Playwright (new or existing test)
+
+1. Add `@tech-preview` to the `test.describe` or `test()` tags.
+2. Add `techPreviewOnly` to the fixture destructuring list.
+3. Remove any manual `test.skip(isTechPreview, …)` guard — the fixture handles it.
+
+### Cypress (new or existing test)
+
+1. Add `import '../../../integration-tests/support/tech-preview-guard'` (or equivalent relative
+   path) to the package's support entry point.
+2. Add the package name to the `test-prow-e2e-techpreview.sh` invocation list.
+
+## What This Does Not Cover
+
+- **Per-feature-gate granularity:** A specific feature gate beyond the top-level `techPreview`
+  flag (e.g., `NodeSwap`) is not handled. Future work could add per-gate fixtures
+  (`nodeSwapOnly`, etc.) following the same pattern.
+- **Playwright project isolation:** Running tech-preview tests in a dedicated Playwright project
+  (e.g., `--project=tech-preview`) is not needed now but is a natural extension if the suite grows
+  large enough to warrant a separate setup/teardown dependency chain.

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -14,3 +14,4 @@ dynamic-demo-plugin
 tsconfig.json
 e2e/tsconfig.json
 e2e/package.json
+integration-tests/tsconfig.json

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -16,6 +16,8 @@ export interface SharedTestConfig {
 
 type TestFixtures = {
   cleanup: CleanupFixture;
+  techPreviewOnly: void;
+  requireFeatureGate: (gateName: string) => Promise<void>;
 };
 
 type WorkerFixtures = {
@@ -57,6 +59,36 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     },
     { scope: 'worker' },
   ],
+
+  techPreviewOnly: async ({ page }, use) => {
+    const isTechPreview = await page.evaluate(() => window.SERVER_FLAGS.techPreview);
+    test.skip(!isTechPreview, 'This test requires a TechPreviewNoUpgrade cluster');
+    await use();
+  },
+
+  requireFeatureGate: async ({ k8sClient }, use) => {
+    await use(async (gateName: string) => {
+      let enabled: string[] = [];
+      try {
+        const fg = await k8sClient.getClusterCustomResource(
+          'config.openshift.io',
+          'v1',
+          'featuregates',
+          'cluster',
+        );
+        const featureSet: string = (fg as any)?.spec?.featureSet ?? '';
+        const sections: any[] = (fg as any)?.status?.featureGates ?? [];
+        const section = sections.find((s: any) => s.featureSet === featureSet);
+        enabled = (section?.enabled ?? []).map((g: any) => String(g.name));
+      } catch {
+        // If the CR can't be read, skip rather than fail
+      }
+      test.skip(
+        !enabled.includes(gateName),
+        `Feature gate '${gateName}' is not enabled on this cluster`,
+      );
+    });
+  },
 
   cleanup: async ({}, use, testInfo) => {
     const testName = testInfo.titlePath.join(' > ');

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -60,8 +60,22 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     { scope: 'worker' },
   ],
 
-  techPreviewOnly: async ({ page }, use) => {
-    const isTechPreview = await page.evaluate(() => window.SERVER_FLAGS.techPreview);
+  techPreviewOnly: async ({ k8sClient }, use) => {
+    let isTechPreview = false;
+    try {
+      const fg = await k8sClient.getClusterCustomResource(
+        'config.openshift.io',
+        'v1',
+        'featuregates',
+        'cluster',
+      );
+      isTechPreview = (fg as any)?.spec?.featureSet === 'TechPreviewNoUpgrade';
+    } catch {
+      // If the CR can't be read, don't skip — surface the infrastructure error
+      throw new Error(
+        `techPreviewOnly: could not read FeatureGate CR 'cluster': check cluster connectivity`,
+      );
+    }
     test.skip(!isTechPreview, 'This test requires a TechPreviewNoUpgrade cluster');
     await use();
   },
@@ -80,8 +94,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         const sections: any[] = (fg as any)?.status?.featureGates ?? [];
         const section = sections.find((s: any) => s.featureSet === featureSet);
         enabled = (section?.enabled ?? []).map((g: any) => String(g.name));
-      } catch {
-        // If the CR can't be read, skip rather than fail
+      } catch (err) {
+        throw new Error(
+          `requireFeatureGate('${gateName}'): could not read FeatureGate CR 'cluster': ${err}`,
+        );
       }
       test.skip(
         !enabled.includes(gateName),

--- a/frontend/e2e/tests/olm/olmv1-catalog.spec.ts
+++ b/frontend/e2e/tests/olm/olmv1-catalog.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '../../fixtures';
+
+test.describe('OLMv1 Software Catalog', { tag: ['@admin', '@tech-preview'] }, () => {
+  test('Software Catalog page is accessible on TechPreview clusters', async ({
+    page,
+    techPreviewOnly,
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/k8s\/cluster\/clusterserviceversions|\/software-catalog/, {
+      timeout: 30_000,
+    });
+  });
+});

--- a/frontend/integration-tests/.eslintrc.cjs
+++ b/frontend/integration-tests/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: {
+    'cypress/globals': true,
+    node: true,
+  },
+  extends: ['plugin:cypress/recommended'],
+  plugins: ['cypress'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
+    ecmaVersion: 2018,
+  },
+  rules: {
+    'no-console': 'off',
+    'cypress/unsafe-to-chain-command': 'off',
+  },
+};

--- a/frontend/integration-tests/support/tech-preview-guard.ts
+++ b/frontend/integration-tests/support/tech-preview-guard.ts
@@ -1,0 +1,39 @@
+/**
+ * Cypress support helpers for TechPreview and per-feature-gate guards.
+ *
+ * Usage (in a Cypress package's support entry point):
+ *
+ *   // Skip entire suite unless cluster is TechPreviewNoUpgrade:
+ *   import './tech-preview-guard';
+ *
+ *   // Skip entire suite unless a specific feature gate is enabled:
+ *   import { requireFeatureGate } from './tech-preview-guard';
+ *   requireFeatureGate('OLMv1');
+ */
+
+before(function () {
+  cy.exec('oc get featuregate cluster -o jsonpath={.spec.featureSet}', {
+    failOnNonZeroExit: false,
+  }).then((result) => {
+    if (result.stdout.trim() !== 'TechPreviewNoUpgrade') {
+      this.skip();
+    }
+  });
+});
+
+export function requireFeatureGate(gateName: string): void {
+  before(function () {
+    cy.exec(
+      "oc get featuregate cluster -o jsonpath='{range .status.featureGates[*]}{range .enabled[*]}{.name}{\"\\n\"}{end}{end}'",
+      { failOnNonZeroExit: false },
+    ).then((result) => {
+      const enabled = result.stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (!enabled.includes(gateName)) {
+        this.skip();
+      }
+    });
+  });
+}

--- a/frontend/integration-tests/tsconfig.json
+++ b/frontend/integration-tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "types": ["cypress"]
+  },
+  "include": ["../node_modules/cypress", "**/*.ts"]
+}

--- a/test-prow-e2e-techpreview.sh
+++ b/test-prow-e2e-techpreview.sh
@@ -1,3 +1,38 @@
 #!/usr/bin/env bash
+#
+# Prow / CI entrypoint for Cypress E2E against a TechPreview OpenShift cluster console.
+# Runs only Cypress packages that contain TechPreview or feature-gate suites.
+# Mirrors test-prow-e2e.sh: same env setup, same CSP check.
+#
+# Usage:
+#   ./test-prow-e2e-techpreview.sh
+#
+# Environment (typical Prow / installer):
+#   ARTIFACT_DIR, INSTALLER_DIR, KUBEADMIN_PASSWORD_FILE  — same as test-prow-e2e.sh
+#
+# Adding a new TechPreview Cypress package:
+#   1. Import tech-preview-guard in the package's Cypress support entry point.
+#   2. Add '-p <package>' to the invocation below.
+#
 
 set -exuo pipefail
+
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
+
+# don't log kubeadmin-password
+set +x
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+
+./contrib/create-user.sh
+
+pushd frontend
+
+# olm: OLMv1 UI is active on TechPreview clusters; OLMv1-specific tests live here.
+# Add further packages as TechPreview / feature-gate Cypress tests are written.
+./integration-tests/test-cypress.sh -p olm -h true
+
+env NO_SANDBOX=true yarn test-puppeteer-csp
+
+popd

--- a/test-prow-playwright-e2e-techpreview.sh
+++ b/test-prow-playwright-e2e-techpreview.sh
@@ -1,3 +1,49 @@
 #!/usr/bin/env bash
+#
+# Prow / CI entrypoint for Playwright E2E against a TechPreview OpenShift cluster console.
+# Runs only tests tagged @tech-preview or @feature-gate.
+# Mirrors test-prow-playwright-e2e.sh: same env setup, same artifact handling.
+#
+# Usage:
+#   ./test-prow-playwright-e2e-techpreview.sh [playwright test args...]
+#
+# Environment (typical Prow / installer):
+#   ARTIFACT_DIR, INSTALLER_DIR, KUBEADMIN_PASSWORD_FILE  — same as test-prow-playwright-e2e.sh
+#
 
 set -exuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${REPO_ROOT}"
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/artifacts}
+INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
+
+if [ -z "$ARTIFACT_DIR" ]; then
+  echo "Error: ARTIFACT_DIR is not set" >&2
+  exit 1
+fi
+case "$ARTIFACT_DIR" in
+  /) echo "Error: ARTIFACT_DIR must not be '/'" >&2; exit 1 ;;
+  /*) ;;
+  *) echo "Error: ARTIFACT_DIR must be an absolute path, got: $ARTIFACT_DIR" >&2; exit 1 ;;
+esac
+
+export ARTIFACT_DIR INSTALLER_DIR
+mkdir -p "${ARTIFACT_DIR}"
+
+# don't log kubeadmin-password
+set +x
+export BRIDGE_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
+export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
+
+./contrib/create-user.sh
+
+pushd frontend
+
+./integration-tests/test-playwright-e2e.sh -- --grep "@tech-preview|@feature-gate" "$@"
+
+env NO_SANDBOX=true yarn test-puppeteer-csp
+
+popd

--- a/test-prow-playwright-e2e.sh
+++ b/test-prow-playwright-e2e.sh
@@ -59,8 +59,12 @@ if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
 elif [ "$SCENARIO" == "smoke" ]; then
   # End of script flags before Playwright's --project (test-playwright-e2e.sh only parses -c).
   ./integration-tests/test-playwright-e2e.sh -- --project=smoke "$@"
+elif [ "$SCENARIO" == "feature-gate" ]; then
+  # Run only tests tagged @feature-gate; the requireFeatureGate fixture skips any
+  # test whose gate is not enabled on this cluster.
+  ./integration-tests/test-playwright-e2e.sh -- --grep @feature-gate "$@"
 else
-  echo "error: unknown scenario '$SCENARIO' (use: e2e, release, or smoke)" >&2
+  echo "error: unknown scenario '$SCENARIO' (use: e2e, release, smoke, or feature-gate)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
**Analysis / Root cause**:
`test-prow-e2e-techpreview.sh` and `test-prow-playwright-e2e-techpreview.sh`
were empty placeholders. CI jobs running against TechPreviewNoUpgrade clusters
had no mechanism to select only the tests that require TechPreview or a specific
feature gate to be enabled.

**Solution description**:
- Adds `@tech-preview` and `@feature-gate` Playwright tags as the selection
  mechanism for CI scripts.
- Adds two fixtures to `frontend/e2e/fixtures/index.ts`:
  - `techPreviewOnly` — skips the test if the cluster's FeatureGate
    `spec.featureSet` is not `TechPreviewNoUpgrade` (reads via k8sClient).
  - `requireFeatureGate(gateName)` — skips unless the named gate appears in
    the cluster's enabled list; throws on infrastructure errors so failures
    are visible rather than silently skipped.
- Adds an example `@tech-preview` test (`e2e/tests/olm/olmv1-catalog.spec.ts`)
  as the first consumer of the new fixtures.
- Populates `test-prow-playwright-e2e-techpreview.sh` to run
  `--grep "@tech-preview|@feature-gate"`.
- Adds a `feature-gate` scenario to `test-prow-playwright-e2e.sh` so
  feature-gate tests also run on standard clusters (fixture skips when the
  gate is not enabled; tests pass naturally as gates graduate to GA).
- Creates `frontend/integration-tests/support/tech-preview-guard.ts` with a
  Cypress `before()` guard (skips suite unless `TechPreviewNoUpgrade`) and a
  `requireFeatureGate(gateName)` helper.
- Populates `test-prow-e2e-techpreview.sh` to run the `olm` Cypress package
  (OLMv1 UI is active on TechPreview clusters).

**Screenshots / screen recording**:
N/A — CI infrastructure change.

**Test setup:**
- Playwright fixtures are verified by TypeScript compilation and `--list`.
- Full validation requires a cluster with `featureSet: TechPreviewNoUpgrade`.

**Test cases:**
- `playwright test --list --grep "@tech-preview"` shows `olmv1-catalog.spec.ts`
- On a TechPreview cluster: `@tech-preview` tests run; `techPreviewOnly` skips nothing.
- On a standard cluster: `techPreviewOnly` skips the test; `requireFeatureGate`
  skips tests whose gates are not enabled.
- Infrastructure error (bad kubeconfig): `requireFeatureGate` throws visibly
  rather than silently skipping.

**Browser conformance**: N/A

**Additional info**:
Feature gate graduation is handled transparently: when a gate moves from
TechPreview to GA, `requireFeatureGate` finds it in the cluster's enabled list
on GA clusters without any test changes. The `@feature-gate` tag runs in both
the regular and techpreview scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tech Preview and feature-gate filtering for Playwright and Cypress end-to-end tests.
  * Added automatic test skipping based on cluster Tech Preview status and enabled feature gates.
  * Added dedicated CI entry points for Tech Preview test suites.
  * Added an OLMv1 Software Catalog Tech Preview end-to-end test.

* **Documentation**
  * Documented the test tagging, filtering, fixture behavior, and CI execution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->