### PR TITLE
Fix OCPBUGS-98767: CVE-2026-48801

### DIFF
--- a/frontend/__mocks__/linkify-react.js
+++ b/frontend/__mocks__/linkify-react.js
@@ -1,0 +1,10 @@
+const React = require('react');
+
+function Linkify(props) {
+  const Component = props.as || props.tagName || 'span';
+  const children = props.children;
+  return React.createElement(Component, { key: '__linkify-wrapper' }, children);
+}
+
+module.exports = Linkify;
+module.exports.default = Linkify;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,8 @@
       "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
       "^dnd-core$": "dnd-core/dist/cjs",
       "^react-dnd$": "react-dnd/dist/cjs",
-      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs"
+      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
+      "linkify-react/dist/linkify-react\\.mjs$": "<rootDir>/__mocks__/linkify-react.js"
     },
     "transform": {
       "^.+\\.(ts|tsx|js|jsx)$": "./node_modules/ts-jest/preprocessor.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
       "^.+\\.(gql|graphql)$": "jest-transform-graphql"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|lodash-es|@console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime)/.*)"
+      "<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|lodash-es|@console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime|linkify-react)/.*)"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
@@ -181,6 +181,8 @@
     "js-yaml": "^3.15.0",
     "json-schema": "^0.3.0",
     "jsonpath-plus": "^10.3.0",
+    "linkify-react": "^4.2.0",
+    "linkifyjs": "^4.2.0",
     "lodash-es": "^4.18.1",
     "marked": "^15.0.6",
     "monaco-yaml": "^5.3.1",
@@ -196,7 +198,6 @@
     "react-dom": "^17.0.1",
     "react-helmet-async": "^2.0.5",
     "react-i18next": "^11.12.0",
-    "react-linkify": "^0.2.2",
     "react-modal": "^3.16.3",
     "react-redux": "7.2.9",
     "react-router": "5.3.x",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,15 +90,14 @@
       "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
       "^dnd-core$": "dnd-core/dist/cjs",
       "^react-dnd$": "react-dnd/dist/cjs",
-      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
-      "linkify-react/dist/linkify-react\\.mjs$": "<rootDir>/__mocks__/linkify-react.js"
+      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs"
     },
     "transform": {
       "^.+\\.(ts|tsx|js|jsx)$": "./node_modules/ts-jest/preprocessor.js",
       "^.+\\.(gql|graphql)$": "jest-transform-graphql"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|lodash-es|@console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime|linkify-react)/.*)"
+      "<rootDir>/node_modules/(?!(@patternfly(-\\S+)?|d3(-\\S+)?|delaunator|robust-predicates|internmap|lodash-es|@console|@novnc|@spice-project|@popperjs|i18next(-\\S+)?|@babel/runtime)/.*)"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,8 @@
       "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
       "^dnd-core$": "dnd-core/dist/cjs",
       "^react-dnd$": "react-dnd/dist/cjs",
-      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs"
+      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
+      "linkify-react/dist/linkify-react.mjs": "linkify-react/dist/linkify-react.cjs"
     },
     "transform": {
       "^.+\\.(ts|tsx|js|jsx)$": "./node_modules/ts-jest/preprocessor.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -91,7 +91,7 @@
       "^dnd-core$": "dnd-core/dist/cjs",
       "^react-dnd$": "react-dnd/dist/cjs",
       "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
-      "linkify-react/dist/linkify-react.mjs": "linkify-react/dist/linkify-react.cjs"
+      "linkify-react/dist/linkify-react\\.mjs$": "<rootDir>/__mocks__/linkify-react.js"
     },
     "transform": {
       "^.+\\.(ts|tsx|js|jsx)$": "./node_modules/ts-jest/preprocessor.js",

--- a/frontend/public/components/app.tsx
+++ b/frontend/public/components/app.tsx
@@ -3,7 +3,6 @@ import * as _ from 'lodash-es';
 import { useState, useRef, useCallback, useEffect, useLayoutEffect, memo, Suspense } from 'react';
 import { render } from 'react-dom';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
-import { linkify } from 'react-linkify';
 import { Provider, useSelector, useDispatch } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { useParams, useLocation, CompatRouter, Routes, Route } from 'react-router-dom-v5-compat';
@@ -80,10 +79,6 @@ import { useImpersonateRefreshFeatures } from './useImpersonateRefreshFeatures';
 delete process.title;
 
 initI18n();
-
-// Disable linkify 'fuzzy links' across the app.
-// Only linkify url strings beginning with a proper protocol scheme.
-linkify.set({ fuzzyLink: false });
 
 const EnhancedProvider: React.FC<{
   provider: React.Provider<any>;

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import Linkify from 'react-linkify';
+import Linkify from 'linkify-react/dist/linkify-react.mjs';
+import type { IntermediateRepresentation, Opts } from 'linkifyjs';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCopyButton } from '@patternfly/react-core';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import Linkify from 'linkify-react';
+import Linkify from 'linkify-react/dist/linkify-react.mjs';
 import type { IntermediateRepresentation, Opts } from 'linkifyjs';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCopyButton } from '@patternfly/react-core';

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import Linkify from 'linkify-react/dist/linkify-react.mjs';
+import type { IntermediateRepresentation, Opts } from 'linkifyjs';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCopyButton } from '@patternfly/react-core';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';
@@ -133,8 +134,22 @@ export const ExternalLinkWithCopy = ({
 };
 
 // Open links in a new window and set noopener/noreferrer.
+const linkifyOptions: Opts = {
+  render: ({ attributes, content }: IntermediateRepresentation) => {
+    const { href, ...props } = attributes;
+    return (
+      <ExternalLink href={href} {...props}>
+        {content}
+      </ExternalLink>
+    );
+  },
+  validate: {
+    url: (value: string) => /^https?:\/\//.test(value),
+  },
+};
+
 export const LinkifyExternal = ({ children }: { children: React.ReactNode }) => (
-  <Linkify component={ExternalLink}>{children}</Linkify>
+  <Linkify options={linkifyOptions}>{children}</Linkify>
 );
 LinkifyExternal.displayName = 'LinkifyExternal';
 

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
-import Linkify from 'linkify-react/dist/linkify-react.mjs';
+import Linkify from 'linkify-react';
 import type { IntermediateRepresentation, Opts } from 'linkifyjs';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCopyButton } from '@patternfly/react-core';

--- a/frontend/public/components/utils/link.tsx
+++ b/frontend/public/components/utils/link.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as _ from 'lodash-es';
 import Linkify from 'linkify-react/dist/linkify-react.mjs';
-import type { IntermediateRepresentation, Opts } from 'linkifyjs';
 import { useTranslation } from 'react-i18next';
 import { ClipboardCopyButton } from '@patternfly/react-core';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16069,12 +16069,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "linkify-it@npm:2.1.0"
-  dependencies:
-    uc.micro: "npm:^1.0.1"
-  checksum: 10c0/2fc45f06740a3c58c3393eecb634f91b62afc8b571ec82dd4fb250acded2d15ab1c83730c0fc0c353b8577d594384c7ca9e7f075be4342e9238d41089d0001bf
+"linkify-react@npm:^4.2.0":
+  version: 4.3.3
+  resolution: "linkify-react@npm:4.3.3"
+  peerDependencies:
+    linkifyjs: "*"
+    react: ">= 15.0.0"
+  checksum: 10c0/67885ea9466003cdd1c7c8bbecbc9fb5f903bde93bb3333bab1e61f12b76af93ba0bc40c7d9f0be3751e48d1dd1a10e3b0499691bfc8a249ef3267e62b03770e
+  languageName: node
+  linkType: hard
+
+"linkifyjs@npm:^4.2.0":
+  version: 4.3.3
+  resolution: "linkifyjs@npm:4.3.3"
+  checksum: 10c0/0eac293927f1465d13625c8c67c83c50d7fda9137c255a4a2ff5970ea4e9ba57de4846b170326e54b9e4e82be24f3705572bc50773737be9b13af5f1e4577798
   languageName: node
   linkType: hard
 
@@ -18285,6 +18293,8 @@ __metadata:
     js-yaml: "npm:^3.15.0"
     json-schema: "npm:^0.3.0"
     jsonpath-plus: "npm:^10.3.0"
+    linkify-react: "npm:^4.2.0"
+    linkifyjs: "npm:^4.2.0"
     lint-staged: "npm:^10.2.2"
     lodash-es: "npm:^4.18.1"
     marked: "npm:^15.0.6"
@@ -18312,7 +18322,6 @@ __metadata:
     react-dom: "npm:^17.0.1"
     react-helmet-async: "npm:^2.0.5"
     react-i18next: "npm:^11.12.0"
-    react-linkify: "npm:^0.2.2"
     react-modal: "npm:^3.16.3"
     react-redux: "npm:7.2.9"
     react-refresh: "npm:^0.10.0"
@@ -19945,17 +19954,6 @@ __metadata:
   version: 3.0.4
   resolution: "react-lifecycles-compat@npm:3.0.4"
   checksum: 10c0/1d0df3c85af79df720524780f00c064d53a9dd1899d785eddb7264b378026979acbddb58a4b7e06e7d0d12aa1494fd5754562ee55d32907b15601068dae82c27
-  languageName: node
-  linkType: hard
-
-"react-linkify@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "react-linkify@npm:0.2.2"
-  dependencies:
-    linkify-it: "npm:^2.0.3"
-    prop-types: "npm:^15.5.8"
-    tlds: "npm:^1.57.0"
-  checksum: 10c0/d288311b7f82baa81b9e90d52699c8b1ffbc7a45ebc05a8dd9a935d7662999c9a70818de67803e18c501ae0ff58185d50954101692a2af6bbc76285450a7c8b6
   languageName: node
   linkType: hard
 
@@ -22891,15 +22889,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tlds@npm:^1.57.0":
-  version: 1.203.1
-  resolution: "tlds@npm:1.203.1"
-  bin:
-    tlds: bin.js
-  checksum: 10c0/58f630ec673add064b0cdd3ba675ac23eabe33523a2629cfae6ea31de109503e1c3889bc128625b810855149945ccbdf4b904c38839780c3afab71e604523204
-  languageName: node
-  linkType: hard
-
 "tldts-core@npm:^6.1.85":
   version: 6.1.85
   resolution: "tldts-core@npm:6.1.85"
@@ -23423,13 +23412,6 @@ __metadata:
   version: 0.7.36
   resolution: "ua-parser-js@npm:0.7.36"
   checksum: 10c0/0ef3047b2c5708e7e2fd7f0bcc3d74741288adefab569d2ce6ecb3081a4e0de14e3ca103ecbc77350bf7b0df24a30d31956c613dd6495b9a5df9bb46ca63d9bc
-  languageName: node
-  linkType: hard
-
-"uc.micro@npm:^1.0.1":
-  version: 1.0.6
-  resolution: "uc.micro@npm:1.0.6"
-  checksum: 10c0/9bde2afc6f2e24b899db6caea47dae778b88862ca76688d844ef6e6121dec0679c152893a74a6cfbd2e6fde34654e6bd8424fee8e0166cdfa6c9ae5d42b8a17b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Replaces `react-linkify` (depends on vulnerable `linkify-it`) with `linkify-react` + `linkifyjs`
- Fixes CVE-2026-48801: quadratic algorithmic complexity in LinkifyIt#match scan loop (DoS)
- Backport of #16814 approach to this release branch