### PR TITLE
NO-JIRA: Make regular notification icon outlined by default

### DIFF
--- a/frontend/public/components/masthead/masthead-toolbar.tsx
+++ b/frontend/public/components/masthead/masthead-toolbar.tsx
@@ -791,6 +791,7 @@ const MastheadToolbarContents: FC<MastheadToolbarContentsProps> = ({
                   onClick={drawerToggle}
                   variant={notificationBadgeVariant}
                   count={notificationCount || 0}
+                  icon={<RhUiNotificationIcon />}
                   data-quickstart-id="qs-masthead-notifications"
                   className="co-masthead-button"
                 />
@@ -841,10 +842,9 @@ const MastheadToolbarContents: FC<MastheadToolbarContentsProps> = ({
                 onClick={drawerToggle}
                 variant={notificationBadgeVariant}
                 count={notificationCount}
+                icon={<RhUiNotificationIcon />}
                 data-quickstart-id="qs-masthead-notifications"
-              >
-                <RhUiNotificationIcon />
-              </NotificationBadge>
+              />
             )}
             <ToolbarItem>{renderMenu(true)}</ToolbarItem>
           </ToolbarGroup>


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

For consistency with other masthead icons.

"Attention" icon is still filled

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

When non-attention, use the unfilled icon. No change in icon in "attention" state

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

| |after|before|
|--|--|--|
|all read|<img width="912" height="392" alt="image" src="https://github.com/user-attachments/assets/3827ea78-e52f-405d-bb81-c130811d500e" />|<img width="824" height="274" alt="image" src="https://github.com/user-attachments/assets/5ddd5adf-565d-44c5-9e36-8eff936f6f44" />|
|urgent (no change)|<img width="888" height="296" alt="image" src="https://github.com/user-attachments/assets/55148698-c482-4d2b-9c13-28a1e8b45092" />|<img width="888" height="296" alt="image" src="https://github.com/user-attachments/assets/ef3b3678-67c9-4e48-bdf9-a6d418ff3c82" />|
|mobile|<img width="209" height="185" alt="image" src="https://github.com/user-attachments/assets/59ab270a-c8f9-405d-9935-c5567d4efdf7" />|<img width="193" height="170" alt="image" src="https://github.com/user-attachments/assets/76f1ed5a-73eb-4cd2-a122-839adf38db50" />(bug)|



**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari (or Epiphany on Linux)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification badge rendering in the masthead toolbar.
  * Preserved quick-start functionality for the stacked notification badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->