### PR TITLE
OCPBUGS-99475: Fix virtualized table row overlap after react-virtualized 9.22.6 upgrade

### DIFF
--- a/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
+++ b/frontend/public/components/factory/Table/VirtualizedTableBody.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import { VirtualTableBody } from '@patternfly/react-virtualized-extension';
 import type { Scroll } from '@patternfly/react-virtualized-extension/dist/esm/components/Virtualized/types';
@@ -61,11 +61,17 @@ const VirtualizedTableBody = <D extends any, R extends any = {}>({
   onRowsRendered,
   onSelect,
 }: VirtualizedTableBodyProps<D, R>) => {
-  const cellMeasurementCache = new CellMeasurerCache({
-    fixedWidth: true,
-    minHeight: 44,
-    keyMapper: (rowIndex) => (data?.[rowIndex] as K8sResourceCommon)?.metadata?.uid || rowIndex, // TODO custom keyMapper ?
-  });
+  const dataRef = useRef(data);
+  dataRef.current = data;
+
+  const cellMeasurementCache = useRef(
+    new CellMeasurerCache({
+      fixedWidth: true,
+      minHeight: 44,
+      keyMapper: (rowIndex) =>
+        (dataRef.current?.[rowIndex] as K8sResourceCommon)?.metadata?.uid || rowIndex,
+    }),
+  ).current;
 
   const activeColumnIDs = useMemo(() => new Set(columns.map((c) => c.id)), [columns]);
 

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import type { FC, ReactText, ReactNode, ComponentType } from 'react';
-import { memo, useMemo, useState, useCallback, useEffect } from 'react';
+import { forwardRef, memo, useMemo, useRef, useState, useCallback, useEffect } from 'react';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import {
   TableGridBreakpoint,
@@ -112,21 +112,24 @@ export const sorts = {
 };
 
 // Common table row/columns helper SFCs for implementing accessible data grid
-export const TableRow: FC<TableRowProps> = ({ id, index, trKey, style, className, ...props }) => {
-  return (
-    <Tr
-      {...props}
-      data-id={id}
-      data-index={index}
-      data-test="resource-row"
-      data-test-rows="resource-row"
-      data-key={trKey}
-      style={style}
-      className={css('pf-v6-c-table__tr', className)}
-      role="row"
-    />
-  );
-};
+export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
+  ({ id, index, trKey, style, className, ...props }, ref) => {
+    return (
+      <Tr
+        {...props}
+        ref={ref}
+        data-id={id}
+        data-index={index}
+        data-test="resource-row"
+        data-test-rows="resource-row"
+        data-key={trKey}
+        style={style}
+        className={css('pf-v6-c-table__tr', className)}
+        role="row"
+      />
+    );
+  },
+);
 TableRow.displayName = 'TableRow';
 
 export type TableRowProps = {
@@ -229,11 +232,16 @@ const VirtualBody: FC<VirtualBodyProps> = (props) => {
     onRowsRendered,
   } = props;
 
-  const cellMeasurementCache = new CellMeasurerCache({
-    fixedWidth: true,
-    minHeight: 44,
-    keyMapper: (rowIndex) => _.get(props.data[rowIndex], 'metadata.uid', rowIndex),
-  });
+  const dataRef = useRef(data);
+  dataRef.current = data;
+
+  const cellMeasurementCache = useRef(
+    new CellMeasurerCache({
+      fixedWidth: true,
+      minHeight: 44,
+      keyMapper: (rowIndex) => _.get(dataRef.current[rowIndex], 'metadata.uid', rowIndex),
+    }),
+  ).current;
 
   const rowRenderer = ({ index, isVisible, key, style, parent }) => {
     const rowArgs = {


### PR DESCRIPTION
**Analysis / Root cause**:
`react-virtualized` was upgraded from 9.22.5 to 9.22.6 (via the PF 6.6.0 bump in commit `4ef96ba0ac`). In 9.22.5, `CellMeasurer` used `findDOMNode(this)` as a fallback to get the DOM node for height measurement. In 9.22.6, this was replaced with `React.createRef()` + `cloneElement` ref injection. Since `TableRow` was a plain function component without `forwardRef`, React silently dropped the ref. `CellMeasurer` could not get the DOM node, measured every row as 0px, and fell back to `minHeight` (44px) — but actual row content is taller, causing constant overlapping rows in all virtualized tables.

**Solution description**:
- Convert `TableRow` to use `forwardRef` so the ref chain works: `CellMeasurer` → `TableRow` → PatternFly `Tr` → `<tr>` DOM element
- Stabilize `CellMeasurerCache` with `useRef` in both `VirtualBody` (`table.tsx`) and `VirtualizedTableBody` to prevent cache recreation on every render

**Screenshots / screen recording**:
<!-- TODO: Add before/after screenshots -->

**Test setup:**
1. Build frontend with `yarn dev-once`
2. Start bridge against a cluster with installed operators
3. Navigate to Installed Operators page

**Test cases:**
- Verify virtualized table rows no longer overlap on the Installed Operators page
- Verify row heights are correctly measured and rows are properly spaced
- Verify scrolling through large lists works without visual artifacts
- Verify other virtualized tables (e.g. Pods, Deployments) render correctly

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
This regression was introduced by the `react-virtualized` 9.22.5 → 9.22.6 upgrade bundled with the PatternFly 6.6.0 bump.

**Reviewers and assignees:**
<!-- Tag reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtualized table rendering when displayed data changes.
  * Fixed cell measurement and row references to stay synchronized with the latest table content.
  * Enhanced table stability and measurement accuracy during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->