### PR TITLE
OCPBUGS-57309:  '0 B' is shown on details page when create pvc with 'EiB' unit

### DIFF
--- a/frontend/public/components/__tests__/units.spec.js
+++ b/frontend/public/components/__tests__/units.spec.js
@@ -181,6 +181,7 @@ describe('units', () => {
     test_(1073741824, '1 GiB');
     test_(1099511627776, '1 TiB');
     test_(1125899906842624, '1 PiB');
+    test_(1152921504606846976, '1 EiB');
   });
 
   describe('should humanize binaryBytesWithoutB values', () => {
@@ -219,6 +220,7 @@ describe('units', () => {
     test_(1073741824, '1 Gi');
     test_(1099511627776, '1 Ti');
     test_(1125899906842624, '1 Pi');
+    test_(1152921504606846976, '1 Ei');
   });
 
   describe('should de-humanize binaryBytesWithoutB values', () => {
@@ -257,6 +259,7 @@ describe('units', () => {
     test_('1Gi', 1073741824);
     test_('1Ti', 1099511627776);
     test_('1Pi', 1125899906842624);
+    test_('1Ei', 1152921504606846976);
     test_('100 i', 100);
     test_('100 Ki', 102400);
   });
@@ -283,7 +286,7 @@ describe('units', () => {
 
 describe('validate', () => {
   it('memory', () => {
-    ['32', '32M', '32Mi'].forEach((v) => {
+    ['32', '32M', '32Mi', '1Ei'].forEach((v) => {
       expect(validate.memory(v)).toEqual(undefined);
     });
 
@@ -357,6 +360,7 @@ describe('convert to base value', () => {
   test_('1Gi', 1073741824);
   test_('1Ti', 1099511627776);
   test_('1Pi', 1125899906842624);
+  test_('1Ei', 1152921504606846976);
 
   // decimal memory units
   test_('1k', 1000);

--- a/frontend/public/components/utils/units.js
+++ b/frontend/public/components/utils/units.js
@@ -20,7 +20,7 @@ const TYPES = {
     divisor: 1000,
   },
   binaryBytes: {
-    units: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'],
+    units: ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'],
     space: true,
     divisor: 1024,
   },
@@ -103,7 +103,8 @@ const convertValueWithUnitsToBaseValue = (value, unitArray, divisor) => {
     }
     return false;
   });
-  if (startingUnitIndex <= 0) {
+
+  if (startingUnitIndex < 0) {
     // can't parse
     return defaultReturn;
   }
@@ -302,7 +303,7 @@ validate.CPU = (value = '') => {
   return validateNumber(number) || validateCPUUnit(unit);
 };
 
-const validMemUnits = new Set(['E', 'P', 'T', 'G', 'M', 'k', 'Pi', 'Ti', 'Gi', 'Mi', 'Ki']);
+const validMemUnits = new Set(['E', 'P', 'T', 'G', 'M', 'k', 'Ei', 'Pi', 'Ti', 'Gi', 'Mi', 'Ki']);
 const validateMemUnit = (value = '') => {
   if (validMemUnits.has(value)) {
     return;


### PR DESCRIPTION
**Analysis / Root cause**:
Creating a PVC with size unit EiB stores `spec.resources.requests.storage` as `1Ei` (same as `oc get pvc -ojson`). On the details page, Requested capacity uses `convertToBaseValue` → `humanizeBinaryBytes`.
`convertToBaseValue` dehumanizes via a reversed unit list where `Ei` is index `0`. The parser treated `startingUnitIndex <= 0` as failure, so `"1Ei"` never converted to bytes and `humanizeBinaryBytes` fell back to `0 B`. Separately, `binaryBytes` had no `EiB` unit, so even a correct byte value could not humanize to exbibytes.
**Solution description**:
In `frontend/public/components/utils/units.js`:
1. Treat only `startingUnitIndex < 0` as unparseable so the largest unit (`Ei`, and similarly other type maxima) can be dehumanized.
2. Add `EiB` to `binaryBytes` so values ≥ 1 Ei humanize as `N EiB`.
3. Add `Ei` to `validMemUnits` so memory validation accepts `1Ei`.
Unit tests in `units.spec.js` cover humanize/dehumanize/`convertToBaseValue`/`validate.memory` for `1Ei`.
Ei remains available in the PVC create dropdown; API/`oc` quantity stays `1Ei`. UI displays the equivalent humanized value `1 EiB` (console binary label convention), not the raw k8s string.
**Screenshots / screen recording**:
<!-- Add before/after of PVC details Requested capacity for a PVC with storage: 1Ei -->
**Before:** 
<img width="1895" height="912" alt="Screenshot 2026-07-22 at 11 34 40 AM" src="https://github.com/user-attachments/assets/4af0913b-23f6-4870-94d9-3687dba30b15" />

**After**
<img width="1548" height="751" alt="Screenshot 2026-07-22 at 11 34 50 AM" src="https://github.com/user-attachments/assets/7994e5b7-5b8e-47cf-9b56-08811b8b5695" />

**Test setup:**
OpenShift cluster with console built from this branch. Ability to create a PVC (any StorageClass that accepts the request, or create via YAML if provisioner rejects Ei).
**Test cases:**
1. Create PVC from console with size `1` and unit `EiB`; confirm YAML/`oc` shows `storage: 1Ei`.
2. Open PVC details → Requested capacity shows `1 EiB` (not `0 B`).
3. Create or apply a PVC via YAML with `requests.storage: 1Ei`; details page still shows `1 EiB`.
4. Regression: PVC with `1Gi` / `1Pi` still shows `1 GiB` / `1 PiB`.
5. `yarn test public/components/__tests__/units.spec.js`
**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)
**Additional info:**
- Jira: https://redhat.atlassian.net/browse/OCPBUGS-57309
- Admission webhook warnings such as `fractional byte value "1Ei" is invalid` are API/cluster policy behavior and are out of scope for this UI fix.
- Display uses humanized `1 EiB`; it is intentionally not a raw mirror of the `oc` string `1Ei`.
- **Note:** The apiserver may incorrectly warn on `1Ei` (`fractional byte value "1Ei" is invalid`) and the console may show that as an Admission Webhook toast. This is a known Kubernetes `Quantity`/`MilliValue` overflow quirk ([kubernetes#128684](https://github.com/kubernetes/kubernetes/issues/128684)); the same warning appears with `oc`. 
<!-- Tag an OCP console engineer for review -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exbibytes in binary-byte and memory value handling, including correct formatting for the largest binary units (EiB and Ei).
  * Improved unit parsing and validation so these units are accepted and converted reliably.
* **Tests**
  * Expanded coverage for humanizing/dehumanizing and base conversion, including `1 EiB` / `1 Ei`.
  * Extended memory validation “valid values” and conversion test matrices to include `1 Ei`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->