### PR TITLE
CONSOLE-5196: Refresh admin auth mid-run to prevent session expiry cascade

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -29,6 +29,13 @@ const packages = [
 // Packages that also have developer-persona tests
 const devPackages = ['smoke', 'dev-console', 'topology', 'webterminal'];
 
+const setupDir = path.resolve(__dirname, 'e2e', 'setup');
+const chromeAuth = {
+  ...devices['Desktop Chrome'],
+  userAgent: INTEGRATION_TEST_USER_AGENT,
+  ignoreHTTPSErrors: true,
+};
+
 const chromeArgs = [
   '--ignore-certificate-errors',
   '--window-size=1920,1080',
@@ -127,16 +134,31 @@ export default defineConfig({
       testMatch: 'teardown.setup.ts',
     },
 
-    ...packages.map((pkg) => ({
-      name: pkg,
-      testDir: path.resolve(__dirname, 'e2e', 'tests', pkg),
-      testIgnore: '**/developer/**',
-      dependencies: ['admin-auth'],
-      use: {
-        ...chrome,
-        storageState: adminStorageState,
-      },
-    })),
+    ...packages.flatMap((pkg, i) => {
+      const prevDep = i === 0 ? 'admin-auth' : packages[i - 1];
+      const refreshProject =
+        i > 0
+          ? [
+              {
+                name: `admin-auth-refresh-${i}`,
+                testDir: setupDir,
+                testMatch: 'admin-auth.setup.ts',
+                dependencies: [prevDep],
+                use: { ...chromeAuth, launchOptions: { args: chromeArgs } },
+              },
+            ]
+          : [];
+      return [
+        ...refreshProject,
+        {
+          name: pkg,
+          testDir: path.resolve(__dirname, 'e2e', 'tests', pkg),
+          testIgnore: '**/developer/**',
+          dependencies: [i > 0 ? `admin-auth-refresh-${i}` : 'admin-auth'],
+          use: { ...chrome, storageState: adminStorageState },
+        },
+      ];
+    }),
     ...(hasDeveloper
       ? devPackages.map((pkg) => ({
           name: `${pkg}-developer`,


### PR DESCRIPTION
**Analysis / Root cause**:

Playwright CI runs all ~300 e2e tests using a single `storageState` (saved OAuth session cookies) created once at the start of the run. The OpenShift OAuth session has a fixed TTL, and with 300+ tests running across 2 workers (~50 min total runtime), the session can expire mid-run — typically around test ~220 when dev-console tests begin.

When the session expires:
1. `warmupSPA` navigates to `/` but the console backend rejects the stale cookie
2. The browser is redirected to `oauth-openshift.../oauth/authorize` then `auth/callback`
3. The page lands on the last-visited page (Topology) instead of a page with `page-heading`
4. `page-heading` is never found so the test fails
5. The `storageState` file on disk is never updated, so every subsequent test loads the same stale cookies causing a **cascade failure** (10-20+ tests fail in a row)

This has caused repeated CI failures across multiple migration PRs (#16741, #16751), where all dev-console, topology, and webterminal tests fail with identical `warmupSPA` OAuth redirect errors — despite the test code being correct (proven by passing on runs where auth holds).

**Solution description**:

Chain an auth refresh project between every test package so each package starts with a fresh OAuth session:

```
admin-auth → smoke → refresh-1 → console → refresh-2 → dev-console → refresh-3 → helm → ...
```

This serializes packages (each depends on the previous refresh) and inserts a lightweight `admin-auth-refresh-N` setup project before every package after the first. Each refresh re-runs the login flow and overwrites `kubeadmin.json` with a fresh session. Overhead is ~35s total (7 refreshes × ~5s each).

Changes:
- `playwright.config.ts`: Replace flat `packages.map()` with `packages.flatMap()` that generates interleaved refresh projects. Extract shared `setupDir` and `chromeAuth` config to reduce duplication.
- `e2e/setup/admin-auth-refresh.setup.ts`: New setup file that performs the same login as `admin-auth.setup.ts` to refresh the `storageState`. Supports `SKIP_GLOBAL_SETUP`, configurable credentials via `OPENSHIFT_USERNAME` / `BRIDGE_KUBEADMIN_PASSWORD`, and uses `import.meta.dirname`.

**Screenshots / screen recording**:
N/A (CI infrastructure change, no UI changes)

**Test setup:**
Tested locally against a live OCP 5.0 cluster. Verified:
- `admin-auth` creates initial `kubeadmin.json`
- `admin-auth-refresh-N` re-logs in and overwrites `kubeadmin.json`
- `dev-console` tests run successfully with the refreshed session (10/10 passed, zero auth redirect failures)

**Test cases:**
- CI run completes without auth expiry cascade in late test packages
- All existing tests continue to pass (no behavioral change to test execution, only dependency ordering)

**Browser conformance**:
N/A (no UI changes)

**Additional info:**
This complements PR #16780 which reduced runtime by setting `WORKERS=2`. That fix brought runtime from ~2h to ~50min, but session expiry still occurs non-deterministically depending on the ephemeral cluster OAuth token lifetime. This PR eliminates the root cause by refreshing auth before every package, ensuring no single package runs with a stale session regardless of total suite runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved browser test setup for authentication refresh scenarios.
  * Added consistent Chrome integration settings, including secure-connection handling and integration user-agent configuration.
  * Updated test sequencing so authentication state is refreshed and reused reliably across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->