### PR TITLE
OCPBUGS-90080: Validate chart URL in /api/helm/verify to prevent SSRF

### DIFF
--- a/pkg/helm/actions/get_chart.go
+++ b/pkg/helm/actions/get_chart.go
@@ -67,7 +67,7 @@ func GetChart(url string, conf *action.Configuration, repositoryNamespace string
 // Secret in namespace with username and password keys when the registry requires authentication.
 func GetChartFromURL(url string, conf *action.Configuration, namespace string, client dynamic.Interface, coreClient corev1client.CoreV1Interface, filesCleanup bool, basicAuthSecretName string) (*chart.Chart, error) {
 
-	if !isValidChartURL(url) {
+	if !IsValidChartURL(url) {
 		return nil, fmt.Errorf("invalid chart URL: %s, must be oci:// URL or http(s)://*.tgz", url)
 	}
 	cmd := action.NewInstall(conf)

--- a/pkg/helm/actions/install_chart.go
+++ b/pkg/helm/actions/install_chart.go
@@ -58,9 +58,9 @@ type RegistryClientSetter interface {
 	SetRegistryClient(rc *registry.Client)
 }
 
-// isValidChartURL validates chart URLs using RFC-compliant hostname labels.
+// IsValidChartURL validates chart URLs using RFC-compliant hostname labels.
 // Accepts oci://<registry>/<path> and http(s)://<host>/<path>.tgz|tar.gz URLs.
-func isValidChartURL(raw string) bool {
+func IsValidChartURL(raw string) bool {
 	return ociURLRe.MatchString(raw) || httpURLRe.MatchString(raw)
 }
 
@@ -324,7 +324,7 @@ func addAuthSecretAnnotation(ch *chart.Chart, secretName string) {
 // basicAuthSecretName names a Secret in ns containing username and password keys for registry auth.
 func InstallChartFromURL(ns, name, url string, vals map[string]interface{}, conf *action.Configuration, coreClient corev1client.CoreV1Interface, version, basicAuthSecretName string) (*kv1.Secret, error) {
 
-	if !isValidChartURL(url) {
+	if !IsValidChartURL(url) {
 		return nil, fmt.Errorf("invalid chart URL: %s, must be oci:// URL or http(s)://*.tgz", url)
 	}
 

--- a/pkg/helm/actions/install_chart_test.go
+++ b/pkg/helm/actions/install_chart_test.go
@@ -663,9 +663,9 @@ func TestIsValidChartURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isValidChartURL(tt.url)
+			got := IsValidChartURL(tt.url)
 			if got != tt.valid {
-				t.Errorf("isValidChartURL(%q) = %v, want %v", tt.url, got, tt.valid)
+				t.Errorf("IsValidChartURL(%q) = %v, want %v", tt.url, got, tt.valid)
 			}
 		})
 	}

--- a/pkg/helm/handlers/handlerChartVerifier.go
+++ b/pkg/helm/handlers/handlerChartVerifier.go
@@ -55,6 +55,10 @@ func (h *verifierHandlers) HandleChartVerifier(user *auth.User, w http.ResponseW
 		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
 		return
 	}
+	if !actions.IsValidChartURL(req.ChartUrl) {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: "invalid chart URL: must be oci:// or http(s)://*.tgz"})
+		return
+	}
 	conf := h.getActionConfigurations(h.ApiServerHost, "default", user.Token, &h.Transport)
 	resp, err := h.chartVerifier(req.ChartUrl, req.Values, conf)
 	if err != nil {

--- a/pkg/helm/handlers/handler_chartVerifier_test.go
+++ b/pkg/helm/handlers/handler_chartVerifier_test.go
@@ -25,8 +25,11 @@ func fakeChartVerification(reportSummary string, err error) func(chartUrl string
 	}
 }
 func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
+	validBody := `{"chart_url":"https://example.com/charts/mychart-1.0.0.tgz"}`
+
 	tests := []struct {
 		name             string
+		body             string
 		expectedResponse string
 		ReportSummary    string
 		error
@@ -34,12 +37,14 @@ func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
 	}{
 		{
 			name:             "Error occurred",
+			body:             validBody,
 			expectedResponse: `{"error":"Failed to verify chart: Chart path is invalid"}`,
 			error:            errors.New("Chart path is invalid"),
 			httpStatusCode:   http.StatusBadGateway,
 		},
 		{
 			name:             "Successful chart verification",
+			body:             validBody,
 			ReportSummary:    fakeReportSummary,
 			httpStatusCode:   http.StatusOK,
 			expectedResponse: ``,
@@ -50,7 +55,7 @@ func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
 			handlers := fakeVerifierHandler()
 			handlers.chartVerifier = fakeChartVerification(tt.ReportSummary, tt.error)
 
-			request := httptest.NewRequest("", "/foo", strings.NewReader("{}"))
+			request := httptest.NewRequest("", "/foo", strings.NewReader(tt.body))
 			response := httptest.NewRecorder()
 
 			handlers.HandleChartVerifier(&auth.User{}, response, request)
@@ -62,6 +67,33 @@ func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
 			}
 			if response.Body.String() != tt.expectedResponse {
 				t.Errorf("response body not matching expected is %s and received is %s", tt.expectedResponse, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestHelmHandlers_HandleChartVerifier_RejectsInvalidURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"rejects internal IP without tgz", `{"chart_url":"http://172.28.1.76:8849/nacos"}`},
+		{"rejects non-tgz HTTP URL", `{"chart_url":"http://example.com/charts/mychart"}`},
+		{"rejects empty chart_url", `{"chart_url":""}`},
+		{"rejects ftp scheme", `{"chart_url":"ftp://example.com/chart.tgz"}`},
+		{"rejects file scheme", `{"chart_url":"file:///etc/passwd"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := fakeVerifierHandler()
+			handlers.chartVerifier = fakeChartVerification("", nil)
+
+			request := httptest.NewRequest("POST", "/api/helm/verify", strings.NewReader(tt.body))
+			response := httptest.NewRecorder()
+
+			handlers.HandleChartVerifier(&auth.User{}, response, request)
+			if response.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400 but got %v", response.Code)
 			}
 		})
 	}


### PR DESCRIPTION
**Analysis / Root cause**:

The `/api/helm/verify` endpoint accepts a `chart_url` parameter and passes it directly to the chart-verifier library without URL validation. It allows authenticated users to force the console backend to issue requests to arbitrary internal network addresses (SSRF). The install and get-chart paths already validate URLs via `IsValidChartURL`, but the verify handler was missing this check.

**Solution description**:

I exported the existing `isValidChartURL` function and call it in `HandleChartVerifier` before invoking the chart verifier. Invalid URLs now return 400 instead of being forwarded.

**Screenshots / screen recording**:
N/A — backend-only change, no UI impact.

**Test setup:**
Run the console bridge locally with `--user-auth=disabled` against any cluster.

**Test cases:**
1. `curl -X POST http://localhost:9000/api/helm/verify -H 'Content-Type: application/json' -H 'X-CSRFToken: test' -b 'csrf-token=test' -d '{"chart_url": "http://172.28.1.76:8849/nacos"}'` → **400** `invalid chart URL`
2. `curl -X POST http://localhost:9000/api/helm/verify -H 'Content-Type: application/json' -H 'X-CSRFToken: test' -b 'csrf-token=test' -d '{"chart_url": "https://charts.helm.sh/stable/argo-cd-2.3.5.tgz"}'` → passes validation (502 chart not found, but not 400)

**Browser conformance**:
N/A — backend-only change.

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-90080


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chart verification now performs upfront `chart_url` validation and returns clear HTTP 400 errors for invalid inputs (including disallowed URL schemes and other unsupported URL formats).
  * `chart_url` validation is now applied consistently across chart loading and installation workflows.
* **Tests**
  * Updated handler tests to reuse a shared valid request payload.
  * Added coverage to confirm invalid `chart_url` requests are rejected with HTTP 400.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->