### PR TITLE
OCPBUGS-95590: Hide Builds nav section when Build capability is disabled

### DIFF
--- a/frontend/packages/console-app/console-extensions.json
+++ b/frontend/packages/console-app/console-extensions.json
@@ -1523,7 +1523,24 @@
         "version": "v1",
         "kind": "ImageStream"
       }
-    }
+    },
+    "flags": { "required": ["OPENSHIFT_BUILDCONFIG"] }
+  },
+  {
+    "type": "console.navigation/resource-ns",
+    "properties": {
+      "perspective": "admin",
+      "section": "storage",
+      "id": "imagestreams-no-builds",
+      "name": "%console-app~ImageStreams%",
+      "startsWith": ["imagestreamtags"],
+      "model": {
+        "group": "image.openshift.io",
+        "version": "v1",
+        "kind": "ImageStream"
+      }
+    },
+    "flags": { "disallowed": ["OPENSHIFT_BUILDCONFIG"] }
   },
   {
     "type": "console.navigation/resource-cluster",


### PR DESCRIPTION
**Analysis / Root cause**:
When the Build capability is disabled on an OpenShift cluster, the Admin perspective still shows a "Builds" navigation section containing only ImageStreams. This is confusing because the section name implies build functionality that isn't available.

**Solution description**:
- Gate the existing ImageStreams navigation entry (under the "builds" section) behind the `OPENSHIFT_BUILDCONFIG` feature flag so it only appears when builds are enabled.
- Add a fallback ImageStreams navigation entry under the "storage" section that appears when `OPENSHIFT_BUILDCONFIG` is disabled, ensuring ImageStreams remains accessible.

**Screenshots / screen recording**:
<!-- Please add screenshots showing the nav with builds enabled vs disabled -->

**Test setup:**
- A cluster with the Build capability disabled

**Test cases:**
- [ ] With Build capability enabled: ImageStreams appears under Builds section as before
- [ ] With Build capability disabled: Builds section is hidden, ImageStreams appears under Storage section
- [ ] ImageStreams links work correctly in both configurations

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
JIRA: https://redhat.atlassian.net/browse/OCPBUGS-95590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ImageStreams navigation now adapts based on build capabilities.
  * Added a storage-focused ImageStreams entry for environments without build support.
  * Existing build-related ImageStreams navigation is shown only when build capabilities are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->