### PR TITLE
OCPBUGS-99040: Fix CVE-2026-49978 - bump DOMPurify to >= 3.4.7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -224,7 +224,8 @@
     "follow-redirects": "^1.16.0",
     "glob-parent": "^5.1.2",
     "hosted-git-info": "^3.0.8",
-    "protobufjs": "7.6.5"
+    "protobufjs": "7.6.5",
+    "dompurify": "^3.4.11"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9844,15 +9844,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.3.2":
-  version: 3.4.3
-  resolution: "dompurify@npm:3.4.3"
+"dompurify@npm:^3.4.11":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/88b9e1a6d0a990e15fab46f4eb96163ef79f20634705b21c82651ffce1ccc5236e4007397d920234afab86123d49be863f2367bd6aacdf28a401aef4d177e0f9
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description of the Change

CVE-2026-49978: DOMPurify IN_PLACE sanitization bypass via attached Shadow Root inside `<template>.content` (XSS). Affects DOMPurify versions <= 3.4.6.

Console has DOMPurify 3.4.3 as a transitive dependency via `monaco-editor`. This adds a `dompurify` yarn resolution to bump it to `^3.4.11` (resolved to 3.4.12).

## Jira

OCPBUGS-99040

## Screenshots / Screen Recordings

N/A - dependency version bump only, no UI changes.

## Testing

- Verified `yarn.lock` resolves dompurify to 3.4.12 (above fix version 3.4.7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the content sanitization dependency to **dompurify 3.4.x** (via a pinned resolution) to improve security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->