### PR TITLE
NO-ISSUE: Add width constraints to lifecycle table columns

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -166,8 +166,8 @@ const managedNamespacesColumnClass = css('pf-m-hidden', 'pf-m-visible-on-sm');
 const statusColumnClass = css('pf-m-hidden', 'pf-m-visible-on-lg');
 const lastUpdatedColumnClass = css('pf-m-hidden', 'pf-m-visible-on-2xl');
 const providedAPIsColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl');
-const clusterCompatibilityColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl');
-const supportPhaseColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl');
+const clusterCompatibilityColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl', 'pf-m-width-15');
+const supportPhaseColumnClass = css('pf-m-hidden', 'pf-m-visible-on-xl', 'pf-m-width-15');
 
 const SubscriptionStatus: FC<{ muted?: boolean; subscription: SubscriptionKind }> = ({
   muted = false,


### PR DESCRIPTION
**Analysis / Root cause**:
The Cluster compatibility and Support phase columns added to the Installed Operators table share the same responsive class as Provided APIs (`pf-m-hidden pf-m-visible-on-xl`) with no explicit width constraint. When lifecycle data loads and renders badge content (e.g. "Incompatible", "General availability") instead of the "-" fallback, the unconstrained columns compete with Provided APIs for space, causing content to overflow and rows to overlap.

**Solution description**:
Add `pf-m-width-15` to both `clusterCompatibilityColumnClass` and `supportPhaseColumnClass` so each lifecycle column claims a fixed 15% of the table width, keeping them bounded and leaving Provided APIs its natural allocation.

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
Enable the operator lifecycle metadata feature flag and navigate to the Installed Operators page with multiple operators installed.

**Test cases:**
- [ ] Verify lifecycle columns render within their 15% width allocation
- [ ] Verify Provided APIs column text does not overlap with adjacent rows
- [ ] Verify row content does not visually bleed into neighboring rows
- [ ] Verify table renders correctly at xl and 2xl breakpoints

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Single two-line change to add PatternFly width modifier classes.

**Reviewers and assignees:**
<!-- Tag reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Cluster Compatibility and Support Phase table columns to use consistent widths, improving layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->