### PR TITLE
CONSOLE-5196: Increase Playwright CI retries and abort after 10 failures

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -51,7 +51,8 @@ export default defineConfig({
   testMatch: '**/*.spec.ts',
   forbidOnly: isCI,
   globalTimeout: Number(process.env.GLOBAL_TIMEOUT_MS) || 0,
-  retries: isCI ? 1 : 0,
+  maxFailures: isCI ? 10 : 0,
+  retries: isCI ? 2 : 0,
   timeout: 120_000,
   reporter: isCI
     ? [


### PR DESCRIPTION
**Analysis / Root cause**:
Playwright e2e tests in CI sometimes flake due to transient cluster or timing issues. With only 1 retry, a single transient failure can fail the entire run. Additionally, once tests start failing consistently, the remaining tests still run — wasting CI time.

**Solution description**:
Two changes to `frontend/playwright.config.ts`:
- Increase `retries` from 1 to 2 in CI, giving flaky tests more chances to pass before failing the run.
- Add `maxFailures: 10` in CI so the run aborts after 10 test failures, avoiding wasted time running remaining tests when the cluster or environment is clearly unhealthy.

Local development behavior is unchanged (`retries: 0`, `maxFailures: 0`).

**Screenshots / screen recording**:
N/A - configuration change only.

**Test setup:**
N/A

**Test cases:**
- Verify CI runs abort after 10 test failures (after exhausting retries)
- Verify local `yarn test-playwright` still runs all tests without early abort

**Browser conformance**:
N/A - CI configuration change only.

**Additional info:**
[CONSOLE-5196](https://redhat.atlassian.net/browse/CONSOLE-5196)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test reliability in continuous integration environments by allowing limited retries for failed tests.
  * Added a cap on the number of failures reported during CI test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->