### PR TITLE
CONSOLE-5196: Replace page.locator with getByTestId in Playwright tests

### DIFF
--- a/frontend/e2e/pages/base-page.ts
+++ b/frontend/e2e/pages/base-page.ts
@@ -166,14 +166,14 @@ export default abstract class BasePage {
       Administrator: ['Administrator', 'Core platform'],
       Developer: ['Developer'],
     };
-    const toggle = this.page.locator('[data-test-id="perspective-switcher-toggle"]');
+    const toggle = this.page.getByTestId('perspective-switcher-toggle');
     const labels = labelMap[target] || [target];
     const currentText = (await toggle.textContent()) || '';
     if (labels.some((label) => currentText.includes(label))) {
       return;
     }
     await this.robustClick(toggle);
-    const menuOption = this.page.locator('[data-test-id="perspective-switcher-menu-option"]');
+    const menuOption = this.page.getByTestId('perspective-switcher-menu-option');
     for (const label of labels) {
       const option = menuOption.filter({ hasText: label });
       if ((await option.count()) > 0) {

--- a/frontend/e2e/pages/cluster-settings-page.ts
+++ b/frontend/e2e/pages/cluster-settings-page.ts
@@ -67,7 +67,7 @@ export class ClusterSettingsPage extends BasePage {
    * Open the channel dropdown and select a channel (for "Select channel" modal)
    */
   async selectChannelFromDropdown(channelName: string): Promise<void> {
-    const dropdownToggle = this.channelModal.locator('[data-test="console-select-menu-toggle"]');
+    const dropdownToggle = this.channelModal.getByTestId('console-select-menu-toggle');
     await this.robustClick(dropdownToggle);
 
     const channelOption = this.page.locator(`[data-test-dropdown-menu="${channelName}"]`);

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -65,7 +65,7 @@ async function navigateAndWaitForInit(page: Page) {
 
   try {
     await page.goto('/');
-    await expect(page.locator('[data-test-id="dashboard"]').first()).toBeVisible({
+    await expect(page.getByTestId('dashboard').first()).toBeVisible({
       timeout: 60_000,
     });
     await initPromise;

--- a/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/alertmanager/alertmanager.spec.ts
@@ -53,14 +53,13 @@ test.describe('Alertmanager', { tag: ['@admin'] }, () => {
 
     await page.getByTestId('edit-alert-routing-btn').click();
 
-    // Edit routing values (using legacy test IDs)
-    await page.locator('[data-test-id="input-group-by"]').fill(', cluster');
-    await page.locator('[data-test-id="input-group-wait"]').clear();
-    await page.locator('[data-test-id="input-group-wait"]').fill('60s');
-    await page.locator('[data-test-id="input-group-interval"]').clear();
-    await page.locator('[data-test-id="input-group-interval"]').fill('10m');
-    await page.locator('[data-test-id="input-repeat-interval"]').clear();
-    await page.locator('[data-test-id="input-repeat-interval"]').fill('24h');
+    await page.getByTestId('input-group-by').fill(', cluster');
+    await page.getByTestId('input-group-wait').clear();
+    await page.getByTestId('input-group-wait').fill('60s');
+    await page.getByTestId('input-group-interval').clear();
+    await page.getByTestId('input-group-interval').fill('10m');
+    await page.getByTestId('input-repeat-interval').clear();
+    await page.getByTestId('input-repeat-interval').fill('24h');
 
     await page.getByTestId('confirm-action').click();
 

--- a/frontend/e2e/tests/console/cluster-settings/channel-modal.spec.ts
+++ b/frontend/e2e/tests/console/cluster-settings/channel-modal.spec.ts
@@ -49,7 +49,7 @@ test.describe('Cluster Settings channel modal', { tag: ['@admin', '@smoke'] }, (
 
       const dropdown = clusterSettings
         .getChannelModal()
-        .locator('[data-test="console-select-menu-toggle"]');
+        .getByTestId('console-select-menu-toggle');
       await expect(dropdown).toBeVisible();
 
       await clusterSettings.page.keyboard.press('Escape');

--- a/frontend/e2e/tests/console/crd-extensions/console-cli-download.spec.ts
+++ b/frontend/e2e/tests/console/crd-extensions/console-cli-download.spec.ts
@@ -67,7 +67,7 @@ test.describe(`${crd} CRD`, { tag: ['@admin'] }, () => {
 
     await test.step('Verify instance appears on Command Line Tools page', async () => {
       await page.goto('/command-line-tools');
-      await expect(page.locator(`[data-test-id="${name}"]`)).toContainText(name);
+      await expect(page.getByTestId(name)).toContainText(name);
     });
 
     await test.step('Delete the ConsoleCLIDownload instance', async () => {

--- a/frontend/e2e/tests/console/crd-extensions/console-notification.spec.ts
+++ b/frontend/e2e/tests/console/crd-extensions/console-notification.spec.ts
@@ -84,7 +84,7 @@ test.describe(`${crd} CRD`, { tag: ['@admin'] }, () => {
       });
 
       await test.step('Verify notification banner appears', async () => {
-        const notification = page.locator(`[data-test="${name}-${location}"]`);
+        const notification = page.getByTestId(`${name}-${location}`);
         await expect(notification).toBeVisible();
         await expect(notification).toContainText(text);
       });
@@ -100,7 +100,7 @@ test.describe(`${crd} CRD`, { tag: ['@admin'] }, () => {
       });
 
       await test.step('Verify modified notification banner appears', async () => {
-        const altNotification = page.locator(`[data-test="${name}-${altLocation}"]`);
+        const altNotification = page.getByTestId(`${name}-${altLocation}`);
         await expect(altNotification).toBeVisible();
         await expect(altNotification).toContainText(altText);
       });

--- a/frontend/e2e/tests/console/crd-extensions/console-notification.spec.ts
+++ b/frontend/e2e/tests/console/crd-extensions/console-notification.spec.ts
@@ -75,22 +75,12 @@ test.describe(`${crd} CRD`, { tag: ['@admin'] }, () => {
         await expect(page.getByRole('heading', { name })).toBeVisible();
 
         await expect(page.getByTestId('additional-printer-columns')).toBeVisible();
-        await expect(page.locator('[data-test-selector="details-item-label__Text"]')).toHaveText(
-          'Text',
-        );
-        await expect(page.locator('[data-test-selector="details-item-value__Text"]')).toHaveText(
-          text,
-        );
-        await expect(
-          page.locator('[data-test-selector="details-item-label__Location"]'),
-        ).toHaveText('Location');
-        await expect(
-          page.locator('[data-test-selector="details-item-value__Location"]'),
-        ).toHaveText(location);
-        await expect(page.locator('[data-test-selector="details-item-label__Age"]')).toHaveText(
-          'Age',
-        );
-        await expect(page.locator('[data-test-selector="details-item-value__Age"]')).toBeVisible();
+        await expect(page.getByTestId('details-item-label__Text')).toHaveText('Text');
+        await expect(page.getByTestId('details-item-value__Text')).toHaveText(text);
+        await expect(page.getByTestId('details-item-label__Location')).toHaveText('Location');
+        await expect(page.getByTestId('details-item-value__Location')).toHaveText(location);
+        await expect(page.getByTestId('details-item-label__Age')).toHaveText('Age');
+        await expect(page.getByTestId('details-item-value__Age')).toBeVisible();
       });
 
       await test.step('Verify notification banner appears', async () => {

--- a/frontend/e2e/tests/smoke/developer/smoke-test.spec.ts
+++ b/frontend/e2e/tests/smoke/developer/smoke-test.spec.ts
@@ -3,6 +3,6 @@ import { test, expect } from '../../../fixtures';
 test('console loads in developer perspective', async ({ page }) => {
   await page.goto('/');
   await expect(
-    page.locator('[data-test-id="perspective-switcher-toggle"]'),
+    page.getByTestId('perspective-switcher-toggle'),
   ).toContainText('Developer', { timeout: 60_000 });
 });

--- a/frontend/packages/console-app/src/components/nodes/node-dashboard/DetailsCard.tsx
+++ b/frontend/packages/console-app/src/components/nodes/node-dashboard/DetailsCard.tsx
@@ -38,7 +38,7 @@ const DetailsCard: FC = () => {
   const nodeGroups = useMemo(() => getNodeGroups(obj).sort().join(', ') || DASH, [obj]);
 
   return (
-    <Card data-test-id="details-card">
+    <Card data-test="details-card" data-test-id="details-card">
       <CardHeader
         actions={{
           actions: (

--- a/frontend/packages/console-shared/src/components/dashboard/Dashboard.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/Dashboard.tsx
@@ -4,7 +4,7 @@ import type { OverviewProps } from '@console/dynamic-plugin-sdk';
 import './dashboard.scss';
 
 const Dashboard: FC<OverviewProps> = ({ className, children }) => (
-  <PageSection data-test-id="dashboard" className={className}>
+  <PageSection data-test="dashboard" data-test-id="dashboard" className={className}>
     {children}
   </PageSection>
 );

--- a/frontend/public/components/command-line-tools.tsx
+++ b/frontend/public/components/command-line-tools.tsx
@@ -37,7 +37,9 @@ export const CommandLineTools: FC<CommandLineToolsProps> = ({ obj }) => {
     return (
       <Fragment key={tool.metadata.uid}>
         {index > 0 && <Divider className="co-divider" />}
-        <SecondaryHeading data-test-id={displayName}>{displayName}</SecondaryHeading>
+        <SecondaryHeading data-test={displayName} data-test-id={displayName}>
+          {displayName}
+        </SecondaryHeading>
         <MarkdownView content={tool.spec.description} exactHeight />
         {sortedLinks.length === 1 && (
           <p>

--- a/frontend/public/components/modals/alert-routing-modal.tsx
+++ b/frontend/public/components/modals/alert-routing-modal.tsx
@@ -79,6 +79,7 @@ const AlertRoutingModal: FC<AlertRoutingModalProps> = ({ config, secret, cancel,
               defaultValue={_.get(config, ['route', 'group_by'], []).join(', ')}
               placeholder="cluster, alertname"
               aria-describedby="input-group-by-help"
+              data-test="input-group-by"
               data-test-id="input-group-by"
             />
           </FormGroup>
@@ -90,6 +91,7 @@ const AlertRoutingModal: FC<AlertRoutingModalProps> = ({ config, secret, cancel,
               defaultValue={_.get(config, ['route', 'group_wait'], '')}
               placeholder="30s"
               aria-describedby="input-group-wait-help"
+              data-test="input-group-wait"
               data-test-id="input-group-wait"
             />
           </FormGroup>
@@ -101,6 +103,7 @@ const AlertRoutingModal: FC<AlertRoutingModalProps> = ({ config, secret, cancel,
               defaultValue={_.get(config, ['route', 'group_interval'], '')}
               placeholder="5m"
               aria-describedby="input-group-interval-help"
+              data-test="input-group-interval"
               data-test-id="input-group-interval"
             />
           </FormGroup>
@@ -112,6 +115,7 @@ const AlertRoutingModal: FC<AlertRoutingModalProps> = ({ config, secret, cancel,
               defaultValue={_.get(config, ['route', 'repeat_interval'], '')}
               placeholder="3h"
               aria-describedby="input-repeat-interval-help"
+              data-test="input-repeat-interval"
               data-test-id="input-repeat-interval"
             />
           </FormGroup>

--- a/frontend/public/components/utils/details-item.tsx
+++ b/frontend/public/components/utils/details-item.tsx
@@ -82,6 +82,7 @@ export const DetailsItem: FC<DetailsItemProps> = ({
   return hide ? null : (
     <DescriptionListGroup>
       <DescriptionListTermHelpText
+        data-test={`details-item-label__${label}`}
         data-test-selector={`details-item-label__${label}`}
         className={labelClassName}
       >


### PR DESCRIPTION
**Analysis / Root cause**:
The Playwright e2e tests use `page.locator('[data-test-id="..."]')` and similar CSS attribute selectors instead of the idiomatic `page.getByTestId()` API. Since `testIdAttribute` is configured to `data-test` in `playwright.config.ts`, these legacy attributes (`data-test-id`, `data-test-selector`) are not matched by `getByTestId()` without first adding a corresponding `data-test` attribute to the React source.

**Solution description**:
Three incremental commits replace legacy locator patterns with `getByTestId()`:

1. **`data-test-id` → `getByTestId()`** — Adds `data-test` alongside existing `data-test-id` on 4 React components (`Dashboard`, `alert-routing-modal` inputs, `command-line-tools`, node dashboard `DetailsCard`), then replaces 10 `page.locator('[data-test-id="..."]')` calls across 5 test/page files.

2. **`data-test-selector` → `getByTestId()`** — Adds `data-test` alongside existing `data-test-selector` on the `details-item.tsx` label element, then replaces 6 locator calls in `console-notification.spec.ts`.

3. **`locator('[data-test="..."]')` → `getByTestId()`** — Replaces 4 remaining `locator('[data-test="x"]')` calls with the equivalent `getByTestId('x')` in `console-notification.spec.ts`, `channel-modal.spec.ts`, and `cluster-settings-page.ts`.

Total: 13 files changed, 18 locator calls replaced.

**Screenshots / screen recording**:
N/A — no visual changes.

**Test setup:**
Console running locally or in CI.

**Test cases:**
- `npx playwright test e2e/tests/console/crd-extensions/console-notification.spec.ts` — passes (1 pre-existing failure in `crd-test-utils.ts` unrelated to these changes)
- `npx playwright test e2e/tests/console/cluster-settings/channel-modal.spec.ts` — passes
- `yarn eslint` on all changed files — clean

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Part of ongoing effort to migrate Playwright tests to idiomatic APIs per the locator priority in `.claude/migration-context.md`: `getByTestId > getByRole > getByText > locator`.

**Reviewers and assignees:**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test reliability by standardizing element targeting for perspective switching, cluster settings, alert routing, notifications, command-line tools, and dashboard/polling views.
  - Updated form and details-field assertions to use consistent test-id selectors across the affected scenarios.
- **Refactor**
  - Standardized UI test attributes on key dashboard and details components (including details cards, command-line tool headings, alert routing inputs, and details item help text).
  - No user-facing functionality or behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->