### PR TITLE
HELM-520: Warn users about insecure HTTP Helm repository URLs and aut…

### DIFF
--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -80,7 +80,7 @@
   "HelmChartRepository": "HelmChartRepository",
   "Hide advanced options": "Hide advanced options",
   "Home page": "Home page",
-  "HTTP is unencrypted. Credentials may be exposed, and downloaded content may have been tampered with in transit. Use HTTPS whenever possible.": "HTTP is unencrypted. Credentials may be exposed, and downloaded content may have been tampered with in transit. Use HTTPS whenever possible.",
+  "HTTP is unencrypted, so your credentials and any downloaded content might be exposed or tampered with in transit. Use HTTPS whenever possible.": "HTTP is unencrypted, so your credentials and any downloaded content might be exposed or tampered with in transit. Use HTTPS whenever possible.",
   "Install": "Install",
   "Install Helm chart from Helm registry.": "Install Helm chart from Helm registry.",
   "Install Helm chart from URL": "Install Helm chart from URL",

--- a/frontend/packages/helm-plugin/locales/en/helm-plugin.json
+++ b/frontend/packages/helm-plugin/locales/en/helm-plugin.json
@@ -80,6 +80,7 @@
   "HelmChartRepository": "HelmChartRepository",
   "Hide advanced options": "Hide advanced options",
   "Home page": "Home page",
+  "HTTP is unencrypted. Credentials may be exposed, and downloaded content may have been tampered with in transit. Use HTTPS whenever possible.": "HTTP is unencrypted. Credentials may be exposed, and downloaded content may have been tampered with in transit. Use HTTPS whenever possible.",
   "Install": "Install",
   "Install Helm chart from Helm registry.": "Install Helm chart from Helm registry.",
   "Install Helm chart from URL": "Install Helm chart from URL",

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepository.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepository.tsx
@@ -26,6 +26,7 @@ import {
   getDefaultResource,
   convertToForm,
   convertToHelmChartRepository,
+  tryHttpsUpgrade,
 } from './helmchartrepository-create-utils';
 import { validationSchema } from './helmchartrepository-validation-utils';
 
@@ -108,6 +109,12 @@ const CreateHelmChartRepository: FC<CreateHelmChartRepositoryProps> = ({
       }
     } else {
       HelmChartRepositoryRes = convertToHelmChartRepository(values.formData, namespace);
+    }
+
+    const currentUrl = HelmChartRepositoryRes.spec?.connectionConfig?.url;
+    const upgradedUrl = await tryHttpsUpgrade(currentUrl);
+    if (upgradedUrl) {
+      HelmChartRepositoryRes.spec.connectionConfig.url = upgradedUrl;
     }
 
     const resourceCall = isEditForm

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepositoryFormEditor.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepositoryFormEditor.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useMemo } from 'react';
-import { TextInputTypes } from '@patternfly/react-core';
+import { TextInputTypes, Alert } from '@patternfly/react-core';
 import type { FormikValues } from 'formik';
 import { useFormikContext } from 'formik';
 import * as fuzzy from 'fuzzysearch';
@@ -142,6 +142,18 @@ const CreateHelmChartRepositoryFormEditor: FC<CreateHelmChartRepositoryFormEdito
         helpText={t('Helm Chart repository URL.')}
         required
       />
+      {formData.repoUrl?.startsWith('http://') && (
+        <>
+          <Alert
+            variant="warning"
+            isInline
+            isPlain
+            title={t(
+              'HTTP is unencrypted. Credentials may be exposed, and downloaded content may have been tampered with in transit. Use HTTPS whenever possible.',
+            )}
+          />
+        </>
+      )}
       <ExpandCollapse
         textExpanded={t('Hide advanced options')}
         textCollapsed={t('Show advanced options')}

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepositoryFormEditor.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/CreateHelmChartRepositoryFormEditor.tsx
@@ -149,7 +149,7 @@ const CreateHelmChartRepositoryFormEditor: FC<CreateHelmChartRepositoryFormEdito
             isInline
             isPlain
             title={t(
-              'HTTP is unencrypted. Credentials may be exposed, and downloaded content may have been tampered with in transit. Use HTTPS whenever possible.',
+              'HTTP is unencrypted, so your credentials and any downloaded content might be exposed or tampered with in transit. Use HTTPS whenever possible.',
             )}
           />
         </>

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/helmchartrepository-create-utils-https-upgrade.spec.ts
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/helmchartrepository-create-utils-https-upgrade.spec.ts
@@ -1,0 +1,67 @@
+import { tryHttpsUpgrade } from '../helmchartrepository-create-utils';
+
+describe('tryHttpsUpgrade', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('should return https URL when server responds with 200', async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    const result = await tryHttpsUpgrade('http://example.com/repo');
+    expect(result).toBe('https://example.com/repo');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/repo',
+      expect.objectContaining({ method: 'HEAD' }),
+    );
+  });
+
+  it('should return null when server responds with a non-OK status', async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    const result = await tryHttpsUpgrade('http://example.com/repo');
+    expect(result).toBeNull();
+  });
+
+  it('should return null when server responds with 500', async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    const result = await tryHttpsUpgrade('http://example.com/repo');
+    expect(result).toBeNull();
+  });
+
+  it('should return null when server does not support HTTPS', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    const result = await tryHttpsUpgrade('http://example.com/repo');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for HTTPS URLs', async () => {
+    const result = await tryHttpsUpgrade('https://example.com');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for OCI URLs', async () => {
+    const result = await tryHttpsUpgrade('oci://registry.io/chart');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for null or undefined input', async () => {
+    expect(await tryHttpsUpgrade(null)).toBeNull();
+    expect(await tryHttpsUpgrade(undefined)).toBeNull();
+  });
+
+  it('should return null when fetch times out', async () => {
+    global.fetch = jest.fn().mockImplementation(
+      (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener('abort', () => reject(new DOMException('Aborted')));
+        }),
+    );
+    jest.useFakeTimers();
+    const promise = tryHttpsUpgrade('http://slow-server.com/repo');
+    jest.advanceTimersByTime(3000);
+    const result = await promise;
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/helmchartrepository-create-utils-https-upgrade.spec.ts
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/helmchartrepository-create-utils-https-upgrade.spec.ts
@@ -51,6 +51,12 @@ describe('tryHttpsUpgrade', () => {
     expect(await tryHttpsUpgrade(undefined)).toBeNull();
   });
 
+  it('should return null for non-string input from YAML parsing', async () => {
+    expect(await tryHttpsUpgrade(123 as unknown as string)).toBeNull();
+    expect(await tryHttpsUpgrade(true as unknown as string)).toBeNull();
+    expect(await tryHttpsUpgrade({} as unknown as string)).toBeNull();
+  });
+
   it('should return null when fetch times out', async () => {
     global.fetch = jest.fn().mockImplementation(
       (_url, options) =>

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/helmchartrepository-create-utils-https-upgrade.spec.ts
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/helmchartrepository-create-utils-https-upgrade.spec.ts
@@ -9,7 +9,7 @@ describe('tryHttpsUpgrade', () => {
   });
 
   it('should return https URL when server responds with 200', async () => {
-    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
     const result = await tryHttpsUpgrade('http://example.com/repo');
     expect(result).toBe('https://example.com/repo');
     expect(global.fetch).toHaveBeenCalledWith(
@@ -19,13 +19,13 @@ describe('tryHttpsUpgrade', () => {
   });
 
   it('should return null when server responds with a non-OK status', async () => {
-    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
     const result = await tryHttpsUpgrade('http://example.com/repo');
     expect(result).toBeNull();
   });
 
   it('should return null when server responds with 500', async () => {
-    global.fetch = jest.fn().mockResolvedValue(new Response(null, { status: 500 }));
+    global.fetch = jest.fn().mockResolvedValue({ ok: false });
     const result = await tryHttpsUpgrade('http://example.com/repo');
     expect(result).toBeNull();
   });

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/helmchartrepository-create-utils.ts
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/helmchartrepository-create-utils.ts
@@ -70,6 +70,25 @@ export const convertToHelmChartRepository = (
   return newResource;
 };
 
+const HTTPS_PROBE_TIMEOUT_MS = 3000;
+
+export const tryHttpsUpgrade = async (httpUrl: string): Promise<string | null> => {
+  if (!httpUrl?.startsWith('http://')) {
+    return null;
+  }
+  const httpsUrl = httpUrl.replace(/^http:\/\//, 'https://');
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HTTPS_PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetch(httpsUrl, { method: 'HEAD', signal: controller.signal });
+    return response.ok ? httpsUrl : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
 export const getDefaultResource = (
   namespace: string,
   kindRef?: K8sResourceKindReference,

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/helmchartrepository-create-utils.ts
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/helmchartrepository-create-utils.ts
@@ -73,7 +73,7 @@ export const convertToHelmChartRepository = (
 const HTTPS_PROBE_TIMEOUT_MS = 3000;
 
 export const tryHttpsUpgrade = async (httpUrl: string): Promise<string | null> => {
-  if (!httpUrl?.startsWith('http://')) {
+  if (typeof httpUrl !== 'string' || !httpUrl.startsWith('http://')) {
     return null;
   }
   const httpsUrl = httpUrl.replace(/^http:\/\//, 'https://');


### PR DESCRIPTION

Show an inline warning when users enter an HTTP repository URL, alerting them that credentials may be exposed and content may be tampered with in transit. On submit, attempt to upgrade the URL to HTTPS by probing the server; fall back to HTTP if HTTPS is unavailable.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an inline warning for Helm chart repositories using unencrypted HTTP.
  * Automatically upgrades repository URLs to HTTPS when the secure endpoint is available.
  * Warns that HTTP connections may expose credentials or allow content tampering.
* **Bug Fixes**
  * Preserves the original URL when HTTPS is unavailable, unreachable, or times out.
* **Tests**
  * Added coverage for successful upgrades, unsupported URLs, failures, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->