### PR TITLE
chore(sdk): attribute react-router ~7.18.1 peer bump to 4.23.0-prerelease.5

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -12,6 +12,7 @@ table in [Console dynamic plugins README](./README.md).
 
 ## 4.23.0-prerelease.5 - TBD
 
+- Update `react-router` peer dependency semver range to `~7.18.1` ([CONSOLE-5415], [#16726])
 - **Deprecated**: The use of multiple predicates in the `useResolvedExtensions` hook is deprecated ([#16115], [CONSOLE-5065])
 - **Type breaking**: Replace `ExtensionTypeGuard` with `ExtensionPredicate` from `@openshift/dynamic-plugin-sdk` ([#16115], [CONSOLE-5065])
 
@@ -19,7 +20,6 @@ table in [Console dynamic plugins README](./README.md).
 
 - Add optional `onSubmit` parameter to `useLabelsModal` hook for customizing label submission behavior ([CONSOLE-5356], [#16560])
 - Update `@patternfly/react-topology` peer dependency semver range to `~6.6.0` ([OCPBUGS-86587], [#16750])
-- Update `react-router` peer dependency semver range to `~7.18.1` ([CONSOLE-5415], [#16726])
 
 ## 4.23.0-prerelease.3 - 2026-07-07
 


### PR DESCRIPTION
## Summary

- Move the `@openshift-console/dynamic-plugin-sdk` changelog note for the `react-router` peer bump to `~7.18.1` from `4.23.0-prerelease.4` to `4.23.0-prerelease.5`
- Request publishing `4.23.0-prerelease.5` so the npm package peer matches Console main

## Why

Console already bumped `react-router` to `~7.18.1` in [#16726](https://github.com/openshift/console/pull/16726) (merged 2026-07-16).

However, npm `@openshift-console/dynamic-plugin-sdk@4.23.0-prerelease.4` was published on **2026-07-14**, before that change landed, and still peers:

```text
react-router: ~7.13.1
```

The changelog currently attributes the peer bump to `prerelease.4`, which is inaccurate for the published package. Plugins that follow the published SDK peer (or scanners that check it) still see the older CVE-affected range.

## Ask

Please publish `@openshift-console/dynamic-plugin-sdk@4.23.0-prerelease.5` (and matching webpack/internal packages as needed) from current main so the generated peer dependency is `react-router: ~7.18.1`.

```sh
cd frontend/packages/console-dynamic-plugin-sdk
yarn build && yarn set-dist-version 4.23.0-prerelease.5
(cd ./dist/core && npm publish)
# webpack / internal as applicable
```

Verify with:

```sh
npm view @openshift-console/dynamic-plugin-sdk@4.23.0-prerelease.5 peerDependencies.react-router
# expected: ~7.18.1
```

## Test plan

- [x] Changelog entry for `~7.18.1` lives under `4.23.0-prerelease.5`
- [x] `4.23.0-prerelease.4` section no longer claims the react-router peer bump
- [ ] After publish: `npm view ... peerDependencies.react-router` returns `~7.18.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to reflect the `react-router` peer dependency version for the `4.23.0-prerelease.5` release.
  - Corrected the previous prerelease changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->