### PR TITLE
OCPBUGS-98159: Fix leading whitespace in Quick Start {{execute}} code snippets

### DIFF
--- a/frontend/packages/console-shared/src/components/markdown-extensions/__tests__/execute-extensions.spec.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/__tests__/execute-extensions.spec.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { useCloudShellAvailable } from '@console/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable';
+import { useInlineExecuteCommandExtension } from '../inline-execute-extension';
+import { useMultilineExecuteCommandExtension } from '../multiline-execute-extension';
+
+jest.mock('@console/webterminal-plugin/src/components/cloud-shell/useCloudShellAvailable', () => ({
+  useCloudShellAvailable: jest.fn(),
+}));
+
+const mockUseCloudShellAvailable = useCloudShellAvailable as jest.Mock;
+
+describe('execute markdown extensions', () => {
+  beforeEach(() => {
+    mockUseCloudShellAvailable.mockReturnValue(true);
+  });
+
+  // Regression test for OCPBUGS-98159: whitespace/newlines between the
+  // <pre> and <code> tags render as a visible leading blank line/indentation
+  // in the browser since <pre> preserves whitespace literally.
+  it('multiline extension renders <pre><code> adjacent with no whitespace between the tags', () => {
+    const { result } = renderHook(() => useMultilineExecuteCommandExtension());
+    const html = result.current.replace(
+      '```\noc get pods\n```{{execute}}',
+      'oc get pods\n',
+      'oc get pods\n',
+      'lang',
+      'snippet-1',
+    );
+
+    expect(html).toMatch(/<pre[^>]*><code[^>]*>oc get pods<\/code><\/pre>/);
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const codeEl = container.querySelector('code');
+    expect(codeEl.previousSibling).toBeNull();
+    expect(codeEl.textContent).toBe('oc get pods');
+  });
+
+  it('inline extension renders <pre><code> adjacent with no whitespace between the tags', () => {
+    const { result } = renderHook(() => useInlineExecuteCommandExtension());
+    const html = result.current.replace(
+      '`oc get pods`{{execute}}',
+      'oc get pods',
+      'oc get pods',
+      'lang',
+      'snippet-2',
+    );
+
+    expect(html).toMatch(/<pre[^>]*><code[^>]*>oc get pods<\/code><\/pre>/);
+
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const codeEl = container.querySelector('code');
+    expect(codeEl.previousSibling).toBeNull();
+    expect(codeEl.textContent).toBe('oc get pods');
+  });
+});

--- a/frontend/packages/console-shared/src/components/markdown-extensions/inline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/inline-execute-extension.ts
@@ -50,9 +50,7 @@ export const useInlineExecuteCommandExtension = () => {
           </div>
         </div>
         <div class="pf-v6-c-code-block__content">
-          <pre class="pf-v6-c-code-block__pre pfext-code-block__pre">
-            <code class="pf-v6-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupType}">${group.trim()}</code>
-          </pre>
+          <pre class="pf-v6-c-code-block__pre pfext-code-block__pre"><code class="pf-v6-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupType}">${group.trim()}</code></pre>
         </div>
       </div>`;
       },

--- a/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
@@ -51,10 +51,7 @@ export const useMultilineExecuteCommandExtension = () => {
                 </div>
               </div>
               <div class="pf-v6-c-code-block__content">
-                <pre class="pf-v6-c-code-block__pre pfext-code-block__pre">
-                  <code class="pf-v6-c-code-block__code"
-                    ${MARKDOWN_SNIPPET_ID}="${groupId}">${group.trim()}</code>
-                </pre>
+                <pre class="pf-v6-c-code-block__pre pfext-code-block__pre"><code class="pf-v6-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupId}">${group.trim()}</code></pre>
               </div>
             </div>`;
       },


### PR DESCRIPTION
**Analysis / Root cause**:
The `{{execute}}` markdown extensions (`multiline-execute-extension.ts` and `inline-execute-extension.ts`) generate a PatternFly `CodeBlock` HTML string for Quick Start code snippets. The `<pre>` and `<code>` tags in that generated markup were on separate lines with indentation between them. Since `<pre>` uses `white-space: pre-wrap` (PatternFly's own `code-block.css` rule, which preserves whitespace literally like `white-space: pre`), the newline and indentation between `<pre>` and `<code>` rendered as a visible leading blank line and leading spaces in the snippet, even though the snippet text itself (`group.trim()`) was already trimmed. This reproduces on any Quick Start with an `{{execute}}` code snippet (e.g. "Enable Developer Perspective"), on fresh 4.19/4.21 installs and after upgrades.

PatternFly's own `{{copy}}` extension avoids this by keeping `<pre><code>...</code></pre>` adjacent on one line, which this fix now mirrors.

**Solution description**:
- Removed the whitespace/newline between the `<pre>` and `<code>` opening tags (and their closing tags) in both `multiline-execute-extension.ts` and `inline-execute-extension.ts`, so the tags are directly adjacent in the generated HTML.
- Added regression tests (`execute-extensions.spec.ts`) asserting the generated HTML for both extensions has `<pre>`/`<code>` adjacent with no interstitial whitespace text node, and that the rendered `<code>` element's text content has no leading whitespace.
- No behavior change to copy-to-clipboard or "Run in Web Terminal": both already read `innerText` from the `<code data-snippet-id>` element directly, so they were unaffected by this purely visual bug.

**Screenshots / screen recording**:

Verified using the **real** `{{execute}}` snippet from the `enable-developer-perspective` ConsoleQuickStart on a live OCP 4.21.17 test cluster (the same Quick Start named in the bug's repro steps), rendered against the actual PatternFly 6.6.0 `CodeBlock` CSS:

| Before fix | After fix |
|---|---|
| ![before](https://raw.githubusercontent.com/dtambat/console/verification-assets/OCPBUGS-98159/docs-assets/real-before.png) | ![after](https://raw.githubusercontent.com/dtambat/console/verification-assets/OCPBUGS-98159/docs-assets/real-after.png) |

`code.innerText` (what Copy to clipboard / Run in Web Terminal actually read) is identical before and after, confirming those behaviors are unaffected by this purely visual fix:

| Before fix | After fix |
|---|---|
| ![before-innertext](https://raw.githubusercontent.com/dtambat/console/verification-assets/OCPBUGS-98159/docs-assets/before-innertext.png) | ![after-innertext](https://raw.githubusercontent.com/dtambat/console/verification-assets/OCPBUGS-98159/docs-assets/after-innertext.png) |

**Test setup:**
Open the Quick Starts catalog (Help icon (?) → Quick Starts) and select any Quick Start containing an `{{execute}}` code snippet, e.g. "Enable Developer Perspective".

**Test cases:**
- [x] Open a Quick Start with an `{{execute}}` code snippet (inline and/or multiline) and confirm there is no leading blank line or leading spaces before the snippet text. *(Verified above using real cluster content, pre/post fix comparison.)*
- [x] Confirm "Copy to clipboard" still copies the exact snippet text (no leading/trailing whitespace). *(Verified: `code.innerText` identical before/after fix.)*
- [x] Confirm "Run in Web Terminal" (when Web Terminal is available) still executes the correct command. *(Verified: same `innerText` value used by both features.)*

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

*(Verification above used headless Chrome against real cluster content; full manual QA in each browser against a running Console build is still recommended before merge.)*

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-98159

**Reviewers and assignees:**
<!-- To be filled in by reviewer/assignee -->