### PR TITLE
OCPBUGS-99030: Fix CVE-2026-49978 - bump DOMPurify to >= 3.4.7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -343,7 +343,7 @@
     "node": ">=14.x"
   },
   "resolutions": {
-    "dompurify": "3.2.7",
+    "dompurify": "^3.4.11",
     "fsevents": "2.3.3",
     "hosted-git-info": "^3.0.8",
     "jquery": "3.5.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11145,15 +11145,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.7":
-  version: 3.2.7
-  resolution: "dompurify@npm:3.2.7"
+"dompurify@npm:^3.4.11":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/d41bb31a72f1acdf9b84c56723c549924b05d92a39a15bd8c40bec9007ff80d5fccf844bc53ee12af5b69044f9a7ce24a1e71c267a4f49cf38711379ed8c1363
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps DOMPurify to >= 3.4.11 (resolves to 3.4.12) via yarn resolutions
- Fixes CVE-2026-49978: DOMPurify IN_PLACE sanitization bypass via Shadow Root inside `<template>.content` (XSS)
- Fix version is 3.4.7; previous version was 3.2.7

## Test plan
- [ ] Verify DOMPurify version in yarn.lock is >= 3.4.7
- [ ] Verify no regressions in console UI