### PR TITLE
OCPBUGS-99418: Bump protobufjs to 7.6.5 to fix CVE-2026-59877, CVE-2026-48712, CVE-2026-41242

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -224,7 +224,7 @@
     "follow-redirects": "^1.16.0",
     "glob-parent": "^5.1.2",
     "hosted-git-info": "^3.0.8",
-    "protobufjs": "7.5.8"
+    "protobufjs": "7.6.5"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4117,20 +4117,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/eventemitter@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
-  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
   languageName: node
   linkType: hard
 
-"@protobufjs/fetch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/fetch@npm:1.1.0"
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.1"
-    "@protobufjs/inquire": "npm:^1.1.0"
-  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
   languageName: node
   linkType: hard
 
@@ -4138,13 +4137,6 @@ __metadata:
   version: 1.0.2
   resolution: "@protobufjs/float@npm:1.0.2"
   checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
-  languageName: node
-  linkType: hard
-
-"@protobufjs/inquire@npm:^1.1.0, @protobufjs/inquire@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "@protobufjs/inquire@npm:1.1.2"
-  checksum: 10c0/af69597818a14cac6a00a74cd5b3fb85aa96658b9dbbae73e6d907cb154ebf470953a8c537b3e6095a43de565ec4e6c5b40227c72f4a7d762d34fbec7ac179e7
   languageName: node
   linkType: hard
 
@@ -15179,7 +15171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
@@ -17573,23 +17565,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.5.8":
-  version: 7.5.8
-  resolution: "protobufjs@npm:7.5.8"
+"protobufjs@npm:7.6.5":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
     "@protobufjs/codegen": "npm:^2.0.5"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.1"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/25968259084a634e035f865febd5a31f75bdaee4fda6fba4e14c57019024e7cada859b470eb69350f430fbd0d509c805249b9fe8a6c44a57a0b484a1ef685751
+    long: "npm:^5.3.2"
+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Analysis / Root cause**:
The `protobufjs` package pinned in yarn resolutions at version 7.5.8 is affected by three CVEs:
- [CVE-2026-59877](https://nvd.nist.gov/vuln/detail/CVE-2026-59877) (OCPBUGS-99418): DoS via crafted `.proto` schema (fixed in 7.6.5)
- [CVE-2026-48712](https://nvd.nist.gov/vuln/detail/CVE-2026-48712) (OCPBUGS-99529): DoS via uncontrolled recursion (fixed in 7.6.1)
- [CVE-2026-41242](https://nvd.nist.gov/vuln/detail/CVE-2026-41242) (OCPBUGS-96734): Arbitrary code execution via injected type fields (fixed in 7.5.5)

**Solution description**:
Bumps the `protobufjs` yarn resolution from `7.5.8` to `7.6.5`, which includes fixes for all three CVEs. No API changes are expected as this is a patch-level update within the 7.x line.

**Screenshots / screen recording**:
N/A - dependency version bump only, no visual changes.

**Test setup:**
No special setup required.

**Test cases:**
- [x] `yarn install` succeeds
- [x] lint-staged pre-commit hook passes
- [ ] `yarn build` succeeds (CI)
- [ ] CI passes

**Browser conformance**:
- [x] Chrome
- [x] Firefox
- [x] Safari (or Epiphany on Linux)

N/A - no runtime behavior change expected.

**Additional info:**
This PR fixes three Jira bugs:
- https://issues.redhat.com/browse/OCPBUGS-99418
- https://issues.redhat.com/browse/OCPBUGS-99529
- https://issues.redhat.com/browse/OCPBUGS-96734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Protocol Buffers library to version 7.6.5 to align with the latest available release.
  * Maintenance update only; existing end-user workflows should remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->