### PR TITLE
OCPBUGS-33836: quickstart page i18n misses (Fix Quick Starts i18n bundle lookup for zh-CN)

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -161,8 +161,8 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
     [activeQuickStartID, setAllQuickStartStates, fireTelemetryEvent],
   );
 
-  const language = getLastLanguage() || 'en';
-  const resourceBundle = i18n.getResourceBundle(language, 'console-app');
+  const language = i18n.resolvedLanguage || 'en';
+  const resourceBundle = i18n.getResourceBundle(language, 'console-app') ?? {};
   const processedResourceBundle = getProcessedResourceBundle(resourceBundle, language);
 
   // https://github.com/i18next/i18next-parser#caveats

--- a/frontend/packages/console-app/src/components/user-preferences/language/useLanguage.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/language/useLanguage.ts
@@ -10,12 +10,13 @@ export const useLanguage = (preferredLanguage: string, preferredLanguageLoaded: 
   const { setResourceBundle } = useQuickStartContext();
 
   useEffect(() => {
-    const onLanguageChange = (lng: string) => {
+    const onLanguageChange = () => {
       if (setResourceBundle) {
         // Update language resource of quick starts components
-        const resourceBundle = i18n.getResourceBundle(lng, 'console-app');
-        const processedBundle = getProcessedResourceBundle(resourceBundle, lng);
-        setResourceBundle(processedBundle, lng);
+        const language = i18n.resolvedLanguage || 'en';
+        const resourceBundle = i18n.getResourceBundle(language, 'console-app') ?? {};
+        const processedBundle = getProcessedResourceBundle(resourceBundle, language);
+        setResourceBundle(processedBundle, language);
       }
     };
     const preferredLanguageInStorage: string = getLastLanguage();


### PR DESCRIPTION

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
Quick Starts chrome strings (for example "Filter by keyword...", "Status") are not translated via `t()`. Console loads the full `console-app` resource bundle and passes it to PatternFly Quick Starts with `i18n.getResourceBundle(language, 'console-app')`.

Language preference stores Chinese as `zh-CN`, but Console i18n is configured with `load: 'languageOnly'`, so locale files are stored under `zh`. Looking up the bundle with `zh-CN` returned `undefined`, and PatternFly fell back to English. The rest of Console was unaffected because it uses `t()`, which resolves `zh-CN` → `zh` correctly.

Related history: OCPBUGS-29365 / #13612 changed the preference value from `zh` to `zh-CN`, which exposed this Quick Starts lookup mismatch.

**Solution description**:
Use i18next's `resolvedLanguage` when loading the Quick Starts `console-app` resource bundle, with `'en'` as a fallback:

- `quick-start-context.tsx` — initial context values passed to PatternFly
- `useLanguage.ts` — `languageChanged` handler that updates the bundle via `setResourceBundle`

`resolvedLanguage` is the language i18next actually resolved/loaded (for example `zh` when preference is `zh-CN`), which matches where resources are stored under `load: 'languageOnly'`. See https://www.i18next.com/overview/api#resolvedlanguage.

Also guard `getResourceBundle` with `?? {}` so a missing bundle does not pass `undefined` into processing / PatternFly.

This does not change language preference storage, locale JSON files, or dynamic plugin i18n (plugins use their own `plugin__*` namespaces and `t()`).

**Screenshots / screen recording**:
**Before:**
<img width="1853" height="900" alt="e" src="https://github.com/user-attachments/assets/a7c10db0-f287-474d-9a36-d25983016c5e" />

**After**
<img width="1723" height="920" alt="f" src="https://github.com/user-attachments/assets/b8c4f99f-abcf-45eb-a6fe-b5b5284a2427" />

<!-- Add before/after of Quick Starts catalog in Chinese: Filter by keyword / Status -->

**Test setup:**
1. Log in to Console.
2. Set User Preferences → Language → 中文 / Chinese (`zh-CN`).
3. Open **Quick Starts** (Help menu or `/quickstart`).

**Test cases:**
1. With language set to Chinese, Quick Starts catalog chrome strings are translated (for example "Filter by keyword..." → "按关键字过滤...", "Status" → "状态").
2. Switch language English → Chinese and confirm chrome strings update without a full reload.
3. Switch language Chinese → English and confirm chrome strings return to English.
4. Spot-check another language (for example Japanese or Korean) still loads the correct Quick Starts chrome strings.
5. Confirm dynamic plugin pages that use `t()` are unchanged.

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
- Jira: https://issues.redhat.com/browse/OCPBUGS-74310
- Scope is limited to PatternFly Quick Starts chrome string bundle lookup. Quick Start CR content localization and plural/`items` key issues are out of scope for this PR.
- Compare: https://github.com/openshift/console/compare/main...cajieh:OCPBUGS-74310-quickstart-items-i18n?expand=1

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection when switching languages.
  * Prevented missing translation resources from causing issues in quick-start content.
  * Ensured quick-start translations remain available and process correctly, including pseudolocalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->