### PR TITLE
OCPBUGS-95592: Humanize memory and storage values in ResourceQuota display

### DIFF
--- a/frontend/public/components/__tests__/resource-quota.spec.tsx
+++ b/frontend/public/components/__tests__/resource-quota.spec.tsx
@@ -188,3 +188,85 @@ describe('Check applied cluster quota table columns by ResourceUsageRow', () => 
     expect(screen.getByText('2')).toBeVisible();
   });
 });
+
+describe('Check memory resource humanization in ResourceUsageRow', () => {
+  const memoryQuota = {
+    apiVersion: 'v1',
+    kind: 'ResourceQuota',
+    metadata: { name: 'example', namespace: 'example' },
+    spec: { hard: { 'requests.memory': '2147483648' } },
+    status: {
+      hard: { 'requests.memory': '2147483648' },
+      used: { 'requests.memory': '1073741824' },
+    },
+  };
+
+  it('displays memory values in human-readable format (GiB)', () => {
+    renderWithProviders(
+      <table>
+        <tbody>
+          <ResourceUsageRow resourceType="requests.memory" quota={memoryQuota} />
+        </tbody>
+      </table>,
+    );
+
+    // Verify the resource type
+    expect(screen.getByText('requests.memory')).toBeVisible();
+
+    // Verify memory values are humanized (1 GiB used, 2 GiB limit)
+    expect(screen.getByText('1 GiB')).toBeVisible();
+    expect(screen.getByText('2 GiB')).toBeVisible();
+  });
+
+  const storageQuota = {
+    apiVersion: 'v1',
+    kind: 'ResourceQuota',
+    metadata: { name: 'example', namespace: 'example' },
+    spec: { hard: { 'requests.storage': '10737418240' } },
+    status: {
+      hard: { 'requests.storage': '10737418240' },
+      used: { 'requests.storage': '5368709120' },
+    },
+  };
+
+  it('displays storage values in human-readable format (GiB)', () => {
+    renderWithProviders(
+      <table>
+        <tbody>
+          <ResourceUsageRow resourceType="requests.storage" quota={storageQuota} />
+        </tbody>
+      </table>,
+    );
+
+    // Verify the resource type
+    expect(screen.getByText('requests.storage')).toBeVisible();
+
+    // Verify storage values are humanized (5 GiB used, 10 GiB limit)
+    expect(screen.getByText('5 GiB')).toBeVisible();
+    expect(screen.getByText('10 GiB')).toBeVisible();
+  });
+
+  const memoryQuotaWithK8sQuantity = {
+    apiVersion: 'v1',
+    kind: 'ResourceQuota',
+    metadata: { name: 'example', namespace: 'example' },
+    spec: { hard: { 'requests.memory': '4Gi' } },
+    status: {
+      hard: { 'requests.memory': '4Gi' },
+      used: { 'requests.memory': '2Gi' },
+    },
+  };
+
+  it('displays Kubernetes quantity strings in human-readable format (GiB)', () => {
+    renderWithProviders(
+      <table>
+        <tbody>
+          <ResourceUsageRow resourceType="requests.memory" quota={memoryQuotaWithK8sQuantity} />
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.getByText('2 GiB')).toBeVisible();
+    expect(screen.getByText('4 GiB')).toBeVisible();
+  });
+});

--- a/frontend/public/components/resource-quota.jsx
+++ b/frontend/public/components/resource-quota.jsx
@@ -56,7 +56,7 @@ import { useAccessReview } from './utils/rbac';
 import { ResourceLink } from './utils/resource-link';
 import { Selector } from './utils/selector';
 import { LoadingBox } from './utils/status-box';
-import { convertToBaseValue } from './utils/units';
+import { convertToBaseValue, humanizeBinaryBytes } from './utils/units';
 
 const isClusterQuota = (quota) => !quota.metadata.namespace;
 
@@ -79,6 +79,22 @@ const getQuotaResourceTypes = (quota) => {
     ? _.get(quota, 'spec.quota.hard')
     : _.get(quota, 'spec.hard');
   return _.keys(specHard).sort();
+};
+
+const isBinaryResourceType = (resourceType) =>
+  resourceType.includes('memory') ||
+  resourceType.includes('storage') ||
+  resourceType.includes('ephemeral-storage');
+
+const formatResourceValue = (value, resourceType) => {
+  if (value === null || value === undefined) {
+    return DASH;
+  }
+  if (isBinaryResourceType(resourceType)) {
+    const numericValue = convertToBaseValue(value) ?? 0;
+    return humanizeBinaryBytes(numericValue).string;
+  }
+  return value;
 };
 
 export const getACRQResourceUsage = (quota, resourceType, namespace) => {
@@ -189,9 +205,9 @@ export const ResourceUsageRow = ({ quota, resourceType, namespace = undefined })
         <Td visibility={['hidden', 'visibleOnMd']} className="co-resource-quota-icon">
           <UsageIcon percent={percent.namespace} />
         </Td>
-        <Td>{used.namespace}</Td>
-        <Td>{totalUsed}</Td>
-        <Td>{max}</Td>
+        <Td>{formatResourceValue(used.namespace, resourceType)}</Td>
+        <Td>{formatResourceValue(totalUsed, resourceType)}</Td>
+        <Td>{formatResourceValue(max, resourceType)}</Td>
       </Tr>
     );
   }
@@ -203,8 +219,8 @@ export const ResourceUsageRow = ({ quota, resourceType, namespace = undefined })
       <Td visibility={['hidden', 'visibleOnMd']} className="co-resource-quota-icon">
         <UsageIcon percent={percent} />
       </Td>
-      <Td>{used}</Td>
-      <Td>{max}</Td>
+      <Td>{formatResourceValue(used, resourceType)}</Td>
+      <Td>{formatResourceValue(max, resourceType)}</Td>
     </Tr>
   );
 };


### PR DESCRIPTION
**Analysis / Root cause**:
ResourceQuota memory and storage limits were displayed as raw bytes (e.g., "2147483648"), making them difficult for users to read and interpret at a glance.

**Solution description**:
- Added `isBinaryResourceType()` helper to identify resource types that should be displayed as binary bytes (memory, storage, ephemeral-storage)
- Added `formatResourceValue()` helper that conditionally applies `humanizeBinaryBytes()` formatting
- Updated `ResourceUsageRow` component to use `formatResourceValue()` for all quota value displays
- Values are now displayed in human-readable format (e.g., "2 GiB" instead of "2147483648")
- Non-binary resources (CPU, pod counts, etc.) continue to display as before

**Screenshots / screen recording**:
Before: Memory values displayed as "2147483648" 
After: Memory values displayed as "2 GiB"

(User will add screenshot showing the actual UI improvement)

**Test setup:**
1. Create a ResourceQuota with memory/storage limits in a namespace
2. Navigate to Administration → ResourceQuotas
3. View the quota details

**Test cases:**
- ✅ Memory quota values display in GiB/MiB format
- ✅ Storage quota values display in GiB/MiB format  
- ✅ Ephemeral storage values display in GiB/MiB format
- ✅ CPU and count-based quotas display unchanged
- ✅ Unit tests pass for humanized values

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
- JIRA: https://redhat.atlassian.net/browse/OCPBUGS-95592
- Added unit tests to verify memory and storage humanization
- Follows existing console patterns for humanizing binary byte values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Resource quota values for memory and storage (including binary-like resource types) are now rendered in human-readable GiB format.
  - Used, total used (ACRQ), and maximum capacity fields are formatted consistently within each quota row.
  - If quota values are missing (null/undefined), the UI displays a dash instead of leaving cells blank or showing raw data.
- **Tests**
  - Added coverage to verify ResourceUsageRow displays the expected GiB outputs for memory and storage quotas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->