### PR TITLE
[release-4.18] OCPBUGS-100069: quickstart page i18n misses (Fix Quick Starts i18n bundle lookup for zh-CN)

### DIFF
--- a/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
+++ b/frontend/packages/console-app/src/components/quick-starts/utils/quick-start-context.tsx
@@ -162,8 +162,8 @@ export const useValuesForQuickStartContext = (): QuickStartContextValues => {
     [activeQuickStartID, setAllQuickStartStates, fireTelemetryEvent],
   );
 
-  const language = getLastLanguage() || 'en';
-  const resourceBundle = i18n.getResourceBundle(language, 'console-app');
+  const language = i18n.resolvedLanguage || 'en';
+  const resourceBundle = i18n.getResourceBundle(language, 'console-app') ?? {};
   const processedResourceBundle = getProcessedResourceBundle(resourceBundle, language);
 
   // https://github.com/i18next/i18next-parser#caveats

--- a/frontend/packages/console-app/src/components/user-preferences/language/useLanguage.ts
+++ b/frontend/packages/console-app/src/components/user-preferences/language/useLanguage.ts
@@ -10,12 +10,13 @@ export const useLanguage = (preferredLanguage: string, preferredLanguageLoaded: 
   const { setResourceBundle } = useQuickStartContext();
 
   React.useEffect(() => {
-    const onLanguageChange = (lng: string) => {
+    const onLanguageChange = () => {
       if (setResourceBundle) {
         // Update language resource of quick starts components
-        const resourceBundle = i18n.getResourceBundle(lng, 'console-app');
-        const processedBundle = getProcessedResourceBundle(resourceBundle, lng);
-        setResourceBundle(processedBundle, lng);
+        const language = i18n.resolvedLanguage || 'en';
+        const resourceBundle = i18n.getResourceBundle(language, 'console-app') ?? {};
+        const processedBundle = getProcessedResourceBundle(resourceBundle, language);
+        setResourceBundle(processedBundle, language);
       }
     };
     const preferredLanguageInStorage: string = getLastLanguage();


### PR DESCRIPTION
Use i18n.resolvedLanguage for Quick Starts resource-bundle lookup so locale variants like zh-CN resolve to the correct console-app translations. Manual backport of #16819 to release-4.18 (cherry-pick conflict in useLanguage.ts).

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->
