### PR TITLE
CONSOLE-5397: Log perspective overrides when starting Bridge

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -598,7 +598,16 @@ func (s *Server) HTTPHandler() (http.Handler, error) {
 	if len(s.Perspectives) > 0 {
 		err := json.Unmarshal([]byte(s.Perspectives), &config.Customization.Perspectives)
 		if err != nil {
-			klog.Errorf("Unable to parse perspective JSON: %v", err)
+			klog.Errorf("Unable to parse perspectives JSON: %v", err)
+		} else if len(config.Customization.Perspectives) > 0 {
+			klog.Infoln("Using console perspective overrides:")
+			grouped := make(map[string][]string)
+			for _, perspective := range config.Customization.Perspectives {
+				grouped[string(perspective.Visibility.State)] = append(grouped[string(perspective.Visibility.State)], perspective.ID)
+			}
+			for visibility, ids := range grouped {
+				klog.Infof(" - [%s]: %s\n", visibility, strings.Join(ids, ", "))
+			}
 		}
 	}
 


### PR DESCRIPTION
### Analysis / Root cause

Follow-up to #16663

When starting Bridge server, perspective overrides are not logged to terminal.

### Solution description

Modify `pkg/server/server.go` to log perspective overrides if provided via `-perspectives` parameter.

### Screenshots

Using test setup from #16663

<img width="1908" height="224" src="https://github.com/user-attachments/assets/adc891c0-a811-4362-ba25-6d276438ed0d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for invalid perspective configuration.
  * Added clearer visibility summaries when perspective overrides are successfully configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->