### PR TITLE
OCPBUGS-90514: Fix CVE-2026-12143 form-data CRLF injection

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8232,7 +8232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.6, combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
+"combined-stream@npm:^1.0.8, combined-stream@npm:~1.0.6":
   version: 1.0.8
   resolution: "combined-stream@npm:1.0.8"
   dependencies:
@@ -11583,26 +11583,29 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^2.3.3":
-  version: 2.5.1
-  resolution: "form-data@npm:2.5.1"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.6"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/7e8fb913b84a7ac04074781a18d0f94735bbe82815ff35348803331f6480956ff0035db5bcf15826edee09fe01e665cfac664678f1526646a6374ee13f960e56
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:~4.0.4":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+  version: 2.5.6
+  resolution: "form-data@npm:2.5.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+    safe-buffer: "npm:^5.2.1"
+  checksum: 10c0/de6b085a2b0d013299ccc888b677dbdb3d2a54ef8d74982bda9ad7d928f57440abae1bc736a5b85ea01077cfb6c72e9a7752dc786304271c03bd0013ef8f08cb
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:~4.0.4":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -12350,12 +12353,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.0, hasown@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "hasown@npm:2.0.2"
+"hasown@npm:^2.0.0, hasown@npm:^2.0.2, hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
   dependencies:
     function-bind: "npm:^1.1.2"
-  checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -15473,7 +15476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.19, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.27, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
Pin form-data to patched versions (2.5.6, 4.0.6) via Yarn resolutions to fix Content-Disposition header injection.

### Analysis / Root cause:
The form-data npm package (transitive dependency) versions 4.0.5 and 2.5.1 are vulnerable to CRLF injection ([CVE-2026-12143](https://nvd.nist.gov/vuln/detail/CVE-2026-12143)). Field names and filenames are concatenated into Content-Disposition headers without escaping CR, LF, or " characters, allowing header injection or multipart part smuggling. Two vulnerable versions are resolved in the lockfile:

form-data@4.0.5 via @cypress/request, @kubernetes/client-node, @types/node-fetch
form-data@2.5.1 via gitlab@10.0.1 (through @console/git-service)

### Solution description:
Updates yarn.lock to resolve form-data to patched versions (4.0.6 and 2.5.6). Both patched versions are within the existing semver ranges of all consumers, so no resolutions override is needed — this is a lockfile-only update. The fix escapes CR/LF/" as %0D/%0A/%22 per the WHATWG spec, matching browser behavior. No API changes.

**Test cases:**

 yarn install succeeds
 yarn why form-data confirms all 4 consumers resolve to patched versions
 yarn test packages/git-service — 9 suites, 123 tests pass
 yarn test packages/dev-console — 99 suites, 679 tests pass
 yarn build — production build succeeds
 yarn test-playwright --project=smoke — 5 tests pass against live OCP cluster
 CI passes

**Additional info:**

CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-12143
Jira: [OCPBUGS-90514](https://issues.redhat.com/browse/OCPBUGS-90514)

Assisted by: Claude Code (Opus 4.6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution settings to ensure consistent versions of form-data and protobufjs are used.
  * Improved dependency consistency and compatibility across supported version ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->