### PR TITLE
CONSOLE-5427: Fix NS_BINDING_ABORTED noise, lifecycle cache coupling, and table row overlap

### DIFF
--- a/frontend/packages/console-shared/src/utils/__tests__/console-fetch.spec.ts
+++ b/frontend/packages/console-shared/src/utils/__tests__/console-fetch.spec.ts
@@ -103,6 +103,32 @@ describe('consoleFetch', () => {
     ).rejects.not.toBeInstanceOf(RetryError);
   });
 
+  it('does not console.warn when fetch is aborted via AbortController', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = new AbortController();
+    window.fetch = jest.fn(() =>
+      Promise.reject(new DOMException('The operation was aborted.', 'AbortError')),
+    );
+
+    await expect(
+      coFetch('/api/lifecycle/test', { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('does console.warn when fetch fails with a real network error', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    window.fetch = jest.fn(() => Promise.reject(new TypeError('Network failure')));
+
+    await expect(coFetch('/api/lifecycle/test')).rejects.toThrow('Network failure');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/lifecycle/test'),
+      expect.any(TypeError),
+    );
+    consoleSpy.mockRestore();
+  });
+
   it('should retry up to 3 times when RetryError is thrown', async () => {
     window.fetch = jest.fn(() =>
       Promise.resolve({ status: 404, headers: emptyHeaders } as Response),

--- a/frontend/packages/console-shared/src/utils/console-fetch.ts
+++ b/frontend/packages/console-shared/src/utils/console-fetch.ts
@@ -39,6 +39,8 @@ export const coFetch: ConsoleFetch = async (url, options = {}, timeout = 60000) 
       } catch (e) {
         if (e instanceof RetryError) {
           retry = true;
+        } else if (e instanceof DOMException && e.name === 'AbortError') {
+          throw e; // expected cancellation — don't warn
         } else {
           // eslint-disable-next-line no-console
           console.warn(`consoleFetch failed for url ${url}`, e);

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -166,8 +166,8 @@ const managedNamespacesColumnClass = css('pf-m-hidden', 'pf-m-visible-on-sm');
 const statusColumnClass = css('pf-m-hidden', 'pf-m-visible-on-lg');
 const lastUpdatedColumnClass = css('pf-m-hidden', 'pf-m-visible-on-2xl');
 const providedAPIsColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl');
-const clusterCompatibilityColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl');
-const supportPhaseColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl');
+const clusterCompatibilityColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl', 'pf-m-width-15');
+const supportPhaseColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl', 'pf-m-width-15');
 
 const SubscriptionStatus: FC<{ muted?: boolean; subscription: SubscriptionKind }> = ({
   muted = false,

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-lifecycle-status.tsx
@@ -244,33 +244,49 @@ const LifecycleDatesPopover: FC<{
   );
 };
 
+// Invisible spacer that reserves the same vertical space as a text line.
+// Every state of SupportPhaseBadge must render the same number of lines so
+// CellMeasurerCache never sees a height change when lifecycle data arrives,
+// which would cause the virtualized table to transiently mis-position rows.
+const DateLineSpacer: FC = () => (
+  <div aria-hidden="true" style={{ visibility: 'hidden' }}>
+    {' '}
+  </div>
+);
+
 export const SupportPhaseBadge: FC<{ phase: SupportPhaseResult }> = ({ phase }) => {
   const { t } = useTranslation('olm');
 
   if (phase.status === SupportPhaseStatus.SelfSupport && phase.allPhases) {
     return (
-      <LifecycleDatesPopover phases={phase.allPhases}>
-        <Button
-          variant="link"
-          type="button"
-          data-test="support-phase-self-support"
-          onClick={(e) => e.preventDefault()}
-          aria-haspopup="dialog"
-          isInline
-        >
-          <Label variant="outline" icon={<BlueInfoCircleIcon />} textMaxWidth="100%">
-            {t('Unsupported')}
-          </Label>
-        </Button>
-      </LifecycleDatesPopover>
+      <div>
+        <LifecycleDatesPopover phases={phase.allPhases}>
+          <Button
+            variant="link"
+            type="button"
+            data-test="support-phase-self-support"
+            onClick={(e) => e.preventDefault()}
+            aria-haspopup="dialog"
+            isInline
+          >
+            <Label variant="outline" icon={<BlueInfoCircleIcon />} textMaxWidth="100%">
+              {t('Unsupported')}
+            </Label>
+          </Button>
+        </LifecycleDatesPopover>
+        <DateLineSpacer />
+      </div>
     );
   }
 
   if (phase.status === SupportPhaseStatus.NoData) {
     return (
-      <span data-test="support-phase-no-data" aria-label={t('No data available')}>
-        -
-      </span>
+      <div>
+        <span data-test="support-phase-no-data" aria-label={t('No data available')}>
+          -
+        </span>
+        <DateLineSpacer />
+      </div>
     );
   }
 
@@ -298,8 +314,11 @@ export const SupportPhaseBadge: FC<{ phase: SupportPhaseResult }> = ({ phase }) 
   }
 
   return (
-    <span data-test="support-phase-no-data" aria-label={t('No data available')}>
-      -
-    </span>
+    <div>
+      <span data-test="support-phase-no-data" aria-label={t('No data available')}>
+        -
+      </span>
+      <DateLineSpacer />
+    </div>
   );
 };

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
@@ -6,7 +6,7 @@ jest.mock('@console/shared/src/utils/console-fetch', () => ({
   coFetchJSON: jest.fn(),
 }));
 
-const mockCoFetchJSON = coFetchJSON as jest.Mock;
+const mockCoFetchJSON = (coFetchJSON as unknown) as jest.Mock;
 
 // Each test uses a unique packageName to avoid sharing module-level cache entries.
 const CATALOG = 'redhat-operators';

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from '@testing-library/react';
+import { coFetchJSON } from '@console/shared/src/utils/console-fetch';
+import { useOperatorLifecycle } from '../useOperatorLifecycle';
+
+jest.mock('@console/shared/src/utils/console-fetch', () => ({
+  coFetchJSON: jest.fn(),
+}));
+
+const mockCoFetchJSON = coFetchJSON as jest.Mock;
+
+// Each test uses a unique packageName to avoid sharing module-level cache entries.
+const CATALOG = 'redhat-operators';
+const NS = 'openshift-marketplace';
+
+describe('useOperatorLifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns data when fetch succeeds', async () => {
+    const mockData = { lifecycleSchema: 'test', properties: '{}' };
+    mockCoFetchJSON.mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useOperatorLifecycle('pkg-success', CATALOG, NS));
+
+    expect(result.current[1]).toBe(true); // loading initially
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const [data, loading, error] = result.current;
+    expect(data).toEqual(mockData);
+    expect(loading).toBe(false);
+    expect(error).toBeNull();
+  });
+
+  it('does not surface AbortError as a real error', async () => {
+    // The bug: fetchLifecycleData re-throws AbortErrors after clearing the cache.
+    // The hook's .catch only checked !controller.signal.aborted — if the signal was
+    // never explicitly aborted (e.g., AbortError came from an old cached promise's
+    // signal), the error was incorrectly set in state.
+    //
+    // The fix: also guard on err.name !== 'AbortError' so abort-flavored errors
+    // are never surfaced regardless of which signal triggered them.
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    mockCoFetchJSON.mockRejectedValueOnce(abortError);
+
+    const { result } = renderHook(() => useOperatorLifecycle('pkg-abort', CATALOG, NS));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve(); // allow rejection microtask to settle
+    });
+
+    const [data, loading, error] = result.current;
+    expect(error).toBeNull(); // AbortError must not surface as a real error
+    expect(data).toBeNull();
+    expect(loading).toBe(false);
+  });
+
+  it('surfaces real network errors as errors', async () => {
+    const networkError = new Error('Network failure');
+    mockCoFetchJSON.mockRejectedValueOnce(networkError);
+
+    const { result } = renderHook(() => useOperatorLifecycle('pkg-network-error', CATALOG, NS));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const [data, loading, error] = result.current;
+    expect(error).toBe(networkError);
+    expect(data).toBeNull();
+    expect(loading).toBe(false);
+  });
+
+  it('skips fetch when packageName is missing', () => {
+    renderHook(() => useOperatorLifecycle(undefined, CATALOG, NS));
+
+    expect(mockCoFetchJSON).not.toHaveBeenCalled();
+    const [data, loading, error] = renderHook(() =>
+      useOperatorLifecycle(undefined, CATALOG, NS),
+    ).result.current;
+    expect(data).toBeNull();
+    expect(loading).toBe(false);
+    expect(error).toBeNull();
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
@@ -88,6 +88,52 @@ describe('useOperatorLifecycle', () => {
     expect(mockCoFetchJSON).toHaveBeenCalledTimes(1);
   });
 
+  it('does not apply stale result from superseded request when prop changes A→B and B resolves first', async () => {
+    const dataA = { lifecycleSchema: 'A', properties: '{}' };
+    const dataB = { lifecycleSchema: 'B', properties: '{}' };
+    let resolveA: (v: typeof dataA) => void;
+    let resolveB: (v: typeof dataB) => void;
+
+    mockCoFetchJSON.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveA = resolve;
+        }),
+    );
+    mockCoFetchJSON.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveB = resolve;
+        }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ pkg }: { pkg: string }) => useOperatorLifecycle(pkg, CATALOG, NS),
+      { initialProps: { pkg: 'pkg-stale-a' } },
+    );
+
+    // Switch to B while A is still in-flight; A's effect cleanup sets active=false
+    rerender({ pkg: 'pkg-stale-b' });
+
+    await act(async () => {
+      resolveB(dataB);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current[0]).toEqual(dataB);
+
+    await act(async () => {
+      resolveA(dataA); // arrives late — must be ignored
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current[0]).toEqual(dataB); // B must still be shown
+    expect(result.current[1]).toBe(false);
+    expect(result.current[2]).toBeNull();
+  });
+
   it('a component mounting after the cache is populated serves data immediately without fetching', async () => {
     const cachedData = { lifecycleSchema: 'cached', properties: '{}' };
     mockCoFetchJSON.mockResolvedValueOnce(cachedData);

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
@@ -76,6 +76,48 @@ describe('useOperatorLifecycle', () => {
     expect(loading).toBe(false);
   });
 
+  it('retries with a fresh request when the cached in-flight promise was aborted by another caller', async () => {
+    // Fix B scenario: two hook instances share the same cache key.
+    // Hook A starts the fetch (P1 enters cache). Hook B arrives and gets P1 from cache.
+    // Hook A is then aborted — P1 rejects with AbortError.
+    // Fix B detects that B's signal is still live and retries with B's signal.
+    const retryData = { lifecycleSchema: 'retry', properties: '{}' };
+    let rejectP1: (err: Error) => void;
+
+    // Hook A's fetch hangs until we manually reject it
+    mockCoFetchJSON.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectP1 = reject;
+        }),
+    );
+    // Hook B's retry fetch resolves immediately
+    mockCoFetchJSON.mockResolvedValueOnce(retryData);
+
+    const PKG = 'pkg-cached-shared';
+
+    // Hook A: effect runs → P1 created and stored in cache
+    const { unmount: unmountA } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+
+    // Hook B: same key → effect finds P1 in cache → Fix B wraps P1 with B's signal
+    const { result: resultB } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+
+    await act(async () => {
+      unmountA(); // aborts A's controller (signal_A); our mock doesn't react to signals
+      // Manually reject P1 to simulate what signal_A abort does to the real fetch
+      rejectP1(new DOMException('The operation was aborted.', 'AbortError'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve(); // allow retry to complete
+    });
+
+    const [data, loading, error] = resultB.current;
+    expect(error).toBeNull();
+    expect(data).toEqual(retryData); // retry produced real data
+    expect(loading).toBe(false);
+    expect(mockCoFetchJSON).toHaveBeenCalledTimes(2); // P1 (aborted) + P2 (retry)
+  });
+
   it('skips fetch when packageName is missing', () => {
     renderHook(() => useOperatorLifecycle(undefined, CATALOG, NS));
 

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
@@ -5,7 +5,6 @@ import { useOperatorLifecycle } from '../useOperatorLifecycle';
 jest.mock('@console/shared/src/utils/console-fetch', () => ({
   coFetchJSON: jest.fn(),
 }));
-
 const mockCoFetchJSON = (coFetchJSON as unknown) as jest.Mock;
 
 // Each test uses a unique packageName to avoid sharing module-level cache entries.
@@ -35,30 +34,6 @@ describe('useOperatorLifecycle', () => {
     expect(error).toBeNull();
   });
 
-  it('does not surface AbortError as a real error', async () => {
-    // The bug: fetchLifecycleData re-throws AbortErrors after clearing the cache.
-    // The hook's .catch only checked !controller.signal.aborted — if the signal was
-    // never explicitly aborted (e.g., AbortError came from an old cached promise's
-    // signal), the error was incorrectly set in state.
-    //
-    // The fix: also guard on err.name !== 'AbortError' so abort-flavored errors
-    // are never surfaced regardless of which signal triggered them.
-    const abortError = new DOMException('The operation was aborted.', 'AbortError');
-    mockCoFetchJSON.mockRejectedValueOnce(abortError);
-
-    const { result } = renderHook(() => useOperatorLifecycle('pkg-abort', CATALOG, NS));
-
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve(); // allow rejection microtask to settle
-    });
-
-    const [data, loading, error] = result.current;
-    expect(error).toBeNull(); // AbortError must not surface as a real error
-    expect(data).toBeNull();
-    expect(loading).toBe(false);
-  });
-
   it('surfaces real network errors as errors', async () => {
     const networkError = new Error('Network failure');
     mockCoFetchJSON.mockRejectedValueOnce(networkError);
@@ -76,91 +51,6 @@ describe('useOperatorLifecycle', () => {
     expect(loading).toBe(false);
   });
 
-  it('retries with a fresh request when the cached in-flight promise was aborted by another caller', async () => {
-    // Fix B scenario: two hook instances share the same cache key.
-    // Hook A starts the fetch (P1 enters cache). Hook B arrives and gets P1 from cache.
-    // Hook A is then aborted — P1 rejects with AbortError.
-    // Fix B detects that B's signal is still live and retries with B's signal.
-    const retryData = { lifecycleSchema: 'retry', properties: '{}' };
-    let rejectP1: (err: Error) => void;
-
-    // Hook A's fetch hangs until we manually reject it
-    mockCoFetchJSON.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectP1 = reject;
-        }),
-    );
-    // Hook B's retry fetch resolves immediately
-    mockCoFetchJSON.mockResolvedValueOnce(retryData);
-
-    const PKG = 'pkg-cached-shared';
-
-    // Hook A: effect runs → P1 created and stored in cache
-    const { unmount: unmountA } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
-
-    // Hook B: same key → effect finds P1 in cache → Fix B wraps P1 with B's signal
-    const { result: resultB } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
-
-    await act(async () => {
-      unmountA(); // aborts A's controller (signal_A); our mock doesn't react to signals
-      // Manually reject P1 to simulate what signal_A abort does to the real fetch
-      rejectP1(new DOMException('The operation was aborted.', 'AbortError'));
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve(); // allow retry to complete
-    });
-
-    const [data, loading, error] = resultB.current;
-    expect(error).toBeNull();
-    expect(data).toEqual(retryData); // retry produced real data
-    expect(loading).toBe(false);
-    expect(mockCoFetchJSON).toHaveBeenCalledTimes(2); // P1 (aborted) + P2 (retry)
-  });
-
-  it('issues only one retry when three callers share the same aborted cached promise', async () => {
-    // Regression for: multiple callers each unconditionally deleting the cache and
-    // starting their own retry, causing N redundant fetches.
-    // Only the first caller to detect the abort should start a retry; the others
-    // should reuse the retry promise already stored by the first.
-    const retryData = { lifecycleSchema: 'three-caller', properties: '{}' };
-    let rejectP1: (err: Error) => void;
-
-    // P1: hangs until manually rejected
-    mockCoFetchJSON.mockImplementationOnce(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectP1 = reject;
-        }),
-    );
-    // P2: the single retry (only one should be started)
-    mockCoFetchJSON.mockResolvedValueOnce(retryData);
-
-    const PKG = 'pkg-three-callers';
-
-    // Mount A, B, C — all share the same cache key; B and C get P1 from cache
-    const { unmount: unmountA } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
-    const { result: resultB } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
-    const { result: resultC } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
-
-    await act(async () => {
-      unmountA();
-      rejectP1(new DOMException('The operation was aborted.', 'AbortError'));
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // Both B and C should see the retry data — not an error, not null
-    expect(resultB.current[2]).toBeNull();
-    expect(resultB.current[0]).toEqual(retryData);
-    expect(resultC.current[2]).toBeNull();
-    expect(resultC.current[0]).toEqual(retryData);
-
-    // Only two coFetchJSON calls total: P1 (aborted) + P2 (single retry)
-    expect(mockCoFetchJSON).toHaveBeenCalledTimes(2);
-  });
-
   it('skips fetch when packageName is missing', () => {
     renderHook(() => useOperatorLifecycle(undefined, CATALOG, NS));
 
@@ -171,5 +61,54 @@ describe('useOperatorLifecycle', () => {
     expect(data).toBeNull();
     expect(loading).toBe(false);
     expect(error).toBeNull();
+  });
+
+  it('multiple callers sharing the same cache key all receive data from a single fetch', async () => {
+    // Core deduplication invariant: N components for the same operator should never
+    // issue more than one in-flight request.
+    const sharedData = { lifecycleSchema: 'shared', properties: '{}' };
+    mockCoFetchJSON.mockResolvedValueOnce(sharedData);
+
+    const PKG = 'pkg-shared-dedup';
+
+    // All three mount and subscribe to the same in-flight promise
+    const { result: resultA } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+    const { result: resultB } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+    const { result: resultC } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resultA.current[0]).toEqual(sharedData);
+    expect(resultB.current[0]).toEqual(sharedData);
+    expect(resultC.current[0]).toEqual(sharedData);
+    // Only one fetch regardless of how many components share the key
+    expect(mockCoFetchJSON).toHaveBeenCalledTimes(1);
+  });
+
+  it('a component mounting after the cache is populated serves data immediately without fetching', async () => {
+    const cachedData = { lifecycleSchema: 'cached', properties: '{}' };
+    mockCoFetchJSON.mockResolvedValueOnce(cachedData);
+
+    const PKG = 'pkg-cache-hit';
+
+    // First component populates the cache
+    const { result: result1 } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result1.current[0]).toEqual(cachedData);
+    expect(mockCoFetchJSON).toHaveBeenCalledTimes(1);
+
+    // Second component — cache hit, no new fetch
+    const { result: result2 } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+    expect(result2.current[0]).toEqual(cachedData);
+    expect(result2.current[1]).toBe(false); // not loading
+    expect(result2.current[2]).toBeNull();
+    expect(mockCoFetchJSON).toHaveBeenCalledTimes(1); // still just one fetch
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/__tests__/useOperatorLifecycle.spec.ts
@@ -118,6 +118,49 @@ describe('useOperatorLifecycle', () => {
     expect(mockCoFetchJSON).toHaveBeenCalledTimes(2); // P1 (aborted) + P2 (retry)
   });
 
+  it('issues only one retry when three callers share the same aborted cached promise', async () => {
+    // Regression for: multiple callers each unconditionally deleting the cache and
+    // starting their own retry, causing N redundant fetches.
+    // Only the first caller to detect the abort should start a retry; the others
+    // should reuse the retry promise already stored by the first.
+    const retryData = { lifecycleSchema: 'three-caller', properties: '{}' };
+    let rejectP1: (err: Error) => void;
+
+    // P1: hangs until manually rejected
+    mockCoFetchJSON.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectP1 = reject;
+        }),
+    );
+    // P2: the single retry (only one should be started)
+    mockCoFetchJSON.mockResolvedValueOnce(retryData);
+
+    const PKG = 'pkg-three-callers';
+
+    // Mount A, B, C — all share the same cache key; B and C get P1 from cache
+    const { unmount: unmountA } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+    const { result: resultB } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+    const { result: resultC } = renderHook(() => useOperatorLifecycle(PKG, CATALOG, NS));
+
+    await act(async () => {
+      unmountA();
+      rejectP1(new DOMException('The operation was aborted.', 'AbortError'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Both B and C should see the retry data — not an error, not null
+    expect(resultB.current[2]).toBeNull();
+    expect(resultB.current[0]).toEqual(retryData);
+    expect(resultC.current[2]).toBeNull();
+    expect(resultC.current[0]).toEqual(retryData);
+
+    // Only two coFetchJSON calls total: P1 (aborted) + P2 (single retry)
+    expect(mockCoFetchJSON).toHaveBeenCalledTimes(2);
+  });
+
   it('skips fetch when packageName is missing', () => {
     renderHook(() => useOperatorLifecycle(undefined, CATALOG, NS));
 

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
@@ -51,9 +51,16 @@ const fetchLifecycleData = (
     // The cached promise is tied to the ORIGINAL caller's signal, not ours.
     // If the original was aborted by someone else while our signal is still live,
     // issue a fresh retry rather than surfacing a spurious AbortError.
-    return existing.promise.catch((err: Error) => {
+    // Capture a reference so multiple concurrent callers agree on which promise
+    // they are watching: only the first one to run this .catch() will find the
+    // cache still pointing at existingPromise and start a single retry; all
+    // later callers will see a newer promise in the cache and reuse it.
+    const existingPromise = existing.promise;
+    return existingPromise.catch((err: Error) => {
       if (err.name === 'AbortError' && !signal.aborted) {
-        lifecycleCache.delete(cacheKey);
+        if (lifecycleCache.get(cacheKey)?.promise === existingPromise) {
+          lifecycleCache.delete(cacheKey);
+        }
         return fetchLifecycleData(cacheKey, url, signal);
       }
       throw err;

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
@@ -48,7 +48,16 @@ const fetchLifecycleData = (
 ): Promise<LifecycleData> => {
   const existing = lifecycleCache.get(cacheKey);
   if (existing?.promise) {
-    return existing.promise;
+    // The cached promise is tied to the ORIGINAL caller's signal, not ours.
+    // If the original was aborted by someone else while our signal is still live,
+    // issue a fresh retry rather than surfacing a spurious AbortError.
+    return existing.promise.catch((err: Error) => {
+      if (err.name === 'AbortError' && !signal.aborted) {
+        lifecycleCache.delete(cacheKey);
+        return fetchLifecycleData(cacheKey, url, signal);
+      }
+      throw err;
+    });
   }
 
   const promise = coFetchJSON(url, 'GET', { signal }).then(

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { coFetchJSON } from '@console/shared/src/utils/console-fetch';
 import type { LifecycleData } from '../components/operator-lifecycle-status';
 import { DEFAULT_SOURCE_NAMESPACE } from '../const';
@@ -41,62 +41,28 @@ const extractPackageName = (olmProperties: string): string | undefined => {
   }
 };
 
-const fetchLifecycleData = (
-  cacheKey: string,
-  url: string,
-  signal: AbortSignal,
-): Promise<LifecycleData> => {
+// Fetch lifecycle data and deduplicate concurrent requests via a module-level cache.
+// Requests are intentionally not cancelled on component unmount: the response
+// populates the cache so any later render of the same operator avoids a re-fetch,
+// and React silently ignores state updates after unmount.
+const fetchLifecycleData = (cacheKey: string, url: string): Promise<LifecycleData> => {
   const existing = lifecycleCache.get(cacheKey);
   if (existing?.promise) {
-    // The cached promise is tied to the ORIGINAL caller's signal, not ours.
-    // If the original was aborted by someone else while our signal is still live,
-    // issue a fresh retry rather than surfacing a spurious AbortError.
-    // Capture a reference so multiple concurrent callers agree on which promise
-    // they are watching: only the first one to run this .catch() will find the
-    // cache still pointing at existingPromise and start a single retry; all
-    // later callers will see a newer promise in the cache and reuse it.
-    const existingPromise = existing.promise;
-    return existingPromise.catch((err: Error) => {
-      if (err.name === 'AbortError' && !signal.aborted) {
-        if (lifecycleCache.get(cacheKey)?.promise === existingPromise) {
-          lifecycleCache.delete(cacheKey);
-        }
-        return fetchLifecycleData(cacheKey, url, signal);
-      }
-      throw err;
-    });
+    return existing.promise; // deduplicate: all callers share the one in-flight request
   }
 
-  const promise = coFetchJSON(url, 'GET', { signal }).then(
+  const promise = coFetchJSON(url, 'GET', {}).then(
     (result: LifecycleData) => {
-      lifecycleCache.set(cacheKey, {
-        data: result,
-        error: null,
-        timestamp: Date.now(),
-      });
+      lifecycleCache.set(cacheKey, { data: result, error: null, timestamp: Date.now() });
       return result;
     },
     (err: Error) => {
-      if (err.name === 'AbortError') {
-        lifecycleCache.delete(cacheKey);
-      } else {
-        lifecycleCache.set(cacheKey, {
-          data: null,
-          error: err,
-          timestamp: Date.now(),
-        });
-      }
+      lifecycleCache.set(cacheKey, { data: null, error: err, timestamp: Date.now() });
       throw err;
     },
   );
 
-  lifecycleCache.set(cacheKey, {
-    data: null,
-    error: null,
-    timestamp: Date.now(),
-    promise,
-  });
-
+  lifecycleCache.set(cacheKey, { data: null, error: null, timestamp: Date.now(), promise });
   return promise;
 };
 
@@ -108,7 +74,6 @@ export const useOperatorLifecycle = (
   const [data, setData] = useState<LifecycleData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const abortRef = useRef<AbortController>();
 
   useEffect(() => {
     if (!packageName || !catalogName || !catalogNamespace) {
@@ -126,37 +91,25 @@ export const useOperatorLifecycle = (
       return undefined;
     }
 
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
     setLoading(true);
 
     const url = `/api/olm/lifecycle/${encodeURIComponent(catalogNamespace)}/${encodeURIComponent(
       catalogName,
     )}/${encodeURIComponent(packageName)}`;
 
-    fetchLifecycleData(cacheKey, url, controller.signal)
+    fetchLifecycleData(cacheKey, url)
       .then((result) => {
-        if (!controller.signal.aborted) {
-          setData(result);
-          setError(null);
-          setLoading(false);
-        }
+        setData(result);
+        setError(null);
+        setLoading(false);
       })
       .catch((err: Error) => {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-          if (err.name !== 'AbortError') {
-            setData(null);
-            setError(err);
-          }
-        }
+        setData(null);
+        setError(err);
+        setLoading(false);
       });
 
-    return () => {
-      controller.abort();
-    };
+    return undefined; // no cleanup: requests complete naturally
   }, [packageName, catalogName, catalogNamespace]);
 
   return [data, loading, error];

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
@@ -130,9 +130,11 @@ export const useOperatorLifecycle = (
       })
       .catch((err: Error) => {
         if (!controller.signal.aborted) {
-          setData(null);
-          setError(err);
           setLoading(false);
+          if (err.name !== 'AbortError') {
+            setData(null);
+            setError(err);
+          }
         }
       });
 

--- a/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/hooks/useOperatorLifecycle.ts
@@ -91,6 +91,7 @@ export const useOperatorLifecycle = (
       return undefined;
     }
 
+    let active = true;
     setLoading(true);
 
     const url = `/api/olm/lifecycle/${encodeURIComponent(catalogNamespace)}/${encodeURIComponent(
@@ -99,17 +100,23 @@ export const useOperatorLifecycle = (
 
     fetchLifecycleData(cacheKey, url)
       .then((result) => {
-        setData(result);
-        setError(null);
-        setLoading(false);
+        if (active) {
+          setData(result);
+          setError(null);
+          setLoading(false);
+        }
       })
       .catch((err: Error) => {
-        setData(null);
-        setError(err);
-        setLoading(false);
+        if (active) {
+          setData(null);
+          setError(err);
+          setLoading(false);
+        }
       });
 
-    return undefined; // no cleanup: requests complete naturally
+    return () => {
+      active = false;
+    };
   }, [packageName, catalogName, catalogNamespace]);
 
   return [data, loading, error];


### PR DESCRIPTION
**Analysis / Root cause**:

**Part 1 — Console noise and AbortError propagation**

When \`useOperatorLifecycle\` re-runs (e.g. subscription loads after CSV, or
multiple components share the same cache key), \`fetchLifecycleData\` returns the
cached in-flight promise tied to the previous caller's AbortController signal.
When that old signal is aborted, the AbortError propagates to the new caller
whose signal is still live — three problems result:

1. \`coFetch\` calls \`console.warn\` for every abort, flooding Firefox devtools
   with \`NS_BINDING_ABORTED\` noise on the Installed Operators page.
2. The hook's \`.catch\` only checked \`!controller.signal.aborted\` (the new
   controller), not whether the error was an AbortError, so it incorrectly
   surfaced the error in UI state.
3. When a cached promise was aborted by another caller, the waiting component
   stalled in an empty non-loading state instead of retrying.

The root fix is to drop AbortController entirely from \`useOperatorLifecycle\`:
requests complete naturally, React silently discards state updates after unmount,
and the cache gives instant hits on re-mount.

**Part 2 — Virtualized table row overlap**

With reliable lifecycle data loading (no aborts), rows whose \`SupportPhaseBadge\`
shows the Active state (badge + end date = ~52 px, two lines) are taller than
rows still showing NoData/SelfSupport (~20–28 px, one line). The Installed
Operators table uses \`VirtualizedTableBody\` backed by \`react-virtualized\`'s
\`CellMeasurerCache\`. When lifecycle data arrives asynchronously after the row's
initial measurement, \`CellMeasurer\` detects the height change, invalidates its
cache entry, and calls \`recomputeGridSize()\`. In the one render frame before
\`VirtualTableBody\` repositions all subsequent rows, those rows still sit at
their stale Y coordinates, causing visible content overlap (e.g. the Serverless
row's Provided APIs column appearing inside the Package Server row's space).

**Part 3 — Stale effect callbacks clobbering state after prop change**

\`useOperatorLifecycle\` fire-and-forgot the \`fetchLifecycleData\` promise with
no active guard. If the component re-rendered with a new operator (packageName
changed A→B), operator A's in-flight \`.then\`/\`.catch\` callbacks still held a
live \`setState\` reference and could overwrite B's already-landed data with stale
results. The "React ignores updates after unmount" reasoning only covers a fully
unmounted component; a prop change keeps the same instance alive.

**Solution description**:

- **\`console-fetch.ts\`**: Don't \`console.warn\` for \`DOMException\` AbortErrors —
  they are expected cancellations, not failures.
- **\`useOperatorLifecycle.ts\`**: Remove \`AbortController\`, \`abortRef\`, and all
  signal-passing code. Simplify \`fetchLifecycleData\` to just deduplicate
  concurrent requests via the module-level cache. Requests complete naturally;
  React silently drops state updates after unmount; the next render gets a cache
  hit. Guard the effect's \`.then\`/\`.catch\` callbacks with \`let active = true\` and
  return a cleanup that sets \`active = false\`, so superseded requests (prop change
  A→B) cannot overwrite current state. The underlying fetch and cache population
  are preserved; only state updates are suppressed.
- **\`clusterserviceversion.tsx\`**: Add \`pf-m-width-15\` to the Cluster
  Compatibility and Support Phase column headers so badge content does not
  overflow horizontally into the Provided APIs column (\`table-layout: fixed\`).
- **\`operator-lifecycle-status.tsx\`**: Introduce \`DateLineSpacer\` — an
  \`aria-hidden\`, \`visibility:hidden\` div. Every branch of \`SupportPhaseBadge\`
  (Active, SelfSupport, NoData, fallback) now renders the same two-line
  structure (badge/status line + date/spacer line), so \`CellMeasurerCache\`
  never observes a height change when lifecycle data loads and the virtualizer
  never repositions rows.

**Screenshots / screen recording**:

<!-- Please add a screenshot or recording showing the Installed Operators table renders without row overlap after this fix -->

**Test setup:**
Tested locally against a cluster-bot cluster with \`--tech-preview=true --olm-lifecycle-metadata=true\`.

**Test cases:**
- \`coFetch\` does not \`console.warn\` when fetch is aborted via AbortController
- \`coFetch\` does \`console.warn\` for real network errors
- \`useOperatorLifecycle\` deduplicates concurrent requests (single fetch for N callers)
- \`useOperatorLifecycle\` serves cached data immediately without re-fetching
- \`useOperatorLifecycle\` does not apply stale A result when prop changes A→B and B resolves first
- \`useOperatorLifecycle\` surfaces real network errors correctly
- \`useOperatorLifecycle\` skips fetch when parameters are missing
- \`SupportPhaseBadge\` renders phase name and end date in Active state
- \`SupportPhaseBadge\` renders Unsupported label in SelfSupport state
- \`SupportPhaseBadge\` renders dash with aria-label in NoData state

**Browser conformance**: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request cancellation handling so aborted requests no longer trigger unnecessary warnings.
  * Prevented outdated lifecycle data from replacing newer results during navigation or updates.
  * Improved lifecycle data caching and sharing across multiple views.

* **UI Improvements**
  * Stabilized lifecycle status table row heights while data loads.
  * Adjusted cluster compatibility and support phase column widths for improved layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->