### PR TITLE
OCPBUGS-99052: recover from reverse proxy panic on browser disconnect

### DIFF
--- a/pkg/server/api_discovery.go
+++ b/pkg/server/api_discovery.go
@@ -102,7 +102,7 @@ func apiDiscoveryHandler(k8sProxy *proxy.Proxy) http.HandlerFunc {
 }
 
 // k8sViaProxy makes an in-process GET request through the k8s proxy.
-func k8sViaProxy(k8sProxy *proxy.Proxy, path string, originalReq *http.Request) ([]byte, error) {
+func k8sViaProxy(handler http.Handler, path string, originalReq *http.Request) (body []byte, err error) {
 	req, err := http.NewRequestWithContext(originalReq.Context(), "GET", path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %s", path)
@@ -111,7 +111,18 @@ func k8sViaProxy(k8sProxy *proxy.Proxy, path string, originalReq *http.Request) 
 	req.Header = originalReq.Header.Clone()
 
 	rec := httptest.NewRecorder()
-	k8sProxy.ServeHTTP(rec, req)
+
+	defer func() {
+		if p := recover(); p != nil {
+			if p == http.ErrAbortHandler {
+				err = fmt.Errorf("request aborted for %s", path)
+			} else {
+				panic(p)
+			}
+		}
+	}()
+
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status %d for %s", rec.Code, path)

--- a/pkg/server/api_discovery_test.go
+++ b/pkg/server/api_discovery_test.go
@@ -313,6 +313,44 @@ func TestApiDiscoveryHandler_AllResourceListsFail(t *testing.T) {
 	}
 }
 
+func TestK8sViaProxy_RecoversAbortPanic(t *testing.T) {
+	t.Run("ErrAbortHandler is recovered", func(t *testing.T) {
+		panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic(http.ErrAbortHandler)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/apis/test/v1", nil)
+		_, err := k8sViaProxy(panicHandler, "/apis/test/v1", req)
+
+		if err == nil {
+			t.Fatal("expected error from aborted request, got nil")
+		}
+		if !strings.Contains(err.Error(), "request aborted") {
+			t.Errorf("expected 'request aborted' error, got: %v", err)
+		}
+	})
+
+	t.Run("unexpected panic is not swallowed", func(t *testing.T) {
+		sentinel := "unexpected failure"
+		panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic(sentinel)
+		})
+
+		defer func() {
+			p := recover()
+			if p == nil {
+				t.Fatal("expected panic to propagate, but it was swallowed")
+			}
+			if p != sentinel {
+				t.Fatalf("expected panic value %q, got %v", sentinel, p)
+			}
+		}()
+
+		req := httptest.NewRequest(http.MethodGet, "/apis/test/v1", nil)
+		k8sViaProxy(panicHandler, "/apis/test/v1", req)
+	})
+}
+
 func TestApiDiscoveryHandler_PartialFailure(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
**Analysis / Root cause**:

The API discovery endpoint (`/api/api-discovery`) uses `httptest.NewRecorder` to make in-process requests through the k8s reverse proxy. When a browser disconnects mid-request (e.g. page refresh or navigation), httputil.ReverseProxy` panics with `http.ErrAbortHandler` during response body copy. Unlike a real HTTP server, the recorder has no server to catch this panic, crashing the goroutine.

Reproducible by rapidly refreshing the browser directly on the api-discovery backend route on HTTP/1.1.

**Solution description**:

Add a `defer/recover` in `k8sViaProxy` that catches `http.ErrAbortHandler` specifically and converts it to an error return. Unexpected panics are re-raised. The first parameter type is widened from `*proxy.Proxy` to `http.Handler` to allow injecting a mock handler in tests.

**Screenshots / screen recording**:

N/A — backend-only fix, no UI changes.

**Test setup:**

No special setup required. Run `go test ./pkg/server/ -run TestK8sViaProxy -v`.

**Test cases:**

- `TestK8sViaProxy_RecoversAbortPanic`: Injects an `http.HandlerFunc` that panics with   `http.ErrAbortHandler` (reproducing what `httputil.ReverseProxy` does on a broken connection) and verifies `k8sViaProxy` returns an error instead of panicking. Deterministically fails without the fix (`panic: net/http: abort Handler`).

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

Stack trace from the crash:
```
goroutine 2879 [running]:
net/http/httputil.(*ReverseProxy).ServeHTTP(...)
  reverseproxy.go:613
github.com/openshift/console/pkg/proxy.(*Proxy).ServeHTTP(...)
  pkg/proxy/proxy.go:151
github.com/openshift/console/pkg/server.k8sViaProxy(...)
  pkg/server/api_discovery.go:114
```

Depends on [CONSOLE-5426](https://redhat.atlassian.net/browse/CONSOLE-5426) (#16769).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of aborted Kubernetes API proxy requests by returning a clear error instead of terminating unexpectedly.
  * Preserved propagation of unexpected server errors for appropriate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->