### PR TITLE
CONSOLE-5065: Plugin runtime init code tweaks

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -63,7 +63,7 @@ module.exports = {
         paths: [
           {
             name: 'lodash-es',
-            message: 'Use lodash instead. webpack is configured to use lodash-es automatically.',
+            message: 'Use lodash instead. Bundler is configured to use lodash-es automatically.',
           },
           {
             name: 'react',

--- a/frontend/@types/console/window.d.ts
+++ b/frontend/@types/console/window.d.ts
@@ -76,14 +76,14 @@ declare interface Window {
   i18n?: {};
   /** Redux store, only available in development builds for debugging */
   store?: {};
-  /** Console plugin store, only available in development builds for debugging */
+  /** Shared scope object used by Console and its plugins (development builds only) */
+  pluginSharedScope?: {};
+  /** Console plugin store only available in development builds for debugging */
   pluginStore?: {};
   /** Console legacy plugin entry callback, used to load dynamic plugins */
   loadPluginEntry?: Function;
   /** Console plugin entry callback, used to load dynamic plugins */
   __load_plugin_entry__?: Function;
-  /** webpack shared scope object */
-  webpackSharedScope?: {};
   /** The global monaco object, exposed when the Monaco Editor is loaded */
   monaco?: {};
 }

--- a/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/runtime/plugin-init.ts
@@ -94,7 +94,7 @@ const registerLegacyPluginEntryCallback = () => {
 };
 
 /**
- * Loads and enables all Console plugins.
+ * Loads and enables all Console dynamic plugins.
  *
  * Precondition: {@link PluginStore} must be initialized.
  */
@@ -112,7 +112,7 @@ export const initConsolePlugins = _.once((pluginStore: PluginStore) => {
 
       if (process.env.NODE_ENV !== 'production') {
         // Expose webpack share scope object for debugging
-        window.webpackSharedScope = scope;
+        window.pluginSharedScope = scope;
       }
     })
     .then(() => {

--- a/frontend/public/plugins.ts
+++ b/frontend/public/plugins.ts
@@ -51,7 +51,6 @@ export const pluginStore = new PluginStore({
     // Explicitly define the default entry callback name
     entryCallbackSettings: {
       name: REMOTE_ENTRY_CALLBACK,
-      registerCallback: true,
     },
 
     // Use coFetch for plugin resource fetching
@@ -132,6 +131,7 @@ export const featureFlagMiddleware: Middleware<{}, RootState> = (s) => {
   };
 };
 
-localPlugins.forEach((plugin) => pluginStore.loadPlugin(plugin));
-
-initConsolePlugins(pluginStore);
+// Ensure all static plugins are loaded before proceeding to load dynamic plugins
+Promise.allSettled(localPlugins.map((plugin) => pluginStore.loadPlugin(plugin))).then(() => {
+  initConsolePlugins(pluginStore);
+});


### PR DESCRIPTION
Minor improvements to Console plugin runtime init code
- ensure that static (local) plugins are loaded before we proceed to load dynamic (remote) plugins
- `window` global `webpackSharedScope` renamed to `pluginSharedScope`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Console plugin initialization so all locally configured plugins complete loading before they are enabled.
  * Increased startup reliability by loading static/local plugins concurrently and then enabling them together.
* **Documentation**
  * Clarified terminology for loading/enabling “Console dynamic plugins.”
* **Development Diagnostics**
  * Updated development-only plugin sharing diagnostics to use a clearer, plugin-specific global name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->