### PR TITLE
[release-4.14] OCPBUGS-88422: Bump axios to ^0.33.0 Addresses CVE-2026-44486

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^0.31.1",
+    "axios": "^0.33.0",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
@@ -359,7 +359,7 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "axios": "^0.31.1",
+    "axios": "^0.33.0",
     "immutable": "3.8.3"
   },
   "husky": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7184,14 +7184,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.31.1":
-  version: 0.31.1
-  resolution: "axios@npm:0.31.1"
+"axios@npm:^0.33.0":
+  version: 0.33.0
+  resolution: "axios@npm:0.33.0"
   dependencies:
     follow-redirects: "npm:^1.15.4"
     form-data: "npm:^4.0.4"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/0193483f680a893955d203d26951fc427c407415d273bba5a2450e3d0ed7261a403eb5fe86f28a7e66c42d98597cbf8e17e3a6c324d294bd143a6a68bc10f8ef
+  checksum: 10c0/9e8ae9d26768a9884c121c33286f6b85fe915cf1bb1c0ac7adff2def81e18b4b7c5bb9630dec3900ec88c037822d602439f2bff23d15c41c2216b89b27fbe524
   languageName: node
   linkType: hard
 
@@ -20822,7 +20822,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^0.31.1"
+    axios: "npm:^0.33.0"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"


### PR DESCRIPTION
OCPBUGS-88422: Bump axios to ^0.33.0 Addresses CVE-2026-44486
https://redhat.atlassian.net/browse/OCPBUGS-88422 

**Steps involved in Axios bump for release-4.14:**
1. Edit frontend/package.json
   update references to axios version in package.json to  "axios": "^0.33.0",

2. Reinstall lockfile
      cd frontend
      yarn install

**Testing:**
 from repo root/

./build-frontend.sh
./build-demos.sh

 from frontend/
 yarn build
Output from the above steps was analysed by Claude - no issues