### PR TITLE
[release-4.22] OCPBUGS-100307: Re-enable Knative Cypress e2e tests

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -80,7 +80,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-helm-nightly
   # yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
-  # yarn run test-cypress-knative-nightly
+  yarn run test-cypress-knative-nightly
   yarn run test-cypress-webterminal-nightly
 
   exit $err;
@@ -92,7 +92,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-olm-headless
   yarn run test-cypress-webterminal-headless
   yarn run test-cypress-helm-headless
-  # yarn run test-cypress-knative-headless
+  yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   # yarn run test-cypress-shipwright-headless
   exit;

--- a/frontend/packages/integration-tests/support/admin.ts
+++ b/frontend/packages/integration-tests/support/admin.ts
@@ -15,6 +15,10 @@ Cypress.Commands.add('initAdmin', () => {
   cy.log('redirect to home');
   cy.visit('/');
   cy.byTestID('loading-indicator').should('not.exist');
+  cy.document().its('readyState').should('eq', 'complete');
+  // Wait for perspective switcher to be rendered - this requires React to finish
+  // loading the NavHeader component and the perspective extensions
+  cy.byLegacyTestID('perspective-switcher-toggle', { timeout: 60000 }).should('be.visible');
   cy.log('ensure perspective switcher is set to Core platform');
   nav.sidenav.switcher.changePerspectiveTo('Core platform');
   nav.sidenav.switcher.shouldHaveText('Core platform');
@@ -25,6 +29,9 @@ Cypress.Commands.add('initDeveloper', () => {
   cy.visit('/add');
   cy.byTestID('loading-indicator').should('not.exist');
   cy.document().its('readyState').should('eq', 'complete');
+  // Wait for perspective switcher to be rendered - this requires React to finish
+  // loading the NavHeader component and the perspective extensions
+  cy.byLegacyTestID('perspective-switcher-toggle', { timeout: 60000 }).should('be.visible');
   cy.log('ensure perspective switcher is set to Developer');
   nav.sidenav.switcher.changePerspectiveTo('Developer');
   cy.log('switched perspective to Developer');

--- a/frontend/packages/integration-tests/views/nav.ts
+++ b/frontend/packages/integration-tests/views/nav.ts
@@ -68,15 +68,14 @@ export const nav = {
                     'have.attr',
                     'aria-expanded',
                     'true',
-                    { timeout: 5000 },
+                    { timeout: 10000 },
                   );
 
-                  // eslint-disable-next-line cypress/no-unnecessary-waiting
-                  cy.wait(1000); // wait for the menu options to render
-
-                  cy.byLegacyTestID('perspective-switcher-menu-option')
+                  // Wait for menu options to be visible instead of fixed delay
+                  cy.byLegacyTestID('perspective-switcher-menu-option', { timeout: 10000 })
+                    .should('be.visible')
                     .contains(newPerspective)
-                    .click({ force: true });
+                    .click();
                 }
               });
             break;
@@ -113,14 +112,11 @@ export const nav = {
                     { timeout: 10000 },
                   );
 
-                  // Wait a bit for portal to render
-                  // eslint-disable-next-line cypress/no-unnecessary-waiting
-                  cy.wait(1500);
-
-                  // Click Developer option
-                  cy.contains('[data-test-id="perspective-switcher-menu-option"]', 'Developer', {
-                    timeout: 10000,
-                  }).click();
+                  // Wait for menu options to be visible instead of fixed delay
+                  cy.byLegacyTestID('perspective-switcher-menu-option', { timeout: 10000 })
+                    .should('be.visible')
+                    .contains('Developer')
+                    .click();
                 }
               });
 
@@ -130,11 +126,11 @@ export const nav = {
               .should('contain.text', 'Developer');
             break;
           default:
-            cy.byLegacyTestID('perspective-switcher-toggle')
-              .click()
-              .byLegacyTestID('perspective-switcher-menu-option')
+            cy.byLegacyTestID('perspective-switcher-toggle').click();
+            cy.byLegacyTestID('perspective-switcher-menu-option', { timeout: 10000 })
+              .should('be.visible')
               .contains(newPerspective)
-              .click({ force: true });
+              .click();
         }
       },
     },

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -32,9 +32,8 @@ elif [ "$SCENARIO" == "dev-console" ]; then
   ./integration-tests/test-cypress.sh -p dev-console -h true
 elif [ "$SCENARIO" == "pipelines" ]; then
   ./integration-tests/test-cypress.sh -p pipelines -h true
-# Disabled: knative-ci.feature failing in CI (OCPBUGS-99226)
-# elif [ "$SCENARIO" == "knative" ]; then
-#   ./integration-tests/test-cypress.sh -p knative -h true
+elif [ "$SCENARIO" == "knative" ]; then
+  ./integration-tests/test-cypress.sh -p knative -h true
 fi
 
 env NO_SANDBOX=true yarn test-puppeteer-csp


### PR DESCRIPTION

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
Knative Cypress e2e was disabled under OCPBUGS-99226 (#16782) because `knative-ci.feature` was flaking in CI. Failures commonly hit the `beforeEach` → `cy.initAdmin()` path when the perspective switcher was not ready yet (timeout on `perspective-switcher-toggle` / menu interaction), which blocked unrelated PRs.

The harness was also using fixed `cy.wait()` delays around perspective menu open, which is brittle under React 18 / CI load.

**Solution description**:
Re-enable Knative Cypress suites and harden shared perspective-switcher helpers:

1. Re-enable Knative runs in:
   - `frontend/integration-tests/test-cypress.sh` (`test-cypress-knative-nightly`, `test-cypress-knative-headless`)
   - `test-prow-e2e.sh` (`SCENARIO == knative`)
2. In `initAdmin` / `initDeveloper`, wait for `perspective-switcher-toggle` to exist and be visible (60s) before switching perspective.
3. In `nav.ts` perspective switcher helpers:
   - Increase menu `aria-expanded` wait where needed
   - Replace fixed `cy.wait(1000/1500)` with waiting for `perspective-switcher-menu-option` visibility
   - Use a normal `.click()` (no `force: true`) once the option is visible

No product UI changes; test harness / CI wiring only.

**Screenshots / screen recording**:
N/A — CI / Cypress harness change only.

**Test setup:**
- Cluster with Knative / Serverless available (same as existing knative Cypress jobs)
- Local (optional): from `frontend/`, run knative headless suite via `./integration-tests/test-cypress.sh -p knative -h true` against a configured bridge/cluster
- CI: confirm knative scenario / nightly + headless jobs run and are green on this PR

**Test cases:**
1. Knative prow scenario (`SCENARIO=knative`) executes (no longer skipped/commented out).
2. Nightly / headless Cypress aggregators invoke knative suites again.
3. Knative `beforeEach` / `initAdmin` no longer times out waiting for perspective switcher under CI load.
4. Switching to Core platform and Developer perspectives succeeds without forced clicks or fixed sleeps.
5. `knative-ci.feature` smoke scenarios pass (create / interact with knative service & revision as covered by the suite).
6. Unrelated Cypress packages that use `initAdmin` / `initDeveloper` still pass (shared harness change).

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

N/A for merge gate (CI Cypress / Chrome-like headless). Mark browsers only if manually exercised locally.

**Additional info:**
- Closes / tracks: https://issues.redhat.com/browse/OCPBUGS-99292
- Related disable: OCPBUGS-99226 (#16782)
- Shared harness impact: `admin.ts` / `nav.ts` changes affect all Cypress suites using `initAdmin` / `initDeveloper`, not only knative.
- Release branches disabled under OCPBUGS-99226 should be re-enabled or explicitly waived after main is stable.
- Merge recommendation: wait for green knative CI on this PR before considering the flake fixed.

**Reviewers and assignees:**
/assign 

<!-- Tag additional knative/e2e owners as needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled Knative Cypress suites for both nightly and headless runs.
  * Re-enabled Knative Cypress execution when the end-to-end scenario is set to Knative.
  * Improved reliability of perspective-switching tests by replacing fixed waits with UI readiness checks (waiting for the correct legacy toggle and menu options to become visible before interacting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->