### PR TITLE
NO-ISSUE: Run full e2e suite in TechPreview CI via script symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ cypress-a11y-report.json
 **/chartstore-*/
 .artifacts/
 .playwright-mcp/
+.worktrees/

--- a/test-prow-e2e-techpreview.sh
+++ b/test-prow-e2e-techpreview.sh
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-set -exuo pipefail
+test-prow-e2e.sh

--- a/test-prow-playwright-e2e-techpreview.sh
+++ b/test-prow-playwright-e2e-techpreview.sh
@@ -1,3 +1,1 @@
-#!/usr/bin/env bash
-
-set -exuo pipefail
+test-prow-playwright-e2e.sh


### PR DESCRIPTION
**Analysis / Root cause**:
The TechPreview CI scripts (test-prow-e2e-techpreview.sh and
test-prow-playwright-e2e-techpreview.sh) are currently stubs that run nothing.

**Solution description**:
Replace both stub scripts with symlinks to their base equivalents
(test-prow-e2e.sh and test-prow-playwright-e2e.sh) so TechPreview CI runs
the full e2e suite. Individual tests that are incompatible with TechPreview
clusters will be adjusted or skipped directly in the test code as a follow-up.

**Screenshots / screen recording**:
N/A — CI script change only.

**Test setup:**
N/A

**Test cases:**
- TechPreview CI jobs should now execute the full Cypress and Playwright suites
  rather than exiting immediately.

**Browser conformance**:
N/A — no UI changes.

**Additional info:**
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository exclusions to omit local worktree directories.
  * Removed obsolete end-to-end test script entrypoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->