### PR TITLE
OCPBUGS-88416 OCPBUGS-88398: Bump Axios to fix CVE-2026-44486. Requires a Patch of axios 0.33.0 types to be compatible with old version of TS

### DIFF
--- a/frontend/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch
+++ b/frontend/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch
@@ -1,0 +1,17 @@
+diff --git a/index.d.ts b/index.d.ts
+index ac6b9f5f95d258493e5ce026386be0ab88e423c0..c68c3fd8b51fd0c4a96c844c573167ed1704562b 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -3,8 +3,11 @@ type HeaderValue = string | string[] | number | boolean;
+ 
+ type AxiosHeaders = Record<string, HeaderValue | Record<Method & CommonHeaders, HeaderValue>>;
+ 
++type LowercaseMethod =
++| 'get' | 'delete' | 'head' | 'options' | 'post'
++| 'put' | 'patch' | 'purge' | 'link' | 'unlink';
+ type MethodsHeaders = {
+-  [Key in Method as Lowercase<Key>]: AxiosHeaders;
++[Key in LowercaseMethod]?: AxiosHeaders;
+ };
+ 
+ interface CommonHeaders  {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-http": "^1.0.20",
     "apollo-link-ws": "^1.0.20",
-    "axios": "^0.21.2",
+    "axios": "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch",
     "classnames": "2.x",
     "d3": "^5.16.0",
     "file-saver": "1.3.x",
@@ -353,7 +353,8 @@
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
     "postcss": "^8.2.13",
-    "immutable": "3.8.3"
+    "immutable": "3.8.3",
+    "axios@npm:^0.21.1": "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch"
   },
   "husky": {
     "hooks": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6987,12 +6987,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1, axios@npm:^0.21.2":
-  version: 0.21.4
-  resolution: "axios@npm:0.21.4"
+"axios@npm:0.33.0":
+  version: 0.33.0
+  resolution: "axios@npm:0.33.0"
   dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10c0/fbcff55ec68f71f02d3773d467db2fcecdf04e749826c82c2427a232f9eba63242150a05f15af9ef15818352b814257541155de0281f8fb2b7e8a5b79f7f2142
+    follow-redirects: "npm:^1.15.4"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/9e8ae9d26768a9884c121c33286f6b85fe915cf1bb1c0ac7adff2def81e18b4b7c5bb9630dec3900ec88c037822d602439f2bff23d15c41c2216b89b27fbe524
+  languageName: node
+  linkType: hard
+
+"axios@patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch":
+  version: 0.33.0
+  resolution: "axios@patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch::version=0.33.0&hash=3bb469"
+  dependencies:
+    follow-redirects: "npm:^1.15.4"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/52aa84dbb08a9851bbc767f2ddf5b0b697384270d20c922e44f78a72b4af9911cae0f083e082386ace9b97827d4ed496325459ba634288463b70f432c2730725
   languageName: node
   linkType: hard
 
@@ -8964,7 +8977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:~1.0.5, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.5, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -11751,6 +11764,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
 "es-to-primitive@npm:^1.1.1, es-to-primitive@npm:^1.2.0":
   version: 1.2.0
   resolution: "es-to-primitive@npm:1.2.0"
@@ -13253,13 +13278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0":
-  version: 1.14.3
-  resolution: "follow-redirects@npm:1.14.3"
+"follow-redirects@npm:^1.15.4":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/02c94952aa0ce0b0d4fd45cb7af4cce5df37158a1757f9528f9488c3a2ed89b7d630764ba1e09918b98b5d9affbc3e06abc4fce90fb5608a79b10a9a81926e6c
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -13318,6 +13343,19 @@ __metadata:
     combined-stream: "npm:^1.0.6"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/7e8fb913b84a7ac04074781a18d0f94735bbe82815ff35348803331f6480956ff0035db5bcf15826edee09fe01e665cfac664678f1526646a6374ee13f960e56
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.4":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -13678,7 +13716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -14645,6 +14683,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -18787,6 +18834,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
 "mime-db@npm:~1.37.0":
   version: 1.37.0
   resolution: "mime-db@npm:1.37.0"
@@ -18809,6 +18863,15 @@ __metadata:
   dependencies:
     mime-db: "npm:1.49.0"
   checksum: 10c0/26e48e64c91ea9554b851cfc62f6147bb1decfd077cc340c0c2cfefc39d88db9d99876fa7065c577e2225a624d087a09a9d9523e6a00dfe62b6bc96225862082
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.35":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 
@@ -20198,7 +20261,7 @@ __metadata:
     apollo-client: "npm:^2.6.8"
     apollo-link-http: "npm:^1.0.20"
     apollo-link-ws: "npm:^1.0.20"
-    axios: "npm:^0.21.2"
+    axios: "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch"
     babel-loader: "npm:^8.2.1"
     browser-env: "npm:3.x"
     cache-loader: "npm:^4.1.0"


### PR DESCRIPTION
OCPBUGS-88416: Bump Axios to fix CVE-2026-44486. Requires a Patch of axios 0.33.0 types to be compatible with an older version of TypeScript 
Fixes CVE-2026-44486.
https://redhat.atlassian.net/browse/OCPBUGS-88416

How this patch was generated:
Step 1:
From frontend/:

Point deps at unpatched 0.33.0 temporarily i.e. In frontend/package.json:
Dependency:
"axios": "0.33.0"

Step 2:
cd frontend
yarn install
yarn patch axios@npm:0.33.0
Yarn prints a temp folder path.

For example:

yarn patch axios@npm:0.33.0
➤ YN0000: Package axios@npm:0.33.0 got extracted with success!
➤ YN0000: You can now edit the following folder: /private/var/folders/xh/64_dr2_j14s6q3vdq008bj9r0000gn/T/xfs-9ac099cb/user
➤ YN0000: Once you are done run yarn patch-commit -s /private/var/folders/xh/64_dr2_j14s6q3vdq008bj9r0000gn/T/xfs-9ac099cb/user and Yarn will store a patchfile based on your changes.
➤ YN0000: Done in 0s 23ms

Apply the same TypeScript fix in that folder’s index.d.ts
For example:
get the directory that is listed e.g./private/var/folders/xh/64_dr2_j14s6q3vdq008bj9r0000gn/T/xfs-8bb6f632/user
in that folder, edit and save the file index.d.ts
replace
type MethodsHeaders = {
[Key in Method as Lowercase]: AxiosHeaders;
};
with
type LowercaseMethod =
| 'get' | 'delete' | 'head' | 'options' | 'post'
| 'put' | 'patch' | 'purge' | 'link' | 'unlink';

type MethodsHeaders = {
[Key in LowercaseMethod]?: AxiosHeaders;
};

Step 3:
Apply changes:
yarn patch-commit -s /private/var/folders/xh/64_dr2_j14s6q3vdq008bj9r0000gn/T/xfs-9ac099cb/user
yarn install
yarn build

Step 4: 
Add and commit changes etc
to determine the name of the patch, find it in the folder .yarn/patches - it will start with the name axios-npm-0.33.0

git add .yarn/patches/axios-npm-0.33.0-023deda7e4.patch
git add package.json
git add yarn.lock
git commit -m "OCPBUGS-88416: Bump Axios to fix CVE-2026-44486. Requires a Patch of axios 0.33.0 types to be compatible with older version of TypeScript"
git push

**Testing**
in the main console folder, 
Test 1
 ./build-frontend.sh > test-4.12.axios-bump.txt
 The output file was anlaysed by Claude:
Verdict: PASS — ./build-frontend.sh succeeded on release-4.12-260721 with the axios 0.33.0 Yarn type patch.

Test 2
./build-demos.sh > test-4.12-build-demos.txt
The output file was anlaysed by Claude:
Verdict: PASS - webpack 5.73.0 compiled successfully in 5628 ms
