### PR TITLE
Fix authenticated SSRF in Dev Console webhook helpers

### DIFF
--- a/pkg/devconsole/common/types.go
+++ b/pkg/devconsole/common/types.go
@@ -1,9 +1,24 @@
 package common
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 type DevConsoleCommonResponse struct {
 	StatusCode int         `json:"statusCode"`
 	Headers    http.Header `json:"headers"`
 	Body       string      `json:"body"`
+}
+
+type ValidationError struct {
+	Err error
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validation error: %v", e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
 }

--- a/pkg/devconsole/handler.go
+++ b/pkg/devconsole/handler.go
@@ -1,11 +1,13 @@
 package devconsole
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/devconsole/artifacthub"
+	"github.com/openshift/console/pkg/devconsole/common"
 	tektonresults "github.com/openshift/console/pkg/devconsole/tekton-results"
 	"github.com/openshift/console/pkg/devconsole/webhooks"
 	"github.com/openshift/console/pkg/serverutils"
@@ -17,6 +19,11 @@ type handlerFunc func(r *http.Request, user *auth.User, dynamicClient *dynamic.D
 func handleRequest(w http.ResponseWriter, r *http.Request, user *auth.User, dynamicClient *dynamic.DynamicClient, k8sMode string, proxyHeaderDenyList []string, handler handlerFunc) {
 	response, err := handler(r, user, dynamicClient, k8sMode, proxyHeaderDenyList)
 	if err != nil {
+		var validationErr *common.ValidationError
+		if errors.As(err, &validationErr) {
+			serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: err.Error()})
+			return
+		}
 		serverutils.SendResponse(w, http.StatusInternalServerError, serverutils.ApiError{Err: err.Error()})
 		return
 	}

--- a/pkg/devconsole/webhooks/validation.go
+++ b/pkg/devconsole/webhooks/validation.go
@@ -1,0 +1,139 @@
+package webhooks
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var privateRanges []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"0.0.0.0/8",
+		"100.64.0.0/10",
+		"::1/128",
+		"fc00::/7",
+		"fe80::/10",
+	} {
+		_, block, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("invalid CIDR %q: %v", cidr, err))
+		}
+		privateRanges = append(privateRanges, block)
+	}
+}
+
+func isPrivateIP(ip net.IP) bool {
+	for _, block := range privateRanges {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+var internalHostSuffixes = []string{
+	".svc",
+	".svc.cluster.local",
+	".pod.cluster.local",
+}
+
+var internalHostExact = []string{
+	"kubernetes",
+	"kubernetes.default",
+	"localhost",
+}
+
+func isInternalHostname(hostname string) bool {
+	h := strings.ToLower(hostname)
+	for _, exact := range internalHostExact {
+		if h == exact {
+			return true
+		}
+	}
+	for _, suffix := range internalHostSuffixes {
+		if strings.HasSuffix(h, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveIP is a package-level variable so tests can override DNS resolution.
+var resolveIP = net.LookupIP
+
+func validateHostURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %v", err)
+	}
+
+	if parsed.Scheme != "https" {
+		return nil, fmt.Errorf("only https URLs are allowed, got %q", parsed.Scheme)
+	}
+
+	if parsed.Hostname() == "" {
+		return nil, fmt.Errorf("URL must have a hostname")
+	}
+
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("URL must not contain query or fragment")
+	}
+
+	if parsed.User != nil {
+		return nil, fmt.Errorf("URL must not contain user info")
+	}
+
+	if isInternalHostname(parsed.Hostname()) {
+		return nil, fmt.Errorf("URL must not target cluster-internal services")
+	}
+
+	ips, err := resolveIP(parsed.Hostname())
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve hostname %q: %v", parsed.Hostname(), err)
+	}
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return nil, fmt.Errorf("URL must not resolve to a private IP address")
+		}
+	}
+
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+
+	return parsed, nil
+}
+
+func ssrfDialControl(network, address string, c syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("invalid address: %v", err)
+	}
+	ip := net.ParseIP(host)
+	if ip != nil && isPrivateIP(ip) {
+		return fmt.Errorf("connections to private IP addresses are not allowed")
+	}
+	return nil
+}
+
+func newSafeHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout: 10 * time.Second,
+				Control: ssrfDialControl,
+			}).DialContext,
+		},
+	}
+}

--- a/pkg/devconsole/webhooks/validation_test.go
+++ b/pkg/devconsole/webhooks/validation_test.go
@@ -1,0 +1,202 @@
+package webhooks
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback v6", "::1", true},
+		{"class A private", "10.0.0.1", true},
+		{"class A private high", "10.255.255.255", true},
+		{"class B private", "172.16.0.1", true},
+		{"class B private high", "172.31.255.255", true},
+		{"class C private", "192.168.1.1", true},
+		{"link-local", "169.254.1.1", true},
+		{"zero network", "0.0.0.1", true},
+		{"ULA v6", "fd00::1", true},
+		{"link-local v6", "fe80::1", true},
+		{"CGNAT", "100.64.0.1", true},
+		{"CGNAT high", "100.127.255.255", true},
+		{"not CGNAT", "100.128.0.1", false},
+		{"public IP", "8.8.8.8", false},
+		{"public IP 2", "1.1.1.1", false},
+		{"public v6", "2001:4860:4860::8888", false},
+		{"not private class B", "172.32.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			assert.NotNil(t, ip, "failed to parse IP %s", tt.ip)
+			assert.Equal(t, tt.expected, isPrivateIP(ip))
+		})
+	}
+}
+
+func TestIsInternalHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		expected bool
+	}{
+		{"kubernetes", "kubernetes", true},
+		{"kubernetes.default", "kubernetes.default", true},
+		{"localhost", "localhost", true},
+		{"svc suffix", "my-service.my-ns.svc", true},
+		{"svc.cluster.local suffix", "my-service.my-ns.svc.cluster.local", true},
+		{"pod.cluster.local suffix", "10-0-0-1.my-ns.pod.cluster.local", true},
+		{"case insensitive", "Kubernetes", true},
+		{"github.com", "github.com", false},
+		{"gitlab.com", "gitlab.com", false},
+		{"custom host", "git.example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isInternalHostname(tt.hostname))
+		})
+	}
+}
+
+func TestValidateHostURL(t *testing.T) {
+	// Override DNS resolution for testing
+	originalResolveIP := resolveIP
+	defer func() { resolveIP = originalResolveIP }()
+
+	publicIP := []net.IP{net.ParseIP("203.0.113.1")}
+	privateIP := []net.IP{net.ParseIP("10.0.0.1")}
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		mockIPs   []net.IP
+		mockErr   error
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid HTTPS URL",
+			rawURL:  "https://github.com",
+			mockIPs: publicIP,
+			wantErr: false,
+		},
+		{
+			name:    "valid HTTPS URL with path",
+			rawURL:  "https://github.example.com/api",
+			mockIPs: publicIP,
+			wantErr: false,
+		},
+		{
+			name:      "HTTP not allowed",
+			rawURL:    "http://github.com",
+			mockIPs:   publicIP,
+			wantErr:   true,
+			errSubstr: "only https",
+		},
+		{
+			name:      "empty scheme",
+			rawURL:    "github.com",
+			mockIPs:   publicIP,
+			wantErr:   true,
+			errSubstr: "only https",
+		},
+		{
+			name:      "query string rejected",
+			rawURL:    "https://github.com?foo=bar",
+			mockIPs:   publicIP,
+			wantErr:   true,
+			errSubstr: "query or fragment",
+		},
+		{
+			name:      "fragment rejected",
+			rawURL:    "https://github.com#section",
+			mockIPs:   publicIP,
+			wantErr:   true,
+			errSubstr: "query or fragment",
+		},
+		{
+			name:      "userinfo rejected",
+			rawURL:    "https://user:pass@github.com",
+			mockIPs:   publicIP,
+			wantErr:   true,
+			errSubstr: "user info",
+		},
+		{
+			name:      "kubernetes internal hostname",
+			rawURL:    "https://kubernetes.default",
+			wantErr:   true,
+			errSubstr: "cluster-internal",
+		},
+		{
+			name:      "svc internal hostname",
+			rawURL:    "https://my-service.my-ns.svc",
+			wantErr:   true,
+			errSubstr: "cluster-internal",
+		},
+		{
+			name:      "svc.cluster.local hostname",
+			rawURL:    "https://my-service.my-ns.svc.cluster.local",
+			wantErr:   true,
+			errSubstr: "cluster-internal",
+		},
+		{
+			name:      "localhost",
+			rawURL:    "https://localhost",
+			wantErr:   true,
+			errSubstr: "cluster-internal",
+		},
+		{
+			name:      "resolves to private IP",
+			rawURL:    "https://internal.example.com",
+			mockIPs:   privateIP,
+			wantErr:   true,
+			errSubstr: "private IP",
+		},
+		{
+			name:      "DNS resolution fails",
+			rawURL:    "https://nonexistent.invalid",
+			mockErr:   &net.DNSError{Err: "no such host", Name: "nonexistent.invalid"},
+			wantErr:   true,
+			errSubstr: "failed to resolve",
+		},
+		{
+			name:    "trailing slash stripped",
+			rawURL:  "https://github.com/",
+			mockIPs: publicIP,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolveIP = func(host string) ([]net.IP, error) {
+				if tt.mockErr != nil {
+					return nil, tt.mockErr
+				}
+				return tt.mockIPs, nil
+			}
+
+			result, err := validateHostURL(tt.rawURL)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errSubstr != "" {
+					assert.Contains(t, err.Error(), tt.errSubstr)
+				}
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, "https", result.Scheme)
+			}
+		})
+	}
+}

--- a/pkg/devconsole/webhooks/webhooks.go
+++ b/pkg/devconsole/webhooks/webhooks.go
@@ -7,18 +7,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"slices"
 
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/devconsole/common"
 )
 
-var client *http.Client = &http.Client{
-	Transport: &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-	},
-}
+const maxResponseBodySize = 10 * 1024 * 1024 // 10 MB
+
+var webhookHeaderDenyList = []string{"Host", "Authorization"}
+
+var client = newSafeHTTPClient()
 
 func makeHTTPRequest(ctx context.Context, url string, headers http.Header, body []byte, proxyHeaderDenyList []string) (common.DevConsoleCommonResponse, error) {
 	serviceRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
@@ -27,7 +26,15 @@ func makeHTTPRequest(ctx context.Context, url string, headers http.Header, body 
 	}
 
 	for key, values := range headers {
-		if slices.Contains(proxyHeaderDenyList, key) {
+		canonicalKey := http.CanonicalHeaderKey(key)
+		if slices.ContainsFunc(proxyHeaderDenyList, func(deny string) bool {
+			return http.CanonicalHeaderKey(deny) == canonicalKey
+		}) {
+			continue
+		}
+		if slices.ContainsFunc(webhookHeaderDenyList, func(deny string) bool {
+			return http.CanonicalHeaderKey(deny) == canonicalKey
+		}) {
 			continue
 		}
 		for _, value := range values {
@@ -40,9 +47,14 @@ func makeHTTPRequest(ctx context.Context, url string, headers http.Header, body 
 		return common.DevConsoleCommonResponse{}, fmt.Errorf("failed to send request: %v", err)
 	}
 	defer serviceResponse.Body.Close()
-	serviceResponseBody, err := io.ReadAll(serviceResponse.Body)
+
+	limitedReader := io.LimitReader(serviceResponse.Body, maxResponseBodySize+1)
+	serviceResponseBody, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return common.DevConsoleCommonResponse{}, fmt.Errorf("failed to read response body: %v", err)
+	}
+	if len(serviceResponseBody) > maxResponseBodySize {
+		return common.DevConsoleCommonResponse{}, fmt.Errorf("response body exceeds maximum allowed size of %d bytes", maxResponseBodySize)
 	}
 
 	return common.DevConsoleCommonResponse{
@@ -53,7 +65,6 @@ func makeHTTPRequest(ctx context.Context, url string, headers http.Header, body 
 }
 
 func CreateGithubWebhook(r *http.Request, user *auth.User, proxyHeaderDenyList []string) (common.DevConsoleCommonResponse, error) {
-	// POST /api/dev-console/webhooks/github
 	var request GithubWebhookRequest
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
@@ -65,19 +76,16 @@ func CreateGithubWebhook(r *http.Request, user *auth.User, proxyHeaderDenyList [
 		return common.DevConsoleCommonResponse{}, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	GH_WEBHOOK_URL := fmt.Sprintf("%s/repos/%s/%s/hooks",
-		request.HostName,
-		url.PathEscape(request.Owner),
-		url.PathEscape(request.RepoName),
-	)
+	baseURL, err := validateHostURL(request.HostName)
+	if err != nil {
+		return common.DevConsoleCommonResponse{}, &common.ValidationError{Err: fmt.Errorf("invalid hostName: %v", err)}
+	}
+	webhookURL := baseURL.JoinPath("repos", request.Owner, request.RepoName, "hooks")
 
-	return makeHTTPRequest(r.Context(), GH_WEBHOOK_URL, request.Headers, bodyBytes, proxyHeaderDenyList)
-
+	return makeHTTPRequest(r.Context(), webhookURL.String(), request.Headers, bodyBytes, proxyHeaderDenyList)
 }
 
 func CreateGitlabWebhook(r *http.Request, user *auth.User, proxyHeaderDenyList []string) (common.DevConsoleCommonResponse, error) {
-	// POST /api/dev-console/webhooks/gitlab
-
 	var request GitlabWebhookRequest
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
@@ -89,17 +97,16 @@ func CreateGitlabWebhook(r *http.Request, user *auth.User, proxyHeaderDenyList [
 		return common.DevConsoleCommonResponse{}, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	GL_WEBHOOK_URL := fmt.Sprintf("%s/api/v4/projects/%s/hooks",
-		request.HostName,
-		url.PathEscape(request.ProjectID),
-	)
+	baseURL, err := validateHostURL(request.HostName)
+	if err != nil {
+		return common.DevConsoleCommonResponse{}, &common.ValidationError{Err: fmt.Errorf("invalid hostName: %v", err)}
+	}
+	webhookURL := baseURL.JoinPath("api", "v4", "projects", request.ProjectID, "hooks")
 
-	return makeHTTPRequest(r.Context(), GL_WEBHOOK_URL, request.Headers, bodyBytes, proxyHeaderDenyList)
+	return makeHTTPRequest(r.Context(), webhookURL.String(), request.Headers, bodyBytes, proxyHeaderDenyList)
 }
 
 func CreateBitbucketWebhook(r *http.Request, user *auth.User, proxyHeaderDenyList []string) (common.DevConsoleCommonResponse, error) {
-	// POST /api/dev-console/webhooks/bitbucket
-
 	var request BitbucketWebhookRequest
 	err := json.NewDecoder(r.Body).Decode(&request)
 	if err != nil {
@@ -111,20 +118,17 @@ func CreateBitbucketWebhook(r *http.Request, user *auth.User, proxyHeaderDenyLis
 		return common.DevConsoleCommonResponse{}, fmt.Errorf("failed to marshal request body: %v", err)
 	}
 
-	var BB_WEBHOOK_URL string
-	if request.IsServer {
-		BB_WEBHOOK_URL = fmt.Sprintf("%s/projects/%s/repos/%s/hooks",
-			request.BaseURL,
-			url.PathEscape(request.Owner),
-			url.PathEscape(request.RepoName),
-		)
-	} else {
-		BB_WEBHOOK_URL = fmt.Sprintf("%s/repositories/%s/%s/hooks",
-			request.BaseURL,
-			url.PathEscape(request.Owner),
-			url.PathEscape(request.RepoName),
-		)
+	baseURL, err := validateHostURL(request.BaseURL)
+	if err != nil {
+		return common.DevConsoleCommonResponse{}, &common.ValidationError{Err: fmt.Errorf("invalid baseURL: %v", err)}
 	}
 
-	return makeHTTPRequest(r.Context(), BB_WEBHOOK_URL, request.Headers, bodyBytes, proxyHeaderDenyList)
+	var webhookURL string
+	if request.IsServer {
+		webhookURL = baseURL.JoinPath("projects", request.Owner, "repos", request.RepoName, "hooks").String()
+	} else {
+		webhookURL = baseURL.JoinPath("repositories", request.Owner, request.RepoName, "hooks").String()
+	}
+
+	return makeHTTPRequest(r.Context(), webhookURL, request.Headers, bodyBytes, proxyHeaderDenyList)
 }

--- a/pkg/devconsole/webhooks/webhooks_test.go
+++ b/pkg/devconsole/webhooks/webhooks_test.go
@@ -1,0 +1,103 @@
+package webhooks
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeHTTPRequest_HeaderFiltering(t *testing.T) {
+	var receivedHeaders http.Header
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "ok")
+	}))
+	defer ts.Close()
+
+	originalClient := client
+	client = ts.Client()
+	defer func() { client = originalClient }()
+
+	denyList := []string{"Cookie", "X-CSRFToken"}
+
+	tests := []struct {
+		name        string
+		headerKey   string
+		shouldBlock bool
+	}{
+		{"exact match Cookie", "Cookie", true},
+		{"lowercase cookie", "cookie", true},
+		{"uppercase COOKIE", "COOKIE", true},
+		{"mixed case cOoKiE", "cOoKiE", true},
+		{"exact X-CSRFToken", "X-CSRFToken", true},
+		{"lowercase x-csrftoken", "x-csrftoken", true},
+		{"webhook-denied Authorization", "Authorization", true},
+		{"webhook-denied authorization lowercase", "authorization", true},
+		{"webhook-denied Host", "Host", true},
+		{"allowed header Content-Type", "Content-Type", false},
+		{"allowed header Accept", "Accept", false},
+		{"allowed header X-Custom", "X-Custom-Header", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receivedHeaders = nil
+			headers := http.Header{}
+			headers.Set(tt.headerKey, "test-value")
+
+			_, err := makeHTTPRequest(context.Background(), ts.URL+"/test", headers, []byte("{}"), denyList)
+			assert.NoError(t, err)
+
+			canonicalKey := http.CanonicalHeaderKey(tt.headerKey)
+			if tt.shouldBlock {
+				assert.Empty(t, receivedHeaders.Values(canonicalKey),
+					"header %q should have been blocked but was forwarded", tt.headerKey)
+			} else {
+				assert.Equal(t, "test-value", receivedHeaders.Get(canonicalKey),
+					"header %q should have been forwarded but was stripped", tt.headerKey)
+			}
+		})
+	}
+}
+
+func TestMakeHTTPRequest_ResponseSizeLimit(t *testing.T) {
+	largeBody := strings.Repeat("x", maxResponseBodySize+100)
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, largeBody)
+	}))
+	defer ts.Close()
+
+	originalClient := client
+	client = ts.Client()
+	defer func() { client = originalClient }()
+
+	_, err := makeHTTPRequest(context.Background(), ts.URL+"/test", http.Header{}, []byte("{}"), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
+func TestMakeHTTPRequest_NormalResponse(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "response-header")
+		w.WriteHeader(http.StatusCreated)
+		io.WriteString(w, `{"id": 123}`)
+	}))
+	defer ts.Close()
+
+	originalClient := client
+	client = ts.Client()
+	defer func() { client = originalClient }()
+
+	resp, err := makeHTTPRequest(context.Background(), ts.URL+"/test", http.Header{}, []byte("{}"), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, `{"id": 123}`, resp.Body)
+	assert.Equal(t, "response-header", resp.Headers.Get("X-Test"))
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook destinations now require secure HTTPS URLs and reject invalid, internal, or private-network addresses.
  - Webhook URLs are normalized consistently across GitHub, GitLab, and Bitbucket integrations.
  - Requests now limit response sizes and prevent sensitive headers from being forwarded.

- **Bug Fixes**
  - Invalid webhook configuration errors now return a clear HTTP 400 response instead of a generic server error.
  - Webhook requests use safer connection handling and improved URL construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->