### PR TITLE
NO-JIRA: Add ReadWriteOncePod support for Cinder CSI driver

### DIFF
--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -46,8 +46,8 @@ const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object.freeze
     Block: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
   },
   'kubernetes.io/cinder': {
-    Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod', 'ReadWriteOncePod'],
-    Block: ['ReadWriteOnce', 'ReadWriteOncePod', 'ReadWriteOncePod'],
+    Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+    Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
   },
   'kubernetes.io/azure-file': {
     Filesystem: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
@@ -99,8 +99,8 @@ const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object.freeze
     Block: ['ReadWriteOnce'],
   },
   'cinder.csi.openstack.org': {
-    Filesystem: ['ReadWriteOnce'],
-    Block: ['ReadWriteOnce'],
+    Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+    Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
   },
   'pd.csi.storage.gke.io': {
     Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],


### PR DESCRIPTION
**Analysis / Root cause**:

The provisioner-to-access-mode mapping in `frontend/public/components/storage/shared.ts` did not list `ReadWriteOncePod` for the OpenStack Cinder CSI driver (`cinder.csi.openstack.org`), so the access mode was not offered in the console when creating a PVC or a StorageClass-backed volume with that provisioner. The Cinder CSI driver reports the `SINGLE_NODE_SINGLE_WRITER` capability, which maps to `ReadWriteOncePod`, so the mode is valid for both `Filesystem` and `Block` volume modes.

Separately, the in-tree `kubernetes.io/cinder` entry listed `ReadWriteOncePod` twice in both of its volume mode arrays.

**Solution description**:

- `cinder.csi.openstack.org`: added `ReadWriteOncePod` to the `Filesystem` and `Block` access mode lists.
- `kubernetes.io/cinder`: removed the duplicated `ReadWriteOncePod` entry from both lists. This had no functional effect, since `getAccessModeForProvisioner` de-duplicates the result with a `Set`, but the mapping itself was incorrect.

No API, extension, or i18n changes. `ReadWriteOncePod` is already part of the `AccessMode` type, `initialAccessModes`, and `getAccessModeOptions`.

**Screenshots / screen recording**:
<!-- To be added -->

**Test setup:**

An OpenShift cluster running on OpenStack with the Cinder CSI driver installed, providing a StorageClass whose provisioner is `cinder.csi.openstack.org`.

**Test cases:**

1. Navigate to Storage → PersistentVolumeClaims → Create PersistentVolumeClaim.
2. Select a StorageClass backed by `cinder.csi.openstack.org`.
3. Verify the access mode options include "Read write once pod (RWOP)" alongside "Single user (RWO)".
4. Select RWOP with volume mode `Filesystem`, create the PVC, and verify it binds and reports `ReadWriteOncePod`.
5. Repeat step 4 with volume mode `Block`.
6. Regression: with a StorageClass backed by another provisioner (for example `manila.csi.openstack.org`), verify its access mode options are unchanged.

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**

Reference: [Kubernetes access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) and the [Cinder CSI driver capabilities](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/features.md).

**Reviewers and assignees:**
<!-- Tag an OCP console engineer to review the changes and verify the functionality. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected supported storage access modes for Kubernetes Cinder volumes.
  * Added `ReadWriteOncePod` support for OpenStack Cinder CSI volumes.
  * Removed a duplicate access mode entry to ensure accurate volume configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->