### PR TITLE
Fix OCPBUGS-98785: CVE-2026-48801

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -339,7 +339,8 @@
     "minimatch@^9.0.4": "^9.0.6",
     "shell-quote": "^1.8.4",
     "protobufjs": "7.5.6",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "linkify-it": "~5.0.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16261,12 +16261,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "linkify-it@npm:2.1.0"
+"linkify-it@npm:~5.0.1":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
-    uc.micro: "npm:^1.0.1"
-  checksum: 10c0/2fc45f06740a3c58c3393eecb634f91b62afc8b571ec82dd4fb250acded2d15ab1c83730c0fc0c353b8577d594384c7ca9e7f075be4342e9238d41089d0001bf
+    uc.micro: "npm:^2.0.0"
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 
@@ -23726,10 +23726,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uc.micro@npm:^1.0.1":
-  version: 1.0.6
-  resolution: "uc.micro@npm:1.0.6"
-  checksum: 10c0/9bde2afc6f2e24b899db6caea47dae778b88862ca76688d844ef6e6121dec0679c152893a74a6cfbd2e6fde34654e6bd8424fee8e0166cdfa6c9ae5d42b8a17b
+"uc.micro@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10c0/8862eddb412dda76f15db8ad1c640ccc2f47cdf8252a4a30be908d535602c8d33f9855dfcccb8b8837855c1ce1eaa563f7fa7ebe3c98fd0794351aab9b9c55fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps linkify-it from 2.1.0 to 5.0.2 via yarn resolutions
- Fixes CVE-2026-48801: quadratic algorithmic complexity in LinkifyIt#match scan loop (DoS)
- Pinned to ~5.0.1 (5.x range) to maintain API compatibility with react-linkify 0.2.x