### PR TITLE
[release-4.22] OCPBUGS-100317: Fix pod terminal not rendering until resize

### DIFF
--- a/frontend/public/components/terminal.tsx
+++ b/frontend/public/components/terminal.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, useRef, useEffect, useImperativeHandle, useCallback, useState } from 'react';
-import { Terminal as XTerminal, ITerminalOptions, ITerminalAddon } from '@xterm/xterm';
+import { getResizeObserver } from '@patternfly/react-core';
 import { FitAddon } from '@xterm/addon-fit';
+import type { ITerminalOptions, ITerminalAddon } from '@xterm/xterm';
+import { Terminal as XTerminal } from '@xterm/xterm';
 import { useIsFullscreen } from '@console/shared/src/hooks/useFullscreen';
 
 const defaultOptions: ITerminalOptions = {
@@ -56,30 +58,13 @@ export const Terminal = forwardRef<ImperativeTerminalType, TerminalProps>(
         return;
       }
 
-      // This assumes we want to fill everything below and to the right.  In full-screen, fill entire viewport
       const height = Math.floor(pageRect.bottom - (isFullscreen ? 0 : nodeRect.top) - padding);
       const width = Math.floor(
         bodyRect.width - (isFullscreen ? 0 : nodeRect.left) - (isFullscreen ? 10 : padding),
       );
 
       setDimensions({ width: `${width}px`, height: `${height}px` });
-
-      // rerender with correct dimensions
-      setTimeout(() => {
-        if (!terminal.current) {
-          return;
-        }
-        // tell the terminal to resize itself
-        fitAddon.current?.fit();
-        // update the pty
-        onResize(terminal.current.rows, terminal.current.cols);
-        // @ts-expect-error The internal xterm textarea was not repositioned when the window was resized.
-        // This workaround triggers a textarea position update to fix this.
-        // See https://bugzilla.redhat.com/show_bug.cgi?id=1983220
-        // and https://github.com/xtermjs/xterm.js/issues/3390
-        terminal.current._core?._syncTextArea?.();
-      }, 0);
-    }, [isFullscreen, onResize, padding]);
+    }, [isFullscreen, padding]);
 
     useEffect(() => {
       const term = new XTerminal({ ...options });
@@ -93,18 +78,40 @@ export const Terminal = forwardRef<ImperativeTerminalType, TerminalProps>(
 
       term.loadAddon(fit);
 
+      let unobserveResize: () => void;
+
       if (terminalRef.current) {
         term.open(terminalRef.current);
         term.focus();
+        unobserveResize = getResizeObserver(
+          terminalRef.current,
+          () => {
+            if (!terminal.current) {
+              return;
+            }
+            // @ts-expect-error Guard: skip resize if xterm's render service hasn't initialized yet.
+            // ResizeObserver can fire before the internal dimensions are available.
+            if (!terminal.current._core?._renderService?.dimensions) {
+              return;
+            }
+            fit.fit();
+            onResize(terminal.current.rows, terminal.current.cols);
+            // @ts-expect-error The internal xterm textarea was not repositioned when the window was resized.
+            // See https://bugzilla.redhat.com/show_bug.cgi?id=1983220
+            // and https://github.com/xtermjs/xterm.js/issues/3390
+            terminal.current._core?._syncTextArea?.();
+          },
+          true,
+        );
         handleResize();
       }
 
-      // Window resize fallback
       window.addEventListener('resize', handleResize);
       window.addEventListener('sidebar_toggle', handleResize);
 
       return () => {
         term.dispose();
+        unobserveResize?.();
         window.removeEventListener('resize', handleResize);
         window.removeEventListener('sidebar_toggle', handleResize);
       };


### PR DESCRIPTION
## Summary

Backport of #16498 to release-4.22.

- **Bug:** https://issues.redhat.com/browse/OCPBUGS-100317
- Replace `setTimeout(0)` + `fitAddon.fit()` with a `ResizeObserver` (via PatternFly's `getResizeObserver`) to fix the race condition between xterm fitting and React 18's batched state updates
- The terminal container starts with `0x0` dimensions; `fit()` was firing before the DOM had correct dimensions, leaving xterm unable to render until a manual window resize

## Test plan

- [ ] Navigate to Workloads → Pods → select a running pod → Terminal tab
- [ ] Verify the shell prompt appears immediately without needing to resize the browser window
- [ ] Resize the browser window — terminal should re-fit correctly
- [ ] Click Expand (fullscreen) — terminal should fill the viewport
- [ ] Click Collapse — terminal should return to normal size
- [ ] Switch containers (if pod has multiple) — new terminal should render promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)