### PR TITLE
OCPBUGS-98943: Make developerCatalog.types matching case-insensitive

### DIFF
--- a/frontend/packages/console-shared/src/components/catalog/utils/__tests__/catalog-utils.spec.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/utils/__tests__/catalog-utils.spec.tsx
@@ -4,6 +4,7 @@ import {
   calculateCatalogItemRelevanceScore,
   getRedHatPriority,
   sortCatalogItems,
+  isCatalogTypeEnabled,
 } from '../catalog-utils';
 import { CatalogSortOrder } from '../types';
 
@@ -464,5 +465,67 @@ describe('sortCatalogItems', () => {
       // Should behave like RELEVANCE mode
       expect(result[0].name).toBe('Zebra Operator'); // Red Hat priority
     });
+  });
+});
+
+describe('isCatalogTypeEnabled - case-insensitive matching', () => {
+  let originalDeveloperCatalogTypes;
+
+  beforeEach(() => {
+    originalDeveloperCatalogTypes = window.SERVER_FLAGS.developerCatalogTypes;
+    window.SERVER_FLAGS = { ...window.SERVER_FLAGS };
+    delete window.SERVER_FLAGS.developerCatalogTypes;
+  });
+
+  afterEach(() => {
+    if (originalDeveloperCatalogTypes !== undefined) {
+      window.SERVER_FLAGS.developerCatalogTypes = originalDeveloperCatalogTypes;
+    } else {
+      delete window.SERVER_FLAGS.developerCatalogTypes;
+    }
+  });
+
+  it('should return true when no developerCatalogTypes configuration exists', () => {
+    expect(isCatalogTypeEnabled('operator')).toBe(true);
+    expect(isCatalogTypeEnabled('HelmChart')).toBe(true);
+  });
+
+  it('should perform case-insensitive matching for enabled types', () => {
+    window.SERVER_FLAGS.developerCatalogTypes = JSON.stringify({
+      state: 'Enabled',
+      enabled: ['operator', 'HelmChart', 'Template'],
+    });
+
+    // Exact case match
+    expect(isCatalogTypeEnabled('operator')).toBe(true);
+    expect(isCatalogTypeEnabled('HelmChart')).toBe(true);
+
+    // Different capitalization should still match
+    expect(isCatalogTypeEnabled('Operator')).toBe(true);
+    expect(isCatalogTypeEnabled('OPERATOR')).toBe(true);
+    expect(isCatalogTypeEnabled('helmchart')).toBe(true);
+    expect(isCatalogTypeEnabled('template')).toBe(true);
+    expect(isCatalogTypeEnabled('TEMPLATE')).toBe(true);
+
+    // Non-enabled type should return false
+    expect(isCatalogTypeEnabled('Devfile')).toBe(false);
+  });
+
+  it('should perform case-insensitive matching for disabled types', () => {
+    window.SERVER_FLAGS.developerCatalogTypes = JSON.stringify({
+      state: 'Disabled',
+      disabled: ['operator', 'HelmChart'],
+    });
+
+    // Disabled types should return false regardless of capitalization
+    expect(isCatalogTypeEnabled('operator')).toBe(false);
+    expect(isCatalogTypeEnabled('Operator')).toBe(false);
+    expect(isCatalogTypeEnabled('OPERATOR')).toBe(false);
+    expect(isCatalogTypeEnabled('helmchart')).toBe(false);
+    expect(isCatalogTypeEnabled('HelmChart')).toBe(false);
+
+    // Non-disabled types should return true
+    expect(isCatalogTypeEnabled('Template')).toBe(true);
+    expect(isCatalogTypeEnabled('template')).toBe(true);
   });
 });

--- a/frontend/packages/console-shared/src/components/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/console-shared/src/components/catalog/utils/catalog-utils.tsx
@@ -396,15 +396,22 @@ export const applyCatalogItemMetadata = (
 export const isCatalogTypeEnabled = (catalogType: string): boolean => {
   const softwareCatalogTypes = getSoftwareCatalogTypes();
   if (softwareCatalogTypes) {
+    // Normalize catalog type to lowercase for case-insensitive comparison
+    const normalizedCatalogType = catalogType?.toLowerCase();
+
     if (
       softwareCatalogTypes?.state === CatalogVisibilityState.Enabled &&
       softwareCatalogTypes?.enabled?.length > 0
     ) {
-      return softwareCatalogTypes?.enabled.includes(catalogType);
+      return softwareCatalogTypes?.enabled.some(
+        (type) => type.toLowerCase() === normalizedCatalogType,
+      );
     }
     if (softwareCatalogTypes?.state === CatalogVisibilityState.Disabled) {
       if (softwareCatalogTypes?.disabled?.length > 0) {
-        return !softwareCatalogTypes?.disabled.includes(catalogType);
+        return !softwareCatalogTypes?.disabled.some(
+          (type) => type.toLowerCase() === normalizedCatalogType,
+        );
       }
       return false;
     }
@@ -425,7 +432,8 @@ export const useGetAllDisabledSubCatalogs = () => {
         softwareCatalogTypes?.enabled?.length > 0
       ) {
         const disabledSubCatalogs = catalogTypeExtensions.filter(
-          (val) => !softwareCatalogTypes?.enabled.includes(val),
+          (val) =>
+            !softwareCatalogTypes?.enabled.some((type) => type.toLowerCase() === val.toLowerCase()),
         );
         return [disabledSubCatalogs];
       }


### PR DESCRIPTION
**Analysis / Root cause**:
The `developerCatalog.types.enabled` configuration in `console.operator.openshift.io` CR had inconsistent case sensitivity. The catalog type `operator` (lowercase) worked, but `Operator` (capitalized) did not, even though `HelmChart` and `Template` worked with capitals.

Root cause: The filtering logic used exact string matching (`.includes()`), so users had to know the exact capitalization of each catalog type identifier to configure it correctly.

**Solution description**:
Made catalog type matching case-insensitive by normalizing both the configured types and the comparison types to lowercase before matching.

Changes made:
- Updated `isCatalogTypeEnabled()` to use `.some()` with case-insensitive comparison instead of `.includes()`
- Updated `useGetAllDisabledSubCatalogs()` to use case-insensitive filtering  
- Added comprehensive unit tests covering enabled/disabled types with various capitalizations

**Screenshots / screen recording**:
Before: `developerCatalog.types.enabled: ["Operator"]` → Operators category missing
After: `developerCatalog.types.enabled: ["Operator"]` → Operators category displays correctly

User can now use any of these and they all work:
- `["operator"]` ✅
- `["Operator"]` ✅ (newly fixed)
- `["OPERATOR"]` ✅ (newly fixed)

**Test setup:**
1. Edit the console operator: `oc edit console.operator.openshift.io`
2. Set `developerCatalog.types.state: Enabled` with `enabled: ["Operator"]` (capitalized)
3. Navigate to Developer → Ecosystem → Software Catalog

**Test cases:**
- ✅ `enabled: ["Operator"]` now displays Operators category
- ✅ `enabled: ["operator"]` continues to work
- ✅ `enabled: ["OPERATOR"]` now works
- ✅ `enabled: ["HelmChart", "Template", "Operator"]` all display correctly
- ✅ `disabled: ["Operator"]` hides Operators regardless of capitalization
- ✅ Unit tests pass for case-insensitive matching
- ✅ Existing configurations continue to work unchanged

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
- JIRA: https://redhat.atlassian.net/browse/OCPBUGS-98943
- This fixes the confusing UX where users had to guess the exact capitalization
- No breaking changes - all existing configurations continue to work
- Added unit tests to prevent regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog type enablement and enable/disable rules are now case-insensitive, ensuring consistent results with mixed-case configuration.
  * Disabled sub-catalog detection now correctly excludes enabled types even when inputs use different capitalization.

* **Tests**
  * Added coverage for missing configuration and both enabled/disabled scenarios, including case-insensitive matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->