### PR TITLE
Hide Builds nav section when Build capability is disabled

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1523,7 +1523,24 @@
         "version": "v1",
         "kind": "ImageStream"
       }
-    }
+    },
+    "flags": { "required": ["OPENSHIFT_BUILDCONFIG"] }
+  },
+  {
+    "type": "console.navigation/resource-ns",
+    "properties": {
+      "perspective": "admin",
+      "section": "storage",
+      "id": "imagestreams-no-builds",
+      "name": "%console-app~ImageStreams%",
+      "startsWith": ["imagestreamtags"],
+      "model": {
+        "group": "image.openshift.io",
+        "version": "v1",
+        "kind": "ImageStream"
+      }
+    },
+    "flags": { "disallowed": ["OPENSHIFT_BUILDCONFIG"] }
   },
   {
     "type": "console.navigation/resource-cluster",


### PR DESCRIPTION
**Analysis / Root cause**:

When a cluster is configured with `baselineCapabilitySet: None` and the Build capability is not enabled, the Admin perspective sidebar still displays a "Builds" section. This happens because:

1. The "Builds" nav section only requires the generic `OPENSHIFT` flag (true on any OpenShift cluster)
2. The ImageStreams nav item is placed in the "builds" section with no Build-specific flag requirement
3. While BuildConfigs and Builds items are correctly hidden by `OPENSHIFT_BUILDCONFIG` and `OPENSHIFT_BUILD` flags, ImageStreams keeps the section visible
4. The `NavSection` component auto-hides empty sections, but ImageStreams prevents this

The result is a misleading "Builds" section containing only "ImageStreams" when Build capability is disabled.

**Solution description**:

- Gate the existing ImageStreams nav entry in the "builds" section behind `OPENSHIFT_BUILDCONFIG` so it only appears there when Build capability is enabled
- Add a fallback ImageStreams nav entry in the "storage" section with `OPENSHIFT_BUILDCONFIG` disallowed, so ImageStreams remains accessible when Build capability is disabled
- The `NavSection` component already auto-hides sections with no visible children, so the "Builds" section disappears when all its children are hidden

| Cluster Config | Builds Section | ImageStreams Location |
|---|---|---|
| Build enabled | Visible (BuildConfigs + Builds + ImageStreams) | Under "Builds" |
| Build disabled, ImageRegistry enabled | Hidden | Under "Storage" |
| Build disabled, ImageRegistry disabled | Hidden | Hidden |

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
- Cluster with `baselineCapabilitySet: None` and Build capability not included in `additionalEnabledCapabilities`
- Verify `oc api-resources --api-group=build.openshift.io` returns empty
- Verify `oc api-resources | grep imagestream` returns ImageStream resources

**Test cases:**
- [ ] On a cluster with Build capability disabled: verify "Builds" section is not shown in Admin perspective sidebar
- [ ] On a cluster with Build capability disabled and ImageRegistry enabled: verify ImageStreams appears under "Storage" section
- [ ] On a cluster with Build capability enabled: verify ImageStreams still appears under "Builds" section (no regression)
- [ ] On a cluster with Build capability enabled: verify BuildConfigs and Builds nav items still appear under "Builds" section

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
This bug affects all release branches (4.20, 4.21, 4.22, and main). Cherry-picks to release branches will be needed.

Reproduced and verified locally by running a dev console build against a 4.20 cluster with Build capability disabled.

**Reviewers and assignees:**

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ImageStreams navigation now displays the appropriate entry based on whether build configuration features are enabled.
  * Users without build configuration support can access ImageStreams through a dedicated navigation entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->