### PR TITLE
[release-4.13] OCPBUGS-88410 OCPBUGS-88442: CVE-2026-44486 openshift4/ose-console: Axios: Information disclosure of proxy credentials via HTTP redirects

### DIFF
--- a/frontend/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch
+++ b/frontend/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch
@@ -1,15 +1,14 @@
 diff --git a/index.d.ts b/index.d.ts
-index 34bc02adf15581be666543f0d77fa845c04d25f9..5e7fb8eb8dcb902fd554428cd6aa533e5dc57db7 100644
+index ac6b9f5f95d258493e5ce026386be0ab88e423c0..a26edf516e8e6f02deff1585eb73b551c7e95cad 100644
 --- a/index.d.ts
 +++ b/index.d.ts
-@@ -3,8 +3,12 @@ type HeaderValue = string | string[] | number | boolean;
+@@ -3,8 +3,11 @@ type HeaderValue = string | string[] | number | boolean;
  
  type AxiosHeaders = Record<string, HeaderValue | Record<Method & CommonHeaders, HeaderValue>>;
  
 +type LowercaseMethod =
 +  | 'get' | 'delete' | 'head' | 'options' | 'post'
 +  | 'put' | 'patch' | 'purge' | 'link' | 'unlink';
-+
  type MethodsHeaders = {
 -  [Key in Method as Lowercase<Key>]: AxiosHeaders;
 +  [Key in LowercaseMethod]?: AxiosHeaders;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch",
+    "axios": "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
@@ -355,7 +355,7 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "axios@npm:^0.21.1": "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch",
+    "axios@npm:^0.21.1": "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch",
     "immutable": "3.8.3"
   },
   "husky": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7083,25 +7083,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.31.1":
-  version: 0.31.1
-  resolution: "axios@npm:0.31.1"
+"axios@npm:0.33.0":
+  version: 0.33.0
+  resolution: "axios@npm:0.33.0"
   dependencies:
     follow-redirects: "npm:^1.15.4"
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/0193483f680a893955d203d26951fc427c407415d273bba5a2450e3d0ed7261a403eb5fe86f28a7e66c42d98597cbf8e17e3a6c324d294bd143a6a68bc10f8ef
+  checksum: 10c0/9e8ae9d26768a9884c121c33286f6b85fe915cf1bb1c0ac7adff2def81e18b4b7c5bb9630dec3900ec88c037822d602439f2bff23d15c41c2216b89b27fbe524
   languageName: node
   linkType: hard
 
-"axios@patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch":
-  version: 0.31.1
-  resolution: "axios@patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch::version=0.31.1&hash=21a978"
+"axios@patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch":
+  version: 0.33.0
+  resolution: "axios@patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch::version=0.33.0&hash=83fa2f"
   dependencies:
     follow-redirects: "npm:^1.15.4"
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/b148742c668c3cbc44c7a65e6aa5214efac23bff529f2f54d4c6c4fa917ea2fbed37ed915165fa3e1d011d94ebe6c1b7263610c28bb1af0de51ce8ad5188dd61
+  checksum: 10c0/73acccbe5896c85fb7aeee2d714e9f54e283f4797c3dac588a7503a00cdeb86b9edc6784b7803cb0269859683dff1ac242cce3a88e15ce995b729d306bbc5e00
   languageName: node
   linkType: hard
 
@@ -20559,7 +20559,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "patch:axios@npm%3A0.31.1#~/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch"
+    axios: "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"


### PR DESCRIPTION
OCPBUGS-88410 requires an Axios bump to >= 0.32.0 
Previously, a bump of Axios to 0.31.1 had been done using  that patch is not sufficient 

Therefore, the patch has been updated as below using information from Claude.

NB: Note that the best way to view the new patch is to view the file in its entirety:
https://github.com/rhdmalone/console/blob/831fbc5425326b2dfa7e8c37ee30701744bc6279/frontend/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch

On release-4.13 you still need the TypeScript patch: the branch uses TypeScript 3.8.3, and axios 0.33.0 still uses Lowercase<> / key remapping (as) in MethodsHeaders, which need TS 4.1+. So bump the package and re-create the Yarn patch against 0.33.0.

Recommended (Yarn 4) flow
From frontend/:

1. Point deps at unpatched 0.33.0 temporarily

In frontend/package.json:

Dependency:
"axios": "0.33.0"
Resolution (replace the patched 0.31.1 line):
"axios@npm:^0.21.1": "0.33.0"

2. Install and create a patch workspace:
cd frontend
yarn install
yarn patch axios@npm:0.33.0
Yarn prints a temp folder path.

3. Apply the same TypeScript fix in that folder’s index.d.ts

Replace:

type MethodsHeaders = {
  [Key in Method as Lowercase<Key>]: AxiosHeaders;
};
with (same as your current patch):

type LowercaseMethod =
  | 'get' | 'delete' | 'head' | 'options' | 'post'
  | 'put' | 'patch' | 'purge' | 'link' | 'unlink';
type MethodsHeaders = {
  [Key in LowercaseMethod]?: AxiosHeaders;
};
4. Commit the patch

yarn patch-commit -s <path-yarn-printed>
That writes a new file under frontend/.yarn/patches/ (e.g. axios-npm-0.33.0-….patch) and updates package.json to use patch:axios@npm%3A0.33.0#~/.yarn/patches/....

5. Align the resolution with the new patch

Set:

"axios@npm:^0.21.1": "patch:axios@npm%3A0.33.0#~/.yarn/patches/<new-patch-file>"
(use the exact string Yarn put on the "axios" dependency)

Then:

yarn install
6. Cleanup

Remove the old patch:
frontend/.yarn/patches/axios-npm-0.31.1-0574a0de7d.patch
Confirm yarn.lock shows axios@patch:…0.33.0… and version 0.33.0
Spot-check TypeScript/build (yarn lint/tsc or your usual console build)
What not to do
Don’t only edit package.json to 0.33.0 without regenerating the patch: the old 0.31.1 patch path won’t apply cleanly, and unpatched 0.33.0 will break under TS 3.8.3.
