### PR TITLE
NO-JIRA: fix default namespace pull secret patch when imagePullSecrets is missing

### DIFF
--- a/frontend/public/components/modals/__tests__/configure-ns-pull-secret-modal.spec.tsx
+++ b/frontend/public/components/modals/__tests__/configure-ns-pull-secret-modal.spec.tsx
@@ -1,0 +1,143 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { ServiceAccountModel } from '../../../models';
+import {
+  k8sCreate as k8sCreateMock,
+  k8sGet as k8sGetMock,
+  k8sPatchByName as k8sPatchByNameMock,
+} from '../../../module/k8s';
+import {
+  ConfigureNamespacePullSecretModalOverlay,
+  getDefaultServiceAccountPatch,
+} from '../configure-ns-pull-secret-modal';
+
+jest.mock('../../../module/k8s', () => ({
+  ...jest.requireActual('../../../module/k8s'),
+  k8sCreate: jest.fn(),
+  k8sGet: jest.fn(),
+  k8sPatchByName: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks/usePromiseHandler', () => ({
+  usePromiseHandler: () => [jest.fn((promise: Promise<unknown>) => promise), false, ''],
+}));
+
+const namespace = {
+  metadata: {
+    name: 'test-ns',
+  },
+} as const;
+
+describe('getDefaultServiceAccountPatch', () => {
+  it('should append to imagePullSecrets when the field exists', () => {
+    expect(getDefaultServiceAccountPatch(true, 'my-pull-secret')).toEqual([
+      {
+        op: 'add',
+        path: '/imagePullSecrets/-',
+        value: { name: 'my-pull-secret' },
+      },
+    ]);
+  });
+
+  it('should initialize imagePullSecrets when the field is missing', () => {
+    expect(getDefaultServiceAccountPatch(false, 'my-pull-secret')).toEqual([
+      {
+        op: 'add',
+        path: '/imagePullSecrets',
+        value: [{ name: 'my-pull-secret' }],
+      },
+    ]);
+  });
+});
+
+describe('ConfigureNamespacePullSecretModalOverlay submit flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (k8sCreateMock as jest.Mock).mockResolvedValue({});
+    (k8sPatchByNameMock as jest.Mock).mockResolvedValue({});
+  });
+
+  const fillAndSubmitForm = async () => {
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('Secret name'), 'my-pull-secret');
+    await user.type(screen.getByLabelText('Registry address'), 'quay.io');
+    await user.type(screen.getByLabelText('Username'), 'test-user');
+    await user.type(screen.getByLabelText('Password'), 'test-password');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+  };
+
+  it('should initialize imagePullSecrets when field is missing on service account', async () => {
+    (k8sGetMock as jest.Mock).mockResolvedValue({});
+    const closeOverlay = jest.fn();
+
+    renderWithProviders(
+      <ConfigureNamespacePullSecretModalOverlay
+        namespace={namespace}
+        closeOverlay={closeOverlay}
+      />,
+    );
+
+    await fillAndSubmitForm();
+
+    await waitFor(() => {
+      expect(k8sPatchByNameMock).toHaveBeenCalledWith(
+        ServiceAccountModel,
+        'default',
+        'test-ns',
+        getDefaultServiceAccountPatch(false, 'my-pull-secret'),
+      );
+    });
+
+    expect((k8sCreateMock as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (k8sGetMock as jest.Mock).mock.invocationCallOrder[0],
+    );
+    expect((k8sGetMock as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (k8sPatchByNameMock as jest.Mock).mock.invocationCallOrder[0],
+    );
+    await waitFor(() => {
+      expect(closeOverlay).toHaveBeenCalled();
+    });
+  });
+
+  it('should append to imagePullSecrets when field exists on service account', async () => {
+    (k8sGetMock as jest.Mock).mockResolvedValue({ imagePullSecrets: [] });
+    const closeOverlay = jest.fn();
+
+    renderWithProviders(
+      <ConfigureNamespacePullSecretModalOverlay
+        namespace={namespace}
+        closeOverlay={closeOverlay}
+      />,
+    );
+
+    await fillAndSubmitForm();
+
+    await waitFor(() => {
+      expect(k8sPatchByNameMock).toHaveBeenCalledWith(
+        ServiceAccountModel,
+        'default',
+        'test-ns',
+        getDefaultServiceAccountPatch(true, 'my-pull-secret'),
+      );
+    });
+  });
+
+  it('should fetch the default service account before patching', async () => {
+    (k8sGetMock as jest.Mock).mockResolvedValue({});
+    const closeOverlay = jest.fn();
+
+    renderWithProviders(
+      <ConfigureNamespacePullSecretModalOverlay
+        namespace={namespace}
+        closeOverlay={closeOverlay}
+      />,
+    );
+
+    await fillAndSubmitForm();
+
+    await waitFor(() => {
+      expect(k8sGetMock).toHaveBeenCalledWith(ServiceAccountModel, 'default', 'test-ns', {});
+    });
+  });
+});

--- a/frontend/public/components/modals/configure-ns-pull-secret-modal.tsx
+++ b/frontend/public/components/modals/configure-ns-pull-secret-modal.tsx
@@ -23,7 +23,7 @@ import type { FC, ChangeEvent, FormEvent } from 'react';
 import { CONST } from '@console/shared/src/constants/common';
 import { usePromiseHandler } from '@console/shared/src/hooks/usePromiseHandler';
 import { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal-support/OverlayProvider';
-import { k8sPatchByName, k8sCreate, K8sResourceKind } from '../../module/k8s';
+import { k8sPatchByName, k8sCreate, k8sGet, K8sResourceKind } from '../../module/k8s';
 import { SecretModel, ServiceAccountModel } from '../../models';
 import { useState, useCallback } from 'react';
 import { ModalComponentProps } from '@console/shared/src/types/modal';
@@ -61,6 +61,26 @@ interface ConfigureNamespacePullSecretProps extends ModalComponentProps {
   namespace: K8sResourceKind;
   pullSecret?: K8sResourceKind;
 }
+
+export const getDefaultServiceAccountPatch = (
+  hasImagePullSecretsField: boolean,
+  pullSecretName: string,
+) =>
+  hasImagePullSecretsField
+    ? [
+        {
+          op: 'add',
+          path: '/imagePullSecrets/-',
+          value: { name: pullSecretName },
+        },
+      ]
+    : [
+        {
+          op: 'add',
+          path: '/imagePullSecrets',
+          value: [{ name: pullSecretName }],
+        },
+      ];
 
 const ConfigureNamespacePullSecret: FC<ConfigureNamespacePullSecretProps> = (props) => {
   const { namespace, cancel, close } = props;
@@ -131,21 +151,21 @@ const ConfigureNamespacePullSecret: FC<ConfigureNamespacePullSecretProps> = (pro
         data,
         type: CONST.PULL_SECRET_TYPE,
       };
-      const defaultServiceAccountPatch = [
-        {
-          op: 'add' as const,
-          path: '/imagePullSecrets/-',
-          value: { name: pullSecretName },
-        },
-      ];
-      const promise = k8sCreate(SecretModel, secret).then(() =>
-        k8sPatchByName(
-          ServiceAccountModel,
-          'default',
-          namespace.metadata.name,
-          defaultServiceAccountPatch,
-        ),
-      );
+      const promise = k8sCreate(SecretModel, secret)
+        .then(() => k8sGet(ServiceAccountModel, 'default', namespace.metadata.name, {}))
+        .then((serviceAccount) => {
+          const defaultServiceAccountPatch = getDefaultServiceAccountPatch(
+            _.has(serviceAccount, 'imagePullSecrets'),
+            pullSecretName,
+          );
+
+          return k8sPatchByName(
+            ServiceAccountModel,
+            'default',
+            namespace.metadata.name,
+            defaultServiceAccountPatch,
+          );
+        });
 
       handlePromise(promise).then(close);
     },


### PR DESCRIPTION
## Problem
Creating a default pull secret in a newly created namespace can fail with an invalid ServiceAccount patch request.

## Root cause
The submit flow always attempted to append using JSON patch path `/imagePullSecrets/-` on the default ServiceAccount.
For new namespaces, `imagePullSecrets` may not exist yet, so append-to-array fails.

## Solution
- Fetch the latest default ServiceAccount during submit.
- Choose patch strategy based on live field presence:
  - If `imagePullSecrets` exists: append to `/imagePullSecrets/-`
  - If missing: initialize `/imagePullSecrets` with the new secret entry
- Add focused tests for:
  - patch selection helper behavior
  - submit-flow call sequencing (`k8sCreate -> k8sGet -> k8sPatchByName`)
  - expected `k8sGet` call arguments
  - async close assertion stability

## Testing
- `node .yarn/releases/yarn-4.14.1.cjs test public/components/modals/__tests__/configure-ns-pull-secret-modal.spec.tsx public/components/__tests__/namespace.spec.tsx --runInBand`
- `node .yarn/releases/yarn-4.14.1.cjs eslint public/components/modals/configure-ns-pull-secret-modal.tsx public/components/modals/__tests__/configure-ns-pull-secret-modal.spec.tsx`

## Notes
- Existing non-blocking console warnings appear during Jest startup in this environment, but test suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace pull secret configuration when the default service account does not already define image pull secrets.
  * Pull secrets are now correctly added whether the service account has an existing image pull secret list or not.
  * Improved successful submission handling by ensuring the configuration modal closes after the service account is updated.

* **Tests**
  * Added coverage for pull secret patch generation and submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->