### PR TITLE
CONSOLE-5425: Add rspack native bindings for linux/s390x and linux/ppc64le

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -231,6 +231,10 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": "eslint --color --fix"
   },
+  "optionalDependencies": {
+    "@rspack/binding-linux-ppc64-gnu": "npm:@megahard/binding-linux-ppc64-gnu@1.2.7-alpha.0-3652-gf2510302a4",
+    "@rspack/binding-linux-s390x-gnu": "npm:@megahard/binding-linux-s390x-gnu@1.2.7-alpha.0-3652-gf2510302a4"
+  },
   "dependenciesMeta": {
     "cypress": {
       "built": true

--- a/frontend/rspack.config.mts
+++ b/frontend/rspack.config.mts
@@ -10,7 +10,6 @@ import {
   ProgressPlugin,
   sharing,
 } from '@rspack/core';
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
 import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 import * as _ from 'lodash';
@@ -368,25 +367,34 @@ if (CHECK_CYCLES === 'true') {
 }
 
 if (ANALYZE_BUNDLE === 'true') {
-  config.plugins.push(
-    new RsdoctorRspackPlugin({
-      features: {
-        loader: false // doesn't work: "Load data failed, please try again"
-      },
-      output: {
-        mode: 'brief',
-        options: {
-          type: ['html'],
-          htmlOptions: {
-            writeDataJson: false,
-            reportHtmlName: 'report.html',
+  // lazy imported to avoid @rspack/resolver causing issues on unsupported architectures (ppc64/s390x)
+  try {
+    const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
+    config.plugins.push(
+      new RsdoctorRspackPlugin({
+        features: {
+          loader: false // doesn't work: "Load data failed, please try again"
+        },
+        output: {
+          mode: 'brief',
+          options: {
+            type: ['html'],
+            htmlOptions: {
+              writeDataJson: false,
+              reportHtmlName: 'report.html',
+            },
           },
         },
-      },
-      // Don't open report in default browser automatically
-      disableClientServer: true,
-    }),
-  );
+        // Don't open report in default browser automatically
+        disableClientServer: true,
+      }),
+    );
+    } catch (err) {
+    console.warn(
+        'Failed to load @rsdoctor/rspack-plugin. Bundle analysis will not be available.',
+        err,
+      );
+    }
 
   // Only fail the build due to excess bundle size if running analyze.sh
   // This way, the other tests (frontend, e2e) can still provide feedback in CI

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4383,65 +4383,79 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-arm64@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-darwin-arm64@npm:2.1.4"
+"@rspack/binding-darwin-arm64@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-darwin-arm64@npm:2.1.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-x64@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-darwin-x64@npm:2.1.4"
+"@rspack/binding-darwin-x64@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-darwin-x64@npm:2.1.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-gnu@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.1.4"
+"@rspack/binding-linux-arm64-gnu@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.1.7"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-musl@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-linux-arm64-musl@npm:2.1.4"
+"@rspack/binding-linux-arm64-musl@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-linux-arm64-musl@npm:2.1.7"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-riscv64-gnu@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-linux-riscv64-gnu@npm:2.1.4"
+"@rspack/binding-linux-ppc64-gnu@npm:@megahard/binding-linux-ppc64-gnu@1.2.7-alpha.0-3652-gf2510302a4":
+  version: 1.2.7-alpha.0-3652-gf2510302a4
+  resolution: "@megahard/binding-linux-ppc64-gnu@npm:1.2.7-alpha.0-3652-gf2510302a4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-riscv64-gnu@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-linux-riscv64-gnu@npm:2.1.7"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-riscv64-musl@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-linux-riscv64-musl@npm:2.1.4"
+"@rspack/binding-linux-riscv64-musl@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-linux-riscv64-musl@npm:2.1.7"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-gnu@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-linux-x64-gnu@npm:2.1.4"
+"@rspack/binding-linux-s390x-gnu@npm:@megahard/binding-linux-s390x-gnu@1.2.7-alpha.0-3652-gf2510302a4":
+  version: 1.2.7-alpha.0-3652-gf2510302a4
+  resolution: "@megahard/binding-linux-s390x-gnu@npm:1.2.7-alpha.0-3652-gf2510302a4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-x64-gnu@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-linux-x64-gnu@npm:2.1.7"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-musl@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-linux-x64-musl@npm:2.1.4"
+"@rspack/binding-linux-x64-musl@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-linux-x64-musl@npm:2.1.7"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-wasm32-wasi@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-wasm32-wasi@npm:2.1.4"
+"@rspack/binding-wasm32-wasi@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-wasm32-wasi@npm:2.1.7"
   dependencies:
     "@emnapi/core": "npm:1.11.2"
     "@emnapi/runtime": "npm:1.11.2"
@@ -4450,43 +4464,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-arm64-msvc@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.1.4"
+"@rspack/binding-win32-arm64-msvc@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.1.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-ia32-msvc@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.1.4"
+"@rspack/binding-win32-ia32-msvc@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.1.7"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-x64-msvc@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding-win32-x64-msvc@npm:2.1.4"
+"@rspack/binding-win32-x64-msvc@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding-win32-x64-msvc@npm:2.1.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@rspack/binding@npm:2.1.4"
+"@rspack/binding@npm:2.1.7":
+  version: 2.1.7
+  resolution: "@rspack/binding@npm:2.1.7"
   dependencies:
-    "@rspack/binding-darwin-arm64": "npm:2.1.4"
-    "@rspack/binding-darwin-x64": "npm:2.1.4"
-    "@rspack/binding-linux-arm64-gnu": "npm:2.1.4"
-    "@rspack/binding-linux-arm64-musl": "npm:2.1.4"
-    "@rspack/binding-linux-riscv64-gnu": "npm:2.1.4"
-    "@rspack/binding-linux-riscv64-musl": "npm:2.1.4"
-    "@rspack/binding-linux-x64-gnu": "npm:2.1.4"
-    "@rspack/binding-linux-x64-musl": "npm:2.1.4"
-    "@rspack/binding-wasm32-wasi": "npm:2.1.4"
-    "@rspack/binding-win32-arm64-msvc": "npm:2.1.4"
-    "@rspack/binding-win32-ia32-msvc": "npm:2.1.4"
-    "@rspack/binding-win32-x64-msvc": "npm:2.1.4"
+    "@rspack/binding-darwin-arm64": "npm:2.1.7"
+    "@rspack/binding-darwin-x64": "npm:2.1.7"
+    "@rspack/binding-linux-arm64-gnu": "npm:2.1.7"
+    "@rspack/binding-linux-arm64-musl": "npm:2.1.7"
+    "@rspack/binding-linux-riscv64-gnu": "npm:2.1.7"
+    "@rspack/binding-linux-riscv64-musl": "npm:2.1.7"
+    "@rspack/binding-linux-x64-gnu": "npm:2.1.7"
+    "@rspack/binding-linux-x64-musl": "npm:2.1.7"
+    "@rspack/binding-wasm32-wasi": "npm:2.1.7"
+    "@rspack/binding-win32-arm64-msvc": "npm:2.1.7"
+    "@rspack/binding-win32-ia32-msvc": "npm:2.1.7"
+    "@rspack/binding-win32-x64-msvc": "npm:2.1.7"
   dependenciesMeta:
     "@rspack/binding-darwin-arm64":
       optional: true
@@ -4512,13 +4526,13 @@ __metadata:
       optional: true
     "@rspack/binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/bb871c14a56c1b2300cd4848dbdaf963fddb10eedfb7b1455cf5012e2eba2c9a1c51216bf8972c63abf9c022eb7a98b4b863e7426caf53ee6d14d8b3c30f99fd
+  checksum: 10c0/22b08e4736feec8165de496d0f8006b939df5ceb92770680359016ae43d261c268840b9f53730b2667be230b3910891d4d348cf160a8eee6afcaa724e04dc164
   languageName: node
   linkType: hard
 
 "@rspack/cli@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@rspack/cli@npm:2.1.3"
+  version: 2.1.7
+  resolution: "@rspack/cli@npm:2.1.7"
   peerDependencies:
     "@rspack/core": ^2.0.0-0
     "@rspack/dev-server": ^2.0.0-0
@@ -4527,15 +4541,15 @@ __metadata:
       optional: true
   bin:
     rspack: ./bin/rspack.js
-  checksum: 10c0/15f96011cc131cb7c5d688d81a81c5933ece72cd3a2f37a032d5e578d88f2271a7c3e46d3ea25659fe422fbe3d0e6d81a6caf69ea598305f47d15099462dbda0
+  checksum: 10c0/ed7d37667942fbd445b894ec89ceb8b104ce68f5f94043db6898ab2319517d0a277cfe0f898ee90f4d83919f16c858e3d5d8e1e57df23a763afce9b36a773742
   languageName: node
   linkType: hard
 
 "@rspack/core@npm:^2.1.3":
-  version: 2.1.4
-  resolution: "@rspack/core@npm:2.1.4"
+  version: 2.1.7
+  resolution: "@rspack/core@npm:2.1.7"
   dependencies:
-    "@rspack/binding": "npm:2.1.4"
+    "@rspack/binding": "npm:2.1.7"
   peerDependencies:
     "@module-federation/runtime-tools": ^0.24.1 || ^2.0.0
     "@swc/helpers": ^0.5.23
@@ -4544,7 +4558,7 @@ __metadata:
       optional: true
     "@swc/helpers":
       optional: true
-  checksum: 10c0/ddb76e8aaa9d9fc7b13fb8629e6bea8825e1390a499a4f522dc7cecdad8468f2ee21b0b4dcb5fb39d903117732d7425dd13068c0230dd5a31d8545f19502702f
+  checksum: 10c0/e9e006e68d54b6a4c742cd7dc84f9f52c67f89da849e23c2723399ad6b7c39654effc1e92f6f2d54ddd10205ee36dca20559ee5a4033ee54d00daa80839aed5b
   languageName: node
   linkType: hard
 
@@ -4642,7 +4656,7 @@ __metadata:
   resolution: "@rspack/resolver-binding-wasm32-wasi@npm:0.2.8"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^1.1.1"
-  conditions: cpu=wasm32
+  checksum: 10c0/9f5ec62eecc5e478ccc25c227e62741b99e06ad0a7334b9ad76fb1b6d02e34523a03b9e5dc3f32016d7539f2e1f5c6df4489058dc3f406c6165d9de270d90475
   languageName: node
   linkType: hard
 
@@ -16504,6 +16518,8 @@ __metadata:
     "@puppeteer/browsers": "npm:^2.6.1"
     "@rjsf/core": "npm:^4.2.3"
     "@rsdoctor/rspack-plugin": "npm:^1.6.1"
+    "@rspack/binding-linux-ppc64-gnu": "npm:@megahard/binding-linux-ppc64-gnu@1.2.7-alpha.0-3652-gf2510302a4"
+    "@rspack/binding-linux-s390x-gnu": "npm:@megahard/binding-linux-s390x-gnu@1.2.7-alpha.0-3652-gf2510302a4"
     "@rspack/cli": "npm:^2.1.3"
     "@rspack/core": "npm:^2.1.3"
     "@rspack/dev-server": "npm:^2.1.0"
@@ -16623,6 +16639,10 @@ __metadata:
     yaml-ast-parser: "npm:^0.0.43"
     yup: "npm:^1.7.1"
   dependenciesMeta:
+    "@rspack/binding-linux-ppc64-gnu":
+      optional: true
+    "@rspack/binding-linux-s390x-gnu":
+      optional: true
     cypress:
       built: true
   languageName: unknown


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

rspack does not yet support s390x/ppc64 which [Konflux](https://konflux-ci.dev/docs/) uses to build this repo. 

This causes build errors. An upstream issue https://github.com/web-infra-dev/rspack/issues/14958 has been opened but in the interim it would be nice to have green builds again.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Thanks to @christianvogt for inspiring the fix. Publish custom, temporary packages on npm, which contain binaries that come from Github action artifacts in https://github.com/web-infra-dev/rspack/pull/14962:
- https://github.com/web-infra-dev/rspack/actions/runs/30635550183/artifacts/8795624851
- https://github.com/web-infra-dev/rspack/actions/runs/30635550183/artifacts/8795602885

There are also no bindings for `@rspack/resolver` for s390x/ppc64, but because it's only used for `./analyze.sh` - this was a fault of our rspack config. Rewrite rsdoctor to be a dynamic import with a try/catch so this does not error out the main build.

**Test cases:**
<!-- List possible test cases to validate the changes. -->

Wait for the build to be green :shrug:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved application startup resilience when optional bundle analysis tools are unavailable.
- Added clearer diagnostic messages instead of stopping configuration unexpectedly.

## Compatibility
- Expanded support for Linux systems running on PPC64 GNU and s390x GNU architectures.
- Platform-specific support remains optional, helping preserve compatibility across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->