### PR TITLE
CONSOLE-5196: Fix Playwright CI timeout with globalTimeout and parallel workers

### DIFF
--- a/frontend/e2e/pages/yaml-editor-page.ts
+++ b/frontend/e2e/pages/yaml-editor-page.ts
@@ -17,7 +17,9 @@ export class YamlEditorPage extends BasePage {
   }
 
   async waitForEditorReady(): Promise<void> {
-    await expect(this.codeEditor).toBeVisible({ timeout: 30_000 });
+    const mounting = this.page.getByTestId('code-editor-mounting');
+    await expect(mounting.or(this.codeEditor)).toBeVisible({ timeout: 60_000 });
+    await expect(this.codeEditor).toBeVisible({ timeout: 60_000 });
   }
 
   async waitForSidebarLoaded(): Promise<void> {

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -19,21 +19,24 @@ const PLUGIN_MANIFEST_DEFAULT = { name: PLUGIN_NAME, version: '0.0.0' };
 const PLUGIN_MANIFEST_DEFAULT2 = { name: PLUGIN_NAME2, version: '0.0.0' };
 const PLUGIN_MANIFEST_NEW_VERSION = { name: PLUGIN_NAME, version: '1.0.0' };
 
-// Wait for the route mock to serve two check-updates responses. The component uses
-// a prev/current ref pattern and needs two poll cycles before it can detect changes.
-async function waitForBaseline(page: import('@playwright/test').Page): Promise<void> {
+// The component uses a prev/current ref pattern that needs two poll cycles to
+// initialize before it can detect changes. Start listening for two mocked
+// check-updates responses BEFORE navigating to avoid race conditions.
+function waitForBaseline(page: import('@playwright/test').Page): Promise<void> {
   let count = 0;
-  await new Promise<void>((resolve) => {
-    page.on('response', (resp) => {
-      if (
-        resp.url().includes('/api/check-updates') &&
-        resp.status() === 200 &&
-        resp.headers()['x-mock'] === '1'
-      ) {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('waitForBaseline timed out')), 90_000);
+    const handler = (resp: import('@playwright/test').Response) => {
+      if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
         count++;
-        if (count >= 2) resolve();
+        if (count >= 2) {
+          clearTimeout(timer);
+          page.off('response', handler);
+          resolve();
+        }
       }
-    });
+    };
+    page.on('response', handler);
   });
 }
 
@@ -42,7 +45,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     let payload = UPDATES_DEFAULT;
 
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: payload, headers: { 'x-mock': '1' } }),
+      route.fulfill({ json: payload }),
     );
 
     const baseline = waitForBaseline(page);
@@ -59,7 +62,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     let manifestAbort = true;
 
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: updatesPayload, headers: { 'x-mock': '1' } }),
+      route.fulfill({ json: updatesPayload }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
       if (manifestAbort) {
@@ -91,7 +94,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     let manifest2Abort = true;
 
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: updatesPayload, headers: { 'x-mock': '1' } }),
+      route.fulfill({ json: updatesPayload }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
       if (manifest1Abort) {
@@ -131,7 +134,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     let updatesPayload = UPDATES_NEW_PLUGIN;
 
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: updatesPayload, headers: { 'x-mock': '1' } }),
+      route.fulfill({ json: updatesPayload }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) =>
       route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
@@ -149,7 +152,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when a plugin version changes', async ({ page }) => {
     let serveNewVersion = false;
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN, headers: { 'x-mock': '1' } }),
+      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
       if (serveNewVersion) {

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -158,7 +158,10 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
       }
       return route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION });
     });
+
+    const baseline = waitForBaseline(page);
     await page.goto('/');
+    await baseline;
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -80,7 +80,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
 
     manifestAbort = false;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
 
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
@@ -124,7 +124,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
 
     manifest2Abort = false;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
 
   test('triggers the console update toast when a plugin is removed', async ({ page }) => {
@@ -147,22 +147,23 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   });
 
   test('triggers the console update toast when a plugin version changes', async ({ page }) => {
-    let manifestFetchCount = 0;
+    let serveNewVersion = false;
     await page.route(CHECK_UPDATES_URL, (route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN, headers: { 'x-mock': '1' } }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
-      manifestFetchCount++;
-      if (manifestFetchCount <= 2) {
-        return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
+      if (serveNewVersion) {
+        return route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION });
       }
-      return route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION });
+      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
     });
 
     const baseline = waitForBaseline(page);
     await page.goto('/');
     await baseline;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
+    serveNewVersion = true;
+
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
 });

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -19,52 +19,73 @@ const PLUGIN_MANIFEST_DEFAULT = { name: PLUGIN_NAME, version: '0.0.0' };
 const PLUGIN_MANIFEST_DEFAULT2 = { name: PLUGIN_NAME2, version: '0.0.0' };
 const PLUGIN_MANIFEST_NEW_VERSION = { name: PLUGIN_NAME, version: '1.0.0' };
 
+// The component needs two poll cycles to initialize its prev/current refs before
+// it can detect changes. Tests wait for two check-updates responses (baselineReady)
+// before switching the mocked payload.
 test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when consoleCommit changes', async ({ page }) => {
-    let resolveFirst: () => void;
-    const firstIntercepted = new Promise<void>((r) => {
-      resolveFirst = r;
+    let payload = UPDATES_DEFAULT;
+
+    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: payload }));
+
+    // Start listening for responses BEFORE navigating so we don't miss the first poll.
+    let responseCount = 0;
+    const baselineReady = new Promise<void>((resolve) => {
+      page.on('response', (resp) => {
+        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
+          responseCount++;
+          if (responseCount >= 2) {
+            resolve();
+          }
+        }
+      });
     });
 
-    await page.route(CHECK_UPDATES_URL, async (route) => {
-      await route.fulfill({ json: UPDATES_DEFAULT });
-      resolveFirst();
-    });
     await page.goto('/');
-    await firstIntercepted;
+    await baselineReady;
 
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_COMMIT }),
-    );
+    // Switch the payload — the next poll will see a different consoleCommit.
+    payload = UPDATES_NEW_COMMIT;
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
   });
 
   test('triggers the console update toast when a plugin is added', async ({ page }) => {
-    let resolveDefault: () => void;
-    const defaultIntercepted = new Promise<void>((r) => {
-      resolveDefault = r;
+    let updatesPayload = UPDATES_DEFAULT;
+    let manifestAbort = true;
+
+    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: updatesPayload }));
+    await page.route(PLUGIN_MANIFEST_URL, (route) => {
+      if (manifestAbort) {
+        return route.abort();
+      }
+      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
     });
 
-    await page.route(CHECK_UPDATES_URL, async (route) => {
-      await route.fulfill({ json: UPDATES_DEFAULT });
-      resolveDefault();
+    let responseCount = 0;
+    const baselineReady = new Promise<void>((resolve) => {
+      page.on('response', (resp) => {
+        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
+          responseCount++;
+          if (responseCount >= 2) {
+            resolve();
+          }
+        }
+      });
     });
+
     await page.goto('/');
-    await defaultIntercepted;
+    await baselineReady;
 
-    await page.route(PLUGIN_MANIFEST_URL, (route) => route.abort());
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
-    );
+    // Add a plugin whose manifest endpoint is erroring — toast should NOT appear yet.
+    updatesPayload = UPDATES_NEW_PLUGIN;
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 10_000,
     });
 
-    await page.route(PLUGIN_MANIFEST_URL, (route) =>
-      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
-    );
+    // Make the manifest endpoint succeed — toast should now appear.
+    manifestAbort = false;
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
   });
@@ -72,60 +93,90 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
     page,
   }) => {
-    await page.route(PLUGIN_MANIFEST_URL, (route) => route.abort());
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
-    );
+    let updatesPayload = UPDATES_NEW_PLUGIN;
+    let manifest1Abort = true;
+    let manifest2Abort = true;
+
+    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: updatesPayload }));
+    await page.route(PLUGIN_MANIFEST_URL, (route) => {
+      if (manifest1Abort) {
+        return route.abort();
+      }
+      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
+    });
+    await page.route(PLUGIN_MANIFEST_URL2, (route) => {
+      if (manifest2Abort) {
+        return route.abort();
+      }
+      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 });
+    });
+
+    let responseCount = 0;
+    const baselineReady = new Promise<void>((resolve) => {
+      page.on('response', (resp) => {
+        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
+          responseCount++;
+          if (responseCount >= 2) {
+            resolve();
+          }
+        }
+      });
+    });
+
     await page.goto('/');
+    await baselineReady;
 
-    // Wait for the first check-updates poll to establish baseline state
+    await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
+      timeout: 10_000,
+    });
+
+    // Introduce a second plugin — both manifest endpoints are still erroring.
+    updatesPayload = UPDATES_NEW_PLUGIN2;
+
+    // Wait for the app to poll and see the new plugin list.
     await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 10_000,
     });
 
-    // Now introduce a second plugin — plugin1 manifest still errors, plugin2 manifest also errors
-    await page.route(PLUGIN_MANIFEST_URL2, (route) => route.abort());
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN2 }),
-    );
-
-    // Wait for the app to poll and see the new plugin list
-    await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
-
-    await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
-      timeout: 10_000,
-    });
-
-    // Make plugin2 manifest succeed — toast should appear
-    await page.route(PLUGIN_MANIFEST_URL2, (route) =>
-      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 }),
-    );
+    // Make plugin2 manifest succeed — toast should appear.
+    manifest2Abort = false;
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
   });
 
   test('triggers the console update toast when a plugin is removed', async ({ page }) => {
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
-    );
+    let updatesPayload = UPDATES_NEW_PLUGIN;
+
+    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: updatesPayload }));
     await page.route(PLUGIN_MANIFEST_URL, (route) =>
       route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
     );
+
+    let responseCount = 0;
+    const baselineReady = new Promise<void>((resolve) => {
+      page.on('response', (resp) => {
+        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
+          responseCount++;
+          if (responseCount >= 2) {
+            resolve();
+          }
+        }
+      });
+    });
+
     await page.goto('/');
+    await baselineReady;
 
-    await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
-
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_DEFAULT }),
-    );
+    // Remove the plugin from the list.
+    updatesPayload = UPDATES_DEFAULT;
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
   });
 
   test('triggers the console update toast when a plugin version changes', async ({ page }) => {
-    // Serve the old version for the first 2 manifest fetches, then switch to the new version.
+    // Serve the old version for the first few manifest fetches, then switch to the new version.
     // The component needs at least one render cycle with the old version recorded as
     // prevPluginManifestsData before it can detect the version change.
     let manifestFetchCount = 0;

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -19,42 +19,48 @@ const PLUGIN_MANIFEST_DEFAULT = { name: PLUGIN_NAME, version: '0.0.0' };
 const PLUGIN_MANIFEST_DEFAULT2 = { name: PLUGIN_NAME2, version: '0.0.0' };
 const PLUGIN_MANIFEST_NEW_VERSION = { name: PLUGIN_NAME, version: '1.0.0' };
 
-// The component needs two poll cycles to initialize its prev/current refs before
-// it can detect changes. Tests wait for two check-updates responses (baselineReady)
-// before switching the mocked payload.
+// Wait for the route mock to serve two check-updates responses. The component uses
+// a prev/current ref pattern and needs two poll cycles before it can detect changes.
+async function waitForBaseline(page: import('@playwright/test').Page): Promise<void> {
+  let count = 0;
+  await new Promise<void>((resolve) => {
+    page.on('response', (resp) => {
+      if (
+        resp.url().includes('/api/check-updates') &&
+        resp.status() === 200 &&
+        resp.headers()['x-mock'] === '1'
+      ) {
+        count++;
+        if (count >= 2) resolve();
+      }
+    });
+  });
+}
+
 test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when consoleCommit changes', async ({ page }) => {
     let payload = UPDATES_DEFAULT;
 
-    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: payload }));
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: payload, headers: { 'x-mock': '1' } }),
+    );
 
-    // Start listening for responses BEFORE navigating so we don't miss the first poll.
-    let responseCount = 0;
-    const baselineReady = new Promise<void>((resolve) => {
-      page.on('response', (resp) => {
-        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
-          responseCount++;
-          if (responseCount >= 2) {
-            resolve();
-          }
-        }
-      });
-    });
-
+    const baseline = waitForBaseline(page);
     await page.goto('/');
-    await baselineReady;
+    await baseline;
 
-    // Switch the payload — the next poll will see a different consoleCommit.
     payload = UPDATES_NEW_COMMIT;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin is added', async ({ page }) => {
     let updatesPayload = UPDATES_DEFAULT;
     let manifestAbort = true;
 
-    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: updatesPayload }));
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: updatesPayload, headers: { 'x-mock': '1' } }),
+    );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
       if (manifestAbort) {
         return route.abort();
@@ -62,32 +68,19 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
       return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
     });
 
-    let responseCount = 0;
-    const baselineReady = new Promise<void>((resolve) => {
-      page.on('response', (resp) => {
-        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
-          responseCount++;
-          if (responseCount >= 2) {
-            resolve();
-          }
-        }
-      });
-    });
-
+    const baseline = waitForBaseline(page);
     await page.goto('/');
-    await baselineReady;
+    await baseline;
 
-    // Add a plugin whose manifest endpoint is erroring — toast should NOT appear yet.
     updatesPayload = UPDATES_NEW_PLUGIN;
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 10_000,
     });
 
-    // Make the manifest endpoint succeed — toast should now appear.
     manifestAbort = false;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
@@ -97,7 +90,9 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     let manifest1Abort = true;
     let manifest2Abort = true;
 
-    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: updatesPayload }));
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: updatesPayload, headers: { 'x-mock': '1' } }),
+    );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
       if (manifest1Abort) {
         return route.abort();
@@ -111,77 +106,50 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
       return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 });
     });
 
-    let responseCount = 0;
-    const baselineReady = new Promise<void>((resolve) => {
-      page.on('response', (resp) => {
-        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
-          responseCount++;
-          if (responseCount >= 2) {
-            resolve();
-          }
-        }
-      });
-    });
-
+    const baseline = waitForBaseline(page);
     await page.goto('/');
-    await baselineReady;
+    await baseline;
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 10_000,
     });
 
-    // Introduce a second plugin — both manifest endpoints are still erroring.
     updatesPayload = UPDATES_NEW_PLUGIN2;
 
-    // Wait for the app to poll and see the new plugin list.
     await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 10_000,
     });
 
-    // Make plugin2 manifest succeed — toast should appear.
     manifest2Abort = false;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin is removed', async ({ page }) => {
     let updatesPayload = UPDATES_NEW_PLUGIN;
 
-    await page.route(CHECK_UPDATES_URL, (route) => route.fulfill({ json: updatesPayload }));
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: updatesPayload, headers: { 'x-mock': '1' } }),
+    );
     await page.route(PLUGIN_MANIFEST_URL, (route) =>
       route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
     );
 
-    let responseCount = 0;
-    const baselineReady = new Promise<void>((resolve) => {
-      page.on('response', (resp) => {
-        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
-          responseCount++;
-          if (responseCount >= 2) {
-            resolve();
-          }
-        }
-      });
-    });
-
+    const baseline = waitForBaseline(page);
     await page.goto('/');
-    await baselineReady;
+    await baseline;
 
-    // Remove the plugin from the list.
     updatesPayload = UPDATES_DEFAULT;
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin version changes', async ({ page }) => {
-    // Serve the old version for the first few manifest fetches, then switch to the new version.
-    // The component needs at least one render cycle with the old version recorded as
-    // prevPluginManifestsData before it can detect the version change.
     let manifestFetchCount = 0;
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
+      route.fulfill({ json: UPDATES_NEW_PLUGIN, headers: { 'x-mock': '1' } }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) => {
       manifestFetchCount++;
@@ -192,6 +160,6 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     });
     await page.goto('/');
 
-    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 300_000 });
+    await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 });

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -19,12 +19,27 @@ const PLUGIN_MANIFEST_DEFAULT = { name: PLUGIN_NAME, version: '0.0.0' };
 const PLUGIN_MANIFEST_DEFAULT2 = { name: PLUGIN_NAME2, version: '0.0.0' };
 const PLUGIN_MANIFEST_NEW_VERSION = { name: PLUGIN_NAME, version: '1.0.0' };
 
-// The component uses a prev/current ref pattern: it needs two poll cycles
-// (each ~15 s apart) before `stateInitialized` becomes true. This helper
-// waits for exactly N mocked check-updates responses, which confirms the
-// component has cycled through enough renders for `prevUpdateData` to be
-// populated. Call it BEFORE page.goto so the listener catches the first
-// response that fires on mount.
+type RouteHandler = (route: import('@playwright/test').Route) => void;
+
+/**
+ * Creates a mutable route handler whose behavior can be swapped at runtime.
+ * This avoids Playwright's handler stacking issues (where calling page.route()
+ * multiple times on the same URL adds stacked handlers). Instead, we register
+ * ONE handler that delegates to a mutable reference.
+ */
+function createMutableHandler(initial: RouteHandler) {
+  let current = initial;
+  const handler: RouteHandler = (route) => current(route);
+  const setHandler = (next: RouteHandler) => {
+    current = next;
+  };
+  return { handler, setHandler };
+}
+
+/**
+ * Wait for N successful check-updates responses (status 200).
+ * Must be called BEFORE page.goto so the listener catches the first response.
+ */
 function waitForResponses(
   page: import('@playwright/test').Page,
   n: number,
@@ -51,47 +66,41 @@ function waitForResponses(
 
 test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when consoleCommit changes', async ({ page }) => {
-    await page.route(CHECK_UPDATES_URL, (route) =>
+    const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_DEFAULT }),
     );
+    await page.route(CHECK_UPDATES_URL, updates.handler);
 
     const ready = waitForResponses(page, 2);
     await page.goto('/');
     await ready;
 
-    // Swap to a new commit hash — the next poll will see the change.
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_COMMIT }),
-    );
+    updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_COMMIT }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin is added', async ({ page }) => {
-    // Phase 1 — baseline: no plugins, no manifest route needed.
-    await page.route(CHECK_UPDATES_URL, (route) =>
+    const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_DEFAULT }),
     );
+    const manifest = createMutableHandler((route) => route.abort());
+    await page.route(CHECK_UPDATES_URL, updates.handler);
+    await page.route(PLUGIN_MANIFEST_URL, manifest.handler);
 
     const ready = waitForResponses(page, 2);
     await page.goto('/');
     await ready;
 
-    // Phase 2 — announce the plugin but keep its manifest endpoint down.
-    // The component should detect pluginsChanged but wait for readiness.
-    await page.route(PLUGIN_MANIFEST_URL, (route) => route.abort());
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
-    );
+    // Announce the plugin but keep its manifest endpoint down.
+    updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_PLUGIN }));
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 30_000,
     });
 
-    // Phase 3 — manifest endpoint becomes available → toast should appear.
-    await page.route(PLUGIN_MANIFEST_URL, (route) =>
-      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
-    );
+    // Make the manifest endpoint available — toast should appear.
+    manifest.setHandler((route) => route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
@@ -99,11 +108,14 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
     page,
   }) => {
-    // Baseline: one plugin exists but its manifest is unreachable.
-    await page.route(PLUGIN_MANIFEST_URL, (route) => route.abort());
-    await page.route(CHECK_UPDATES_URL, (route) =>
+    const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
+    const manifest1 = createMutableHandler((route) => route.abort());
+    const manifest2 = createMutableHandler((route) => route.abort());
+    await page.route(PLUGIN_MANIFEST_URL, manifest1.handler);
+    await page.route(CHECK_UPDATES_URL, updates.handler);
+    await page.route(PLUGIN_MANIFEST_URL2, manifest2.handler);
 
     const ready = waitForResponses(page, 2);
     await page.goto('/');
@@ -114,10 +126,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     });
 
     // Add a second plugin — both manifests still down.
-    await page.route(PLUGIN_MANIFEST_URL2, (route) => route.abort());
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_NEW_PLUGIN2 }),
-    );
+    updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_PLUGIN2 }));
 
     await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
 
@@ -125,19 +134,17 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
       timeout: 30_000,
     });
 
-    // Make plugin2 manifest reachable → toast should appear.
-    await page.route(PLUGIN_MANIFEST_URL2, (route) =>
-      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 }),
-    );
+    // Make plugin2 manifest reachable — toast should appear.
+    manifest2.setHandler((route) => route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
 
   test('triggers the console update toast when a plugin is removed', async ({ page }) => {
-    // Baseline: one plugin registered with a working manifest.
-    await page.route(CHECK_UPDATES_URL, (route) =>
+    const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
+    await page.route(CHECK_UPDATES_URL, updates.handler);
     await page.route(PLUGIN_MANIFEST_URL, (route) =>
       route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
     );
@@ -146,31 +153,25 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     await page.goto('/');
     await ready;
 
-    // Remove the plugin from the update response.
-    await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: UPDATES_DEFAULT }),
-    );
+    updates.setHandler((route) => route.fulfill({ json: UPDATES_DEFAULT }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin version changes', async ({ page }) => {
-    // Baseline: one plugin at version 0.0.0.
+    const manifest = createMutableHandler((route) =>
+      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
+    );
     await page.route(CHECK_UPDATES_URL, (route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
-    await page.route(PLUGIN_MANIFEST_URL, (route) =>
-      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
-    );
+    await page.route(PLUGIN_MANIFEST_URL, manifest.handler);
 
     const ready = waitForResponses(page, 2);
     await page.goto('/');
     await ready;
 
-    // Bump the manifest version — the next poll should detect the change.
-    await page.route(PLUGIN_MANIFEST_URL, (route) =>
-      route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION }),
-    );
+    manifest.setHandler((route) => route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -19,17 +19,26 @@ const PLUGIN_MANIFEST_DEFAULT = { name: PLUGIN_NAME, version: '0.0.0' };
 const PLUGIN_MANIFEST_DEFAULT2 = { name: PLUGIN_NAME2, version: '0.0.0' };
 const PLUGIN_MANIFEST_NEW_VERSION = { name: PLUGIN_NAME, version: '1.0.0' };
 
-// The component uses a prev/current ref pattern that needs two poll cycles to
-// initialize before it can detect changes. Start listening for two mocked
-// check-updates responses BEFORE navigating to avoid race conditions.
-function waitForBaseline(page: import('@playwright/test').Page): Promise<void> {
+// The component uses a prev/current ref pattern: it needs two poll cycles
+// (each ~15 s apart) before `stateInitialized` becomes true. This helper
+// waits for exactly N mocked check-updates responses, which confirms the
+// component has cycled through enough renders for `prevUpdateData` to be
+// populated. Call it BEFORE page.goto so the listener catches the first
+// response that fires on mount.
+function waitForResponses(
+  page: import('@playwright/test').Page,
+  n: number,
+): Promise<void> {
   let count = 0;
   return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('waitForBaseline timed out')), 90_000);
+    const timer = setTimeout(
+      () => reject(new Error(`waitForResponses: only saw ${count}/${n} responses`)),
+      90_000,
+    );
     const handler = (resp: import('@playwright/test').Response) => {
       if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
         count++;
-        if (count >= 2) {
+        if (count >= n) {
           clearTimeout(timer);
           page.off('response', handler);
           resolve();
@@ -42,46 +51,47 @@ function waitForBaseline(page: import('@playwright/test').Page): Promise<void> {
 
 test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when consoleCommit changes', async ({ page }) => {
-    let payload = UPDATES_DEFAULT;
-
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: payload }),
+      route.fulfill({ json: UPDATES_DEFAULT }),
     );
 
-    const baseline = waitForBaseline(page);
+    const ready = waitForResponses(page, 2);
     await page.goto('/');
-    await baseline;
+    await ready;
 
-    payload = UPDATES_NEW_COMMIT;
+    // Swap to a new commit hash — the next poll will see the change.
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: UPDATES_NEW_COMMIT }),
+    );
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin is added', async ({ page }) => {
-    let updatesPayload = UPDATES_DEFAULT;
-    let manifestAbort = true;
-
+    // Phase 1 — baseline: no plugins, no manifest route needed.
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: updatesPayload }),
+      route.fulfill({ json: UPDATES_DEFAULT }),
     );
-    await page.route(PLUGIN_MANIFEST_URL, (route) => {
-      if (manifestAbort) {
-        return route.abort();
-      }
-      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
-    });
 
-    const baseline = waitForBaseline(page);
+    const ready = waitForResponses(page, 2);
     await page.goto('/');
-    await baseline;
+    await ready;
 
-    updatesPayload = UPDATES_NEW_PLUGIN;
+    // Phase 2 — announce the plugin but keep its manifest endpoint down.
+    // The component should detect pluginsChanged but wait for readiness.
+    await page.route(PLUGIN_MANIFEST_URL, (route) => route.abort());
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
+    );
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
-      timeout: 10_000,
+      timeout: 30_000,
     });
 
-    manifestAbort = false;
+    // Phase 3 — manifest endpoint becomes available → toast should appear.
+    await page.route(PLUGIN_MANIFEST_URL, (route) =>
+      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
+    );
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
@@ -89,83 +99,78 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
     page,
   }) => {
-    let updatesPayload = UPDATES_NEW_PLUGIN;
-    let manifest1Abort = true;
-    let manifest2Abort = true;
-
+    // Baseline: one plugin exists but its manifest is unreachable.
+    await page.route(PLUGIN_MANIFEST_URL, (route) => route.abort());
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: updatesPayload }),
+      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
-    await page.route(PLUGIN_MANIFEST_URL, (route) => {
-      if (manifest1Abort) {
-        return route.abort();
-      }
-      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
-    });
-    await page.route(PLUGIN_MANIFEST_URL2, (route) => {
-      if (manifest2Abort) {
-        return route.abort();
-      }
-      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 });
-    });
 
-    const baseline = waitForBaseline(page);
+    const ready = waitForResponses(page, 2);
     await page.goto('/');
-    await baseline;
+    await ready;
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
-      timeout: 10_000,
+      timeout: 30_000,
     });
 
-    updatesPayload = UPDATES_NEW_PLUGIN2;
+    // Add a second plugin — both manifests still down.
+    await page.route(PLUGIN_MANIFEST_URL2, (route) => route.abort());
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: UPDATES_NEW_PLUGIN2 }),
+    );
 
     await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
-      timeout: 10_000,
+      timeout: 30_000,
     });
 
-    manifest2Abort = false;
+    // Make plugin2 manifest reachable → toast should appear.
+    await page.route(PLUGIN_MANIFEST_URL2, (route) =>
+      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 }),
+    );
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });
 
   test('triggers the console update toast when a plugin is removed', async ({ page }) => {
-    let updatesPayload = UPDATES_NEW_PLUGIN;
-
+    // Baseline: one plugin registered with a working manifest.
     await page.route(CHECK_UPDATES_URL, (route) =>
-      route.fulfill({ json: updatesPayload }),
+      route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
     await page.route(PLUGIN_MANIFEST_URL, (route) =>
       route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
     );
 
-    const baseline = waitForBaseline(page);
+    const ready = waitForResponses(page, 2);
     await page.goto('/');
-    await baseline;
+    await ready;
 
-    updatesPayload = UPDATES_DEFAULT;
+    // Remove the plugin from the update response.
+    await page.route(CHECK_UPDATES_URL, (route) =>
+      route.fulfill({ json: UPDATES_DEFAULT }),
+    );
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 60_000 });
   });
 
   test('triggers the console update toast when a plugin version changes', async ({ page }) => {
-    let serveNewVersion = false;
+    // Baseline: one plugin at version 0.0.0.
     await page.route(CHECK_UPDATES_URL, (route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
-    await page.route(PLUGIN_MANIFEST_URL, (route) => {
-      if (serveNewVersion) {
-        return route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION });
-      }
-      return route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT });
-    });
+    await page.route(PLUGIN_MANIFEST_URL, (route) =>
+      route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
+    );
 
-    const baseline = waitForBaseline(page);
+    const ready = waitForResponses(page, 2);
     await page.goto('/');
-    await baseline;
+    await ready;
 
-    serveNewVersion = true;
+    // Bump the manifest version — the next poll should detect the change.
+    await page.route(PLUGIN_MANIFEST_URL, (route) =>
+      route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION }),
+    );
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
   });

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -37,31 +37,46 @@ function createMutableHandler(initial: RouteHandler) {
 }
 
 /**
- * Wait for N successful check-updates responses (status 200).
- * Must be called BEFORE page.goto so the listener catches the first response.
+ * Navigate to `/` and wait for the PollConsoleUpdates component to initialize.
+ *
+ * The component uses a prev/current ref pattern: it needs at least 2 poll
+ * cycles (~15s apart) before `stateInitialized` becomes true. In CI, OAuth
+ * redirects can cause multiple navigations (and component remounts) even
+ * after the dashboard appears. Each navigation resets the counter because
+ * a remount means the component starts fresh.
  */
-function waitForResponses(
-  page: import('@playwright/test').Page,
-  n: number,
-): Promise<void> {
+async function navigateAndWaitForInit(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await expect(page.locator('[data-test-id="dashboard"]').first()).toBeVisible({ timeout: 60_000 });
+
   let count = 0;
-  return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`waitForResponses: only saw ${count}/${n} responses`)),
-      90_000,
-    );
-    const handler = (resp: import('@playwright/test').Response) => {
-      if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
-        count++;
-        if (count >= n) {
-          clearTimeout(timer);
-          page.off('response', handler);
-          resolve();
+
+  const resetOnNav = () => {
+    count = 0;
+  };
+  page.on('framenavigated', resetOnNav);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`navigateAndWaitForInit: only saw ${count}/2 responses`)),
+        90_000,
+      );
+      const handler = (resp: import('@playwright/test').Response) => {
+        if (resp.url().includes('/api/check-updates') && resp.status() === 200) {
+          count++;
+          if (count >= 2) {
+            clearTimeout(timer);
+            page.off('response', handler);
+            resolve();
+          }
         }
-      }
-    };
-    page.on('response', handler);
-  });
+      };
+      page.on('response', handler);
+    });
+  } finally {
+    page.off('framenavigated', resetOnNav);
+  }
 }
 
 test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
@@ -71,9 +86,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     );
     await page.route(CHECK_UPDATES_URL, updates.handler);
 
-    const ready = waitForResponses(page, 2);
-    await page.goto('/');
-    await ready;
+    await navigateAndWaitForInit(page);
 
     updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_COMMIT }));
 
@@ -88,18 +101,14 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     await page.route(CHECK_UPDATES_URL, updates.handler);
     await page.route(PLUGIN_MANIFEST_URL, manifest.handler);
 
-    const ready = waitForResponses(page, 2);
-    await page.goto('/');
-    await ready;
+    await navigateAndWaitForInit(page);
 
-    // Announce the plugin but keep its manifest endpoint down.
     updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_PLUGIN }));
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 30_000,
     });
 
-    // Make the manifest endpoint available — toast should appear.
     manifest.setHandler((route) => route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
@@ -117,15 +126,12 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     await page.route(CHECK_UPDATES_URL, updates.handler);
     await page.route(PLUGIN_MANIFEST_URL2, manifest2.handler);
 
-    const ready = waitForResponses(page, 2);
-    await page.goto('/');
-    await ready;
+    await navigateAndWaitForInit(page);
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 30_000,
     });
 
-    // Add a second plugin — both manifests still down.
     updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_PLUGIN2 }));
 
     await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
@@ -134,7 +140,6 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
       timeout: 30_000,
     });
 
-    // Make plugin2 manifest reachable — toast should appear.
     manifest2.setHandler((route) => route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT2 }));
 
     await expect(page.getByTestId('refresh-web-console')).toBeVisible({ timeout: 120_000 });
@@ -149,9 +154,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
       route.fulfill({ json: PLUGIN_MANIFEST_DEFAULT }),
     );
 
-    const ready = waitForResponses(page, 2);
-    await page.goto('/');
-    await ready;
+    await navigateAndWaitForInit(page);
 
     updates.setHandler((route) => route.fulfill({ json: UPDATES_DEFAULT }));
 
@@ -167,9 +170,7 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
     );
     await page.route(PLUGIN_MANIFEST_URL, manifest.handler);
 
-    const ready = waitForResponses(page, 2);
-    await page.goto('/');
-    await ready;
+    await navigateAndWaitForInit(page);
 
     manifest.setHandler((route) => route.fulfill({ json: PLUGIN_MANIFEST_NEW_VERSION }));
 

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
@@ -241,16 +241,18 @@ route:
     });
 
     await test.step('Verify match and match_re were converted to matchers in YAML', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
 
-      const config: AlertmanagerConfig = jsYaml.load(yamlContent) as AlertmanagerConfig;
-      const route: AlertmanagerRoute | undefined = config.route.routes?.find(
-        (r: AlertmanagerRoute) => r.receiver === receiverName,
-      );
+        const config: AlertmanagerConfig = jsYaml.load(yamlContent) as AlertmanagerConfig;
+        const route: AlertmanagerRoute | undefined = config.route.routes?.find(
+          (r: AlertmanagerRoute) => r.receiver === receiverName,
+        );
 
-      expect(route?.matchers?.[0]).toBe(matcher1);
-      expect(route?.matchers?.[1]).toBe(matcher2);
+        expect(route?.matchers?.[0]).toBe(matcher1);
+        expect(route?.matchers?.[1]).toBe(matcher2);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
   });
 });

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/email.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/email.spec.ts
@@ -117,22 +117,24 @@ route:
     await test.step('Verify Email Receiver was created correctly', async () => {
       await alertmanager.validateReceiverInList(receiverName);
 
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      // Verify values are NOT in globals
-      expect(configs.globals).not.toHaveProperty('email_to');
-      expect(configs.globals).not.toHaveProperty('smtp_from');
-      expect(configs.globals).not.toHaveProperty('smtp_smarthost');
-      expect(configs.globals).not.toHaveProperty('smtp_require_tls');
+        // Verify values are NOT in globals
+        expect(configs.globals).not.toHaveProperty('email_to');
+        expect(configs.globals).not.toHaveProperty('smtp_from');
+        expect(configs.globals).not.toHaveProperty('smtp_smarthost');
+        expect(configs.globals).not.toHaveProperty('smtp_require_tls');
 
-      // Verify values ARE in receiver config
-      expect(configs.receiverConfig.to).toBe(emailTo);
-      expect(configs.receiverConfig.from).toBe(emailFrom);
-      expect(configs.receiverConfig.smarthost).toBe(emailSmarthost);
-      // require_tls should not be in receiver config (unchanged from global)
-      expect(configs.receiverConfig).not.toHaveProperty('require_tls');
+        // Verify values ARE in receiver config
+        expect(configs.receiverConfig.to).toBe(emailTo);
+        expect(configs.receiverConfig.from).toBe(emailFrom);
+        expect(configs.receiverConfig.smarthost).toBe(emailSmarthost);
+        // require_tls should not be in receiver config (unchanged from global)
+        expect(configs.receiverConfig).not.toHaveProperty('require_tls');
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Edit receiver with auth and advanced fields', async () => {
@@ -169,25 +171,27 @@ route:
     });
 
     await test.step('Verify auth and advanced fields were saved correctly', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      // Auth username should NOT be in globals
-      expect(configs.globals).not.toHaveProperty('smtp_auth_username');
+        // Auth username should NOT be in globals
+        expect(configs.globals).not.toHaveProperty('smtp_auth_username');
 
-      // Auth fields should be in receiver config
-      expect(configs.receiverConfig.auth_username).toBe(username);
-      expect(configs.receiverConfig.auth_password).toBe(password);
-      expect(configs.receiverConfig.auth_identity).toBe(identity);
-      expect(configs.receiverConfig.auth_secret).toBe(secret);
+        // Auth fields should be in receiver config
+        expect(configs.receiverConfig.auth_username).toBe(username);
+        expect(configs.receiverConfig.auth_password).toBe(password);
+        expect(configs.receiverConfig.auth_identity).toBe(identity);
+        expect(configs.receiverConfig.auth_secret).toBe(secret);
 
-      // require_tls should now be explicitly false in receiver config
-      expect(configs.receiverConfig.require_tls).toBe(false);
+        // require_tls should now be explicitly false in receiver config
+        expect(configs.receiverConfig.require_tls).toBe(false);
 
-      // Advanced fields
-      expect(configs.receiverConfig.send_resolved).toBe(true);
-      expect(configs.receiverConfig.html).toBe(html);
+        // Advanced fields
+        expect(configs.receiverConfig.send_resolved).toBe(true);
+        expect(configs.receiverConfig.html).toBe(html);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Save fields as global defaults', async () => {
@@ -201,22 +205,24 @@ route:
     });
 
     await test.step('Verify fields were saved as globals', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      // Verify values are now in globals
-      expect(configs.globals.smtp_from).toBe(emailFrom);
-      expect(configs.globals.smtp_hello).toBe(localhost);
-      expect(configs.globals.smtp_smarthost).toBe(emailSmarthost);
-      expect(configs.globals.smtp_auth_username).toBe(username);
-      expect(configs.globals.smtp_auth_password).toBe(password);
-      expect(configs.globals.smtp_auth_identity).toBe(identity);
-      expect(configs.globals.smtp_auth_secret).toBe(secret);
-      expect(configs.globals.smtp_require_tls).toBe(false);
+        // Verify values are now in globals
+        expect(configs.globals.smtp_from).toBe(emailFrom);
+        expect(configs.globals.smtp_hello).toBe(localhost);
+        expect(configs.globals.smtp_smarthost).toBe(emailSmarthost);
+        expect(configs.globals.smtp_auth_username).toBe(username);
+        expect(configs.globals.smtp_auth_password).toBe(password);
+        expect(configs.globals.smtp_auth_identity).toBe(identity);
+        expect(configs.globals.smtp_auth_secret).toBe(secret);
+        expect(configs.globals.smtp_require_tls).toBe(false);
 
-      // Non-global field (to) should still be in receiver config
-      expect(configs.receiverConfig.to).toBe(emailTo);
+        // Non-global field (to) should still be in receiver config
+        expect(configs.receiverConfig.to).toBe(emailTo);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
   });
 });

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/pagerduty.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/pagerduty.spec.ts
@@ -83,12 +83,14 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
     });
 
     await test.step('Verify pagerduty_url was saved with Receiver and not global', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.globals).not.toHaveProperty('pagerduty_url');
-      expect(configs.receiverConfig.url).toBe(pagerDutyURL1);
+        expect(configs.globals).not.toHaveProperty('pagerduty_url');
+        expect(configs.receiverConfig.url).toBe(pagerDutyURL1);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Save pagerduty_url as global', async () => {
@@ -106,12 +108,14 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
     });
 
     await test.step('Verify pagerduty_url was saved as global', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.globals.pagerduty_url).toBe(pagerDutyURL2);
-      expect(configs.receiverConfig).not.toHaveProperty('url');
+        expect(configs.globals.pagerduty_url).toBe(pagerDutyURL2);
+        expect(configs.receiverConfig).not.toHaveProperty('url');
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Add pagerduty_url to receiver with existing global', async () => {
@@ -131,12 +135,14 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
     await test.step(
       'Verify pagerduty_url saved with Receiver and global still exists',
       async () => {
-        await alertmanager.navigateToYAMLPage();
-        const yamlContent = await alertmanager.getYAMLContent();
-        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+        await expect(async () => {
+          await alertmanager.navigateToYAMLPage();
+          const yamlContent = await alertmanager.getYAMLContent();
+          const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-        expect(configs.globals.pagerduty_url).toBe(pagerDutyURL2);
-        expect(configs.receiverConfig.url).toBe(pagerDutyURL3);
+          expect(configs.globals.pagerduty_url).toBe(pagerDutyURL2);
+          expect(configs.receiverConfig.url).toBe(pagerDutyURL3);
+        }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
       },
     );
 
@@ -159,15 +165,17 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
     });
 
     await test.step('Verify changed fields are saved with Receiver', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.receiverConfig.send_resolved).toBe(false);
-      expect(configs.receiverConfig.client).toBe('updated-client');
-      expect(configs.receiverConfig.client_url).toBe('http://updated-client-url');
-      expect(configs.receiverConfig.description).toBeUndefined();
-      expect(configs.receiverConfig.severity).toBeUndefined();
+        expect(configs.receiverConfig.send_resolved).toBe(false);
+        expect(configs.receiverConfig.client).toBe('updated-client');
+        expect(configs.receiverConfig.client_url).toBe('http://updated-client-url');
+        expect(configs.receiverConfig.description).toBeUndefined();
+        expect(configs.receiverConfig.severity).toBeUndefined();
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Restore defaults, change desc and severity', async () => {
@@ -195,15 +203,17 @@ test.describe('Alertmanager PagerDuty Receiver Form', { tag: ['@admin'] }, () =>
     });
 
     await test.step('Verify defaults removed from config, desc and severity saved', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.receiverConfig.send_resolved).toBeUndefined();
-      expect(configs.receiverConfig.client).toBeUndefined();
-      expect(configs.receiverConfig.client_url).toBeUndefined();
-      expect(configs.receiverConfig.description).toBe(pagerDutyDescription);
-      expect(configs.receiverConfig.severity).toBe(severity);
+        expect(configs.receiverConfig.send_resolved).toBeUndefined();
+        expect(configs.receiverConfig.client).toBeUndefined();
+        expect(configs.receiverConfig.client_url).toBeUndefined();
+        expect(configs.receiverConfig.description).toBe(pagerDutyDescription);
+        expect(configs.receiverConfig.severity).toBe(severity);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
   });
 });

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/slack.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/slack.spec.ts
@@ -74,16 +74,18 @@ test.describe('Alertmanager Slack Receiver Form', { tag: ['@admin'] }, () => {
     await test.step('Verify Slack Receiver was created correctly', async () => {
       await alertmanager.validateReceiverInList(receiverName);
 
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.globals).not.toHaveProperty('slack_api_url');
-      expect(configs.receiverConfig.channel).toBe(slackChannel);
-      expect(configs.receiverConfig.api_url).toBe(slackAPIURL);
-      // Advanced fields are not saved since they equal their global values
-      expect(configs.receiverConfig).not.toHaveProperty('send_resolved');
-      expect(configs.receiverConfig).not.toHaveProperty('username');
+        expect(configs.globals).not.toHaveProperty('slack_api_url');
+        expect(configs.receiverConfig.channel).toBe(slackChannel);
+        expect(configs.receiverConfig.api_url).toBe(slackAPIURL);
+        // Advanced fields are not saved since they equal their global values
+        expect(configs.receiverConfig).not.toHaveProperty('send_resolved');
+        expect(configs.receiverConfig).not.toHaveProperty('username');
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Save globals and advanced fields', async () => {
@@ -122,17 +124,19 @@ test.describe('Alertmanager Slack Receiver Form', { tag: ['@admin'] }, () => {
     });
 
     await test.step('Verify YAML has correct global and receiver config', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.globals.slack_api_url).toBe(slackAPIURL);
-      expect(configs.receiverConfig).not.toHaveProperty('api_url');
-      expect(configs.receiverConfig.channel).toBe('myslackchannel');
-      expect(configs.receiverConfig.send_resolved).toBe(true);
-      expect(configs.receiverConfig.icon_url).toBe(slackIconURL);
-      expect(configs.receiverConfig.username).toBe(slackUsername);
-      expect(configs.receiverConfig.link_names).toBe(true);
+        expect(configs.globals.slack_api_url).toBe(slackAPIURL);
+        expect(configs.receiverConfig).not.toHaveProperty('api_url');
+        expect(configs.receiverConfig.channel).toBe('myslackchannel');
+        expect(configs.receiverConfig.send_resolved).toBe(true);
+        expect(configs.receiverConfig.icon_url).toBe(slackIconURL);
+        expect(configs.receiverConfig.username).toBe(slackUsername);
+        expect(configs.receiverConfig.link_names).toBe(true);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
   });
 });

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/webhook.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/receivers/webhook.spec.ts
@@ -45,12 +45,14 @@ test.describe('Alertmanager Webhook Receiver Form', { tag: ['@admin'] }, () => {
     await test.step('Verify Webhook Receiver was created correctly', async () => {
       await alertmanager.validateReceiverInList(receiverName);
 
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.receiverConfig.url).toBe(webhookURL);
-      expect(configs.receiverConfig).not.toHaveProperty('send_resolved');
+        expect(configs.receiverConfig.url).toBe(webhookURL);
+        expect(configs.receiverConfig).not.toHaveProperty('send_resolved');
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
 
     await test.step('Edit Webhook Receiver and save advanced fields', async () => {
@@ -75,12 +77,14 @@ test.describe('Alertmanager Webhook Receiver Form', { tag: ['@admin'] }, () => {
     });
 
     await test.step('Verify YAML has correct config', async () => {
-      await alertmanager.navigateToYAMLPage();
-      const yamlContent = await alertmanager.getYAMLContent();
-      const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
+      await expect(async () => {
+        await alertmanager.navigateToYAMLPage();
+        const yamlContent = await alertmanager.getYAMLContent();
+        const configs = getGlobalsAndReceiverConfig(receiverName, configName, yamlContent);
 
-      expect(configs.receiverConfig.url).toBe(updatedWebhookURL);
-      expect(configs.receiverConfig.send_resolved).toBe(false);
+        expect(configs.receiverConfig.url).toBe(updatedWebhookURL);
+        expect(configs.receiverConfig.send_resolved).toBe(false);
+      }).toPass({ intervals: [2_000, 3_000, 5_000], timeout: 30_000 });
     });
   });
 });

--- a/frontend/e2e/tests/console/crud/other-routes.spec.ts
+++ b/frontend/e2e/tests/console/crud/other-routes.spec.ts
@@ -36,7 +36,7 @@ const routes: RouteConfig[] = [
   {
     path: '/k8s/all-namespaces/events',
     assertLoaded: async (page) => {
-      await expect(page.getByRole('row').first()).toBeVisible();
+      await expect(page.getByTestId('event-totals')).toBeVisible();
     },
   },
   {

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -19,11 +19,15 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
 
     await warmupSPA(page);
 
-    // Ensure we are on the Overview page with a clean favorite state.
-    await page.goto('/');
+    // Navigate to the Overview page directly — "/" can redirect based on lastNamespace.
+    await page.goto('/dashboards');
     await expect(page.getByTestId('page-heading').locator('h1')).toContainText('Overview', {
       timeout: 30_000,
     });
+    // Wait for the favorite button to reflect the cleared state.
+    const favButton = page.getByTestId('favorite-button');
+    await expect(favButton).toBeVisible({ timeout: 30_000 });
+    await expect(favButton).not.toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
 
     await test.step('Verify no favorites message when none are added', async () => {
       await sidebar.getByRole('button', { name: 'Favorites' }).click();
@@ -52,7 +56,7 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
     });
 
     await test.step('Remove a favorite from the left navigation menu', async () => {
-      await page.goto('/');
+      await page.goto('/dashboards');
       await page.getByTestId('favorite-button').click();
       const dialog = page.getByRole('dialog');
       await expect(dialog).toContainText('Add to favorites');
@@ -66,7 +70,7 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
 
     await test.step('Disable add to favorite button when limit reached', async () => {
       const pages = [
-        '/',
+        '/dashboards',
         '/k8s/all-namespaces/core~v1~Pod',
         '/k8s/all-namespaces/apps~v1~Deployment',
         '/k8s/all-namespaces/core~v1~Secret',

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -19,6 +19,12 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
 
     await warmupSPA(page);
 
+    // Ensure we are on the Overview page with a clean favorite state.
+    await page.goto('/');
+    await expect(page.getByTestId('page-heading').locator('h1')).toContainText('Overview', {
+      timeout: 30_000,
+    });
+
     await test.step('Verify no favorites message when none are added', async () => {
       await sidebar.getByRole('button', { name: 'Favorites' }).click();
       await expect(page.getByTestId('no-favorites-message')).toBeVisible({ timeout: 30_000 });
@@ -27,7 +33,7 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
     await test.step('Open Add to Favorites modal', async () => {
       await page.getByTestId('favorite-button').click();
       const dialog = page.getByRole('dialog');
-      await expect(dialog).toContainText('Add to favorites');
+      await expect(dialog).toContainText('Add to favorites', { timeout: 10_000 });
     });
 
     await test.step('Save a favorite with custom name', async () => {

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '../../../fixtures';
-import { warmupSPA } from '../../../pages/base-page';
 
 test.describe('Favorites', { tag: ['@admin'] }, () => {
   test('adds, displays, removes, and limits favorites', async ({ page, k8sClient }) => {
@@ -17,17 +16,18 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
       }
     });
 
-    await warmupSPA(page);
-
-    // Navigate to the Overview page directly — "/" can redirect based on lastNamespace.
-    await page.goto('/dashboards');
-    await expect(page.getByTestId('page-heading').locator('h1')).toContainText('Overview', {
-      timeout: 30_000,
-    });
-    // Wait for the favorite button to reflect the cleared state.
-    const favButton = page.getByTestId('favorite-button');
-    await expect(favButton).toBeVisible({ timeout: 30_000 });
-    await expect(favButton).not.toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
+    // Navigate directly to /dashboards — do NOT use warmupSPA (which navigates to "/",
+    // poisoning sessionStorage with lastNamespace and causing SPA redirects).
+    // Use expect.toPass to retry the navigation until the cleared favorites propagate.
+    await expect(async () => {
+      await page.goto('/dashboards', { waitUntil: 'domcontentloaded', timeout: 60_000 });
+      await expect(page.getByTestId('page-heading').locator('h1')).toContainText('Overview', {
+        timeout: 10_000,
+      });
+      const favButton = page.getByTestId('favorite-button');
+      await expect(favButton).toBeVisible({ timeout: 10_000 });
+      await expect(favButton).not.toHaveAttribute('aria-pressed', 'true', { timeout: 5_000 });
+    }).toPass({ timeout: 60_000, intervals: [2_000, 5_000, 10_000] });
 
     await test.step('Verify no favorites message when none are added', async () => {
       await sidebar.getByRole('button', { name: 'Favorites' }).click();

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -5,12 +5,12 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
   test('adds, displays, removes, and limits favorites', async ({ page, k8sClient }) => {
     const sidebar = page.locator('#page-sidebar');
 
-    await test.step('Clear any stale favorites from prior runs', async () => {
+    await test.step('Clear any stale favorites and lastNamespace from prior runs', async () => {
       try {
         await k8sClient.patchConfigMap(
           'user-settings-kubeadmin',
           'openshift-console-user-settings',
-          { 'console.favorites': '[]' },
+          { 'console.favorites': '[]', 'console.lastNamespace': '' },
         );
       } catch {
         // ConfigMap may not exist yet
@@ -57,9 +57,15 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
 
     await test.step('Remove a favorite from the left navigation menu', async () => {
       await page.goto('/dashboards');
-      await page.getByTestId('favorite-button').click();
+      await expect(page.getByTestId('page-heading').locator('h1')).toContainText('Overview', {
+        timeout: 30_000,
+      });
+      const addFavBtn = page.getByTestId('favorite-button');
+      await expect(addFavBtn).toBeVisible({ timeout: 30_000 });
+      await expect(addFavBtn).not.toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
+      await addFavBtn.click();
       const dialog = page.getByRole('dialog');
-      await expect(dialog).toContainText('Add to favorites');
+      await expect(dialog).toContainText('Add to favorites', { timeout: 10_000 });
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(sidebar).toContainText('Overview');
@@ -84,9 +90,12 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
 
       for (let i = 0; i < pages.length; i++) {
         await page.goto(pages[i]);
-        await page.getByTestId('favorite-button').first().click();
+        const btn = page.getByTestId('favorite-button').first();
+        await expect(btn).toBeVisible({ timeout: 30_000 });
+        await expect(btn).not.toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
+        await btn.click();
         const dialog = page.getByRole('dialog');
-        await expect(dialog).toContainText('Add to favorites');
+        await expect(dialog).toContainText('Add to favorites', { timeout: 10_000 });
         const nameInput = page.getByTestId('input-name');
         await nameInput.clear();
         await nameInput.fill(`test-favorite-${i}`);

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -2,14 +2,26 @@ import { test, expect } from '../../../fixtures';
 import { warmupSPA } from '../../../pages/base-page';
 
 test.describe('Favorites', { tag: ['@admin'] }, () => {
-  test('adds, displays, removes, and limits favorites', async ({ page }) => {
+  test('adds, displays, removes, and limits favorites', async ({ page, k8sClient }) => {
     const sidebar = page.locator('#page-sidebar');
+
+    await test.step('Clear any stale favorites from prior runs', async () => {
+      try {
+        await k8sClient.patchConfigMap(
+          'user-settings-kubeadmin',
+          'openshift-console-user-settings',
+          { 'console.favorites': '[]' },
+        );
+      } catch {
+        // ConfigMap may not exist yet
+      }
+    });
 
     await warmupSPA(page);
 
     await test.step('Verify no favorites message when none are added', async () => {
       await sidebar.getByRole('button', { name: 'Favorites' }).click();
-      await expect(page.getByTestId('no-favorites-message')).toBeVisible();
+      await expect(page.getByTestId('no-favorites-message')).toBeVisible({ timeout: 30_000 });
     });
 
     await test.step('Open Add to Favorites modal', async () => {

--- a/frontend/e2e/tests/console/favorites/favorites.spec.ts
+++ b/frontend/e2e/tests/console/favorites/favorites.spec.ts
@@ -63,9 +63,14 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
       const addFavBtn = page.getByTestId('favorite-button');
       await expect(addFavBtn).toBeVisible({ timeout: 30_000 });
       await expect(addFavBtn).not.toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
-      await addFavBtn.click();
-      const dialog = page.getByRole('dialog');
-      await expect(dialog).toContainText('Add to favorites', { timeout: 10_000 });
+
+      await expect(async () => {
+        await addFavBtn.click();
+        await expect(page.getByRole('dialog')).toContainText('Add to favorites', {
+          timeout: 5_000,
+        });
+      }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
+
       await page.getByRole('button', { name: 'Save' }).click();
 
       await expect(sidebar).toContainText('Overview');
@@ -93,14 +98,22 @@ test.describe('Favorites', { tag: ['@admin'] }, () => {
         const btn = page.getByTestId('favorite-button').first();
         await expect(btn).toBeVisible({ timeout: 30_000 });
         await expect(btn).not.toHaveAttribute('aria-pressed', 'true', { timeout: 10_000 });
-        await btn.click();
-        const dialog = page.getByRole('dialog');
-        await expect(dialog).toContainText('Add to favorites', { timeout: 10_000 });
+
+        // Wrap click-and-dialog in a retry loop — the button can render before
+        // user preferences finish loading, so the first click may not open the
+        // dialog if the component is still hydrating.
+        await expect(async () => {
+          await btn.click();
+          await expect(page.getByRole('dialog')).toContainText('Add to favorites', {
+            timeout: 5_000,
+          });
+        }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 5_000] });
+
         const nameInput = page.getByTestId('input-name');
         await nameInput.clear();
         await nameInput.fill(`test-favorite-${i}`);
         await nameInput.press('Enter');
-        await expect(dialog).toBeHidden();
+        await expect(page.getByRole('dialog')).toBeHidden();
       }
 
       await page.goto('/k8s/all-namespaces/apps~v1~DaemonSet');

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -36,6 +36,7 @@ const chromeArgs = [
   '--no-sandbox',
   '--disable-setuid-sandbox',
   '--disable-background-networking',
+  '--disable-background-timer-throttling',
   '--disable-client-side-phishing-detection',
   '--disable-default-apps',
   '--disable-extensions',

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
   testDir: './e2e/tests',
   testMatch: '**/*.spec.ts',
   forbidOnly: isCI,
+  globalTimeout: parseInt(process.env.GLOBAL_TIMEOUT_MS || '0', 10) || (isCI ? 110 * 60 * 1000 : 0),
   retries: isCI ? 1 : 0,
   timeout: 120_000,
   reporter: isCI
@@ -84,7 +85,7 @@ export default defineConfig({
     },
   },
 
-  workers: process.env.WORKERS ? parseInt(process.env.WORKERS, 10) : isCI ? 1 : undefined,
+  workers: process.env.WORKERS ? parseInt(process.env.WORKERS, 10) : undefined,
 
   projects: [
     {

--- a/frontend/public/components/utils/event-stream.tsx
+++ b/frontend/public/components/utils/event-stream.tsx
@@ -56,7 +56,6 @@ class SysEvent extends Component<SysEventProps> {
           className,
         )}
         style={style}
-        role="row"
       >
         <EventComponent event={event} list={list} cache={measurementCache} index={index} />
       </div>

--- a/test-prow-playwright-e2e.sh
+++ b/test-prow-playwright-e2e.sh
@@ -47,6 +47,8 @@ export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jso
 
 ./contrib/create-user.sh
 
+export WORKERS="${WORKERS:-2}"
+
 pushd frontend
 
 SCENARIO="${1:-e2e}"


### PR DESCRIPTION
**Analysis / Root cause**:

The Playwright e2e suite had two categories of failures:

1. **CI timeout** — With 299 tests, 55 retries, and a single worker (serial execution), the suite exceeded Prow's 2-hour hard timeout. The container was killed mid-run with exit code 127, preventing clean JUnit output and artifact collection.

2. **Flaky tests** — Several test specs failed intermittently in CI but passed locally:
   - **poll-console-updates**: The `PollConsoleUpdates` component needs 2 poll cycles (~15s each) to initialize. In CI, OAuth redirects cause additional navigations that remount the component, but the test's response counter was counting responses from the redirect flow rather than the final component mount. Additionally, calling `page.route()` multiple times on the same URL stacks handlers in Playwright rather than replacing them, which caused interference under CI timing conditions.
   - **favorites**: The `FavoriteButton` component initializes with `isStarred=false` before user preferences load asynchronously. Clicking during this hydration window silently removes a favorite instead of opening the dialog. Additionally, `sessionStorage.lastNamespace` from prior test runs caused SPA redirects to unexpected pages.
   - **alertmanager**: YAML editor verification failed because alertmanager config propagation is eventually consistent — the old config could be returned briefly after a save.
   - **other-routes**: Route loading assertions needed longer timeouts for CI.

**Solution description**:

1. **Add `globalTimeout` to `playwright.config.ts`** — 110 minutes in CI (10 min headroom before Prow's 2h kill). Overridable via `GLOBAL_TIMEOUT_MS` env var. Unlimited locally.

2. **Default to `WORKERS=2` in `test-prow-playwright-e2e.sh`** — cuts wall-clock time roughly in half. Overridable at the job level.

3. **Simplify `workers` config** — remove the `isCI ? 1 : undefined` fallback since `WORKERS` is now always set in CI.

4. **Fix poll-console-updates tests** — Use `createMutableHandler` pattern: register one route handler per URL that delegates to a mutable reference, avoiding Playwright's handler stacking. Use `navigateAndWaitForInit` that waits for the dashboard to render and resets the response counter on `framenavigated` events, so OAuth-triggered remounts restart the initialization sequence.

5. **Fix favorites test** — Clear `console.lastNamespace` in test setup, navigate directly to `/dashboards` instead of using `warmupSPA`, and wrap click-and-dialog sequences in `expect.toPass` retry loops to handle the FavoriteButton hydration race.

6. **Fix alertmanager tests** — Wrap YAML editor verification in `expect.toPass` retry loops to handle eventual consistency of alertmanager config propagation.

7. **Fix event stream a11y** — Remove incorrect `role="row"` from the SysEvent container that caused an a11y violation.

**Screenshots / screen recording**:

N/A — CI infrastructure and test reliability only, no UI changes (except the minor a11y fix).

**Test setup:**

No special setup required.

**Test cases:**

- All 5 poll-console-updates tests pass locally with `WORKERS=2` (3/3 consecutive runs)
- Favorites test passes with cleared user preferences
- Alertmanager tests handle config propagation delays
- `grep -n globalTimeout frontend/playwright.config.ts` — confirm it's set
- `grep -n WORKERS test-prow-playwright-e2e.sh` — confirm it's exported
- Re-trigger `e2e-playwright` CI job to verify the suite completes within the 2h budget

**Browser conformance**:

N/A — no UI changes (except minor a11y fix in event-stream.tsx).

**Additional info:**

The poll-console-updates CI failure root cause: in CI, OAuth redirects (`/` → `/auth/login` → OAuth server → `/auth/callback` → `/`) cause the `PollConsoleUpdates` component to remount. The test's response counter was resolving early by counting responses from the redirect flow, then swapping the mock handler before the component had initialized in its final mount. The fix uses a navigation-aware counter that resets on `framenavigated` events, plus mutable route handlers that avoid Playwright's handler stacking behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)