### PR TITLE
OCPBUGS-94168: Fix CVE-2026-13149 brace-expansion DoS vulnerability

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -224,7 +224,10 @@
     "follow-redirects": "^1.16.0",
     "glob-parent": "^5.1.2",
     "hosted-git-info": "^3.0.8",
-    "protobufjs": "7.5.8"
+    "protobufjs": "7.5.8",
+    "brace-expansion@npm:^1.1.7": "1.1.16",
+    "brace-expansion@npm:^2.0.2": "2.1.2",
+    "brace-expansion@npm:^5.0.5": "5.0.7"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7292,31 +7292,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+"brace-expansion@npm:1.1.16":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.0
-  resolution: "brace-expansion@npm:2.1.0"
+"brace-expansion@npm:2.1.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Analysis / Root cause**:
[CVE-2026-13149](https://nvd.nist.gov/vuln/detail/CVE-2026-13149) — brace-expansion through 5.0.6 is vulnerable to denial of service. The `expand()` function exhibits exponential-time complexity (O(2^n)) in the number of consecutive non-expanding `{}` brace groups. A ~90 byte payload can block the calling thread for minutes. The `max` option does not mitigate this.

The repo carried three vulnerable transitive copies via minimatch: 1.1.12 (via minimatch 3.1.5), 2.1.0 (via minimatch 9.0.9), and 5.0.5 (via minimatch 10.2.5).

Jira: https://redhat.atlassian.net/browse/OCPBUGS-94168

**Solution description**:
Add per-descriptor yarn resolutions to bump each brace-expansion major line to its patched release:
- `brace-expansion@npm:^1.1.7` → **1.1.16** (for minimatch 3.x)
- `brace-expansion@npm:^2.0.2` → **2.1.2** (for minimatch 9.x)
- `brace-expansion@npm:^5.0.5` → **5.0.7** (for minimatch 10.x)

Each resolution targets a specific descriptor to preserve API compatibility within its major line. A blanket `>=1.1.16` resolution was attempted first but broke minimatch 3.x because brace-expansion 5.x has an incompatible API (`expand is not a function`).

**Screenshots / screen recording**:
N/A — dependency-only change with no UI impact.

**Test setup:**
N/A

**Test cases:**
- `yarn build` completes successfully with the updated dependencies.
- `yarn lint` passes (verifies eslint-plugin-import's `no-extraneous-dependencies` rule works with the updated brace-expansion, which was the failure mode of the first attempt).

**Browser conformance**:
- [x] Chrome
- [x] Firefox
- [x] Safari (or Epiphany on Linux)

N/A — no runtime behavior change.

**Additional info:**
- CVSS 5.3 (Medium) — CWE-400, CWE-407
- Fixed versions: 1.1.16, 2.1.2, 5.0.7

**Reviewers and assignees:**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package resolution settings to ensure compatible versions of required components are used, including keeping `protobufjs` pinned and adding `brace-expansion` overrides for more targeted version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->