### PR TITLE
OCPBUGS-99226: Disable Knative e2e cypress test

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -76,7 +76,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
 
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
-  yarn run test-cypress-knative-nightly
+  # yarn run test-cypress-knative-nightly
   exit $err;
 fi
 
@@ -85,7 +85,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-headless
   yarn run test-cypress-olm-headless
   yarn run test-cypress-helm-headless
-  yarn run test-cypress-knative-headless
+  # yarn run test-cypress-knative-headless
   exit;
 fi
 

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -32,8 +32,9 @@ elif [ "$SCENARIO" == "dev-console" ]; then
   ./integration-tests/test-cypress.sh -p dev-console -h true
 elif [ "$SCENARIO" == "pipelines" ]; then
   ./integration-tests/test-cypress.sh -p pipelines -h true
-elif [ "$SCENARIO" == "knative" ]; then
-  ./integration-tests/test-cypress.sh -p knative -h true
+# Disabled: knative-ci.feature failing in CI (OCPBUGS-82512)
+# elif [ "$SCENARIO" == "knative" ]; then
+#   ./integration-tests/test-cypress.sh -p knative -h true
 fi
 
 env NO_SANDBOX=true yarn test-puppeteer-csp


### PR DESCRIPTION
**Analysis / Root cause:**
The Knative Cypress suite (features/e2e/knative-ci.feature) is failing intermittently in CI with a perspective-switcher-menu-option timeout during the knative beforeEach hook (cy.initAdmin() → perspective switcher). This has driven a high failure rate on e2e-aws-console (including release-4.22), blocking unrelated PRs such as console-operator changes. The flake is timing-related (PatternFly menu portal + React 18 concurrent rendering), not a product regression in Knative UI.

**Solution description:**
Temporarily disable Knative Cypress execution in CI orchestration so other PRs can merge while the flake is fixed

**Test cases:**
 - CI: confirm Knative Cypress is not run in headless/nightly aggregation paths.
 - CI: confirm non-Knative Cypress suites still run as before.
 - Follow-up: re-enable Knative tests after OCPBUGS-99226 fix lands and knative/e2e-aws-console is stable.

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled Knative Cypress and end-to-end test scenarios in nightly, headless, and CI test runs.
  * Other test suites and artifact/report generation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->