### PR TITLE
OCPBUGS-77379: Incorrect translations for 'CatalogSources' and 'OperatorGroups' in l…

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/locales/fr/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/fr/olm.json
@@ -1,6 +1,6 @@
 {
   "OperatorSource": "Source de l’opérateur",
-  "CatalogSource": "Source du catalogue",
+  "CatalogSource": "CatalogSource",
   "CatalogSources": "CatalogSources",
   "PackageManifest": "Manifeste de package",
   "PackageManifests": "Manifestes de packages",
@@ -10,8 +10,8 @@
   "InstallPlans": "Plans d’installation",
   "Subscription": "Abonnement",
   "Subscriptions": "Abonnements",
-  "OperatorGroup": "Groupe d’opérateurs",
-  "OperatorGroups": "Groupes d’opérateurs",
+  "OperatorGroup": "OperatorGroup",
+  "OperatorGroups": "OperatorGroups",
   "OperatorHub": "OperatorHub",
   "OperatorHubs": "Hub d’opérateurs",
   "Operator Backed": "Soutenu par un opérateur",

--- a/frontend/packages/operator-lifecycle-manager/locales/ko/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/ko/olm.json
@@ -10,7 +10,7 @@
   "InstallPlans": "InstallPlans",
   "Subscription": "서브스크립션",
   "Subscriptions": "서브스크립션",
-  "OperatorGroup": "Operator 그룹",
+  "OperatorGroup": "OperatorGroup",
   "OperatorGroups": "OperatorGroups",
   "OperatorHub": "OperatorHub",
   "OperatorHubs": "OperatorHubs",

--- a/frontend/packages/operator-lifecycle-manager/locales/zh/olm.json
+++ b/frontend/packages/operator-lifecycle-manager/locales/zh/olm.json
@@ -1,7 +1,7 @@
 {
   "OperatorSource": "OperatorSource",
   "CatalogSource": "CatalogSource",
-  "CatalogSources": "CatalogSource",
+  "CatalogSources": "CatalogSources",
   "PackageManifest": "PackageManifest",
   "PackageManifests": "PackageManifests",
   "ClusterServiceVersion": "ClusterServiceVersion",
@@ -11,7 +11,7 @@
   "Subscription": "订阅",
   "Subscriptions": "订阅",
   "OperatorGroup": "OperatorGroup",
-  "OperatorGroups": "OperatorGroup",
+  "OperatorGroups": "OperatorGroups",
   "OperatorHub": "OperatorHub",
   "OperatorHubs": "OperatorHubs",
   "Operator Backed": "Operator 支持的",


### PR DESCRIPTION
**Analysis / Root cause**:
`CatalogSource`, `CatalogSources`, `OperatorGroup`, and `OperatorGroups` are Kubernetes custom resource kinds. Per console i18n guidance, CR kind names must stay in English so UI labels match the API and CLI.
Some `locales/{xx}/olm.json` entries were translated or incorrectly pluralized (e.g. French full translations, Korean `Operator 그룹`, Chinese singular forms for plural keys), so non-English UIs showed localized kind names instead of the API kind.
**Solution description**:
Set the following keys back to their English CR kind names in:
- `frontend/packages/operator-lifecycle-manager/locales/fr/olm.json` — `CatalogSource`, `OperatorGroup`, `OperatorGroups`
- `frontend/packages/operator-lifecycle-manager/locales/ko/olm.json` — `OperatorGroup`
- `frontend/packages/operator-lifecycle-manager/locales/zh/olm.json` — `CatalogSources`, `OperatorGroups`
Surrounding sentence translations that *mention* these kinds are unchanged; only the kind label keys themselves are kept in English.
**Screenshots / screen recording**:
<!-- Optional: OperatorHub / OLM list pages in fr, ko, zh showing CatalogSources and OperatorGroups in English -->
**Test setup:**
Console with UI language set to French, Korean, or Chinese (Simplified).
**Test cases:**
1. Set language to **fr** → CatalogSources / OperatorGroups nav or list labels show `CatalogSources` / `OperatorGroups` (not French translations).
2. Set language to **ko** → `OperatorGroup` shows as `OperatorGroup` (not `Operator 그룹`).
3. Set language to **zh** → plural labels show `CatalogSources` / `OperatorGroups` (not singular `CatalogSource` / `OperatorGroup`).
4. Confirm related descriptive strings still translate normally (e.g. “Create CatalogSource”, detail help text).
**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)
**Additional info:**
- Jira: https://redhat.atlassian.net/browse/OCPBUGS-77379
- Related guidance / precedent: https://redhat.atlassian.net/browse/OCPBUGS-70011
- Future i18n upload/download batches should keep these CR kind keys untranslated.
**Reviewers and assignees:**
<!-- Tag an OCP console engineer for review -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected localized Operator Lifecycle Manager catalog terminology in French, Korean, and Simplified Chinese.
  * Standardized technical terms such as `CatalogSource` and `OperatorGroup` across supported locales.
  * Fixed plural labels for catalog sources and operator groups in Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->