### PR TITLE
OCPBUGS-67295: Fix icon display for duplicate operator names from different catalogs

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/index.tsx
@@ -95,6 +95,7 @@ export const iconFor = (pkg: PackageManifestKind) => {
       resourceVersion: [pkg.metadata.name, defaultChannel.name, defaultChannel.currentCSV].join(
         '.',
       ),
+      catalog: pkg?.status?.catalogSource,
     },
   });
 };


### PR DESCRIPTION
**Analysis / Root cause**:
When multiple catalogs provide operators with the same name (e.g., loki-operator from both redhat-operators and community-operators), the icon URL generation in the `iconFor()` function does not differentiate between catalogs. This causes incorrect icons to be displayed because the URL only includes the operator name, default channel, and CSV but not the catalog source.

**Solution description**:
Added `catalog: pkg?.status?.catalogSource` to the `queryParams` in the `iconFor()` function within `frontend/packages/operator-lifecycle-manager/src/components/index.tsx`. This ensures the icon URL includes the catalog source, allowing the backend to serve the correct icon for operators with duplicate names from different catalogs.

**Screenshots / screen recording**:
<!-- User to fill in -->

**Test setup:**
1. Set up a cluster with multiple catalogs that have operators with duplicate names (e.g., loki-operator in both redhat-operators and community-operators)
2. Navigate to OperatorHub in the console

**Test cases:**
1. Verify that operators with the same name from different catalogs display their correct respective icons
2. Verify that the icon URL now includes the `catalog` query parameter
3. Verify that existing operators with unique names still display icons correctly

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info**:
This fix implements the solution proposed by Jian Zhang in OCPBUGS-67295.

Jira: https://issues.redhat.com/browse/OCPBUGS-67295

**Reviewers and assignees:**
/cc @jcaianirh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon loading by including the package catalog source in the icon resource URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->