### PR TITLE
NO-JIRA: Autofocus name field in create project/namespace modals

### DIFF
--- a/frontend/packages/console-shared/src/components/modals/CreateNamespaceModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/CreateNamespaceModal.tsx
@@ -190,6 +190,7 @@ export const CreateNamespaceModal: OverlayComponent<CreateProjectModalProps> = (
               onChange={(_event, value) => setName(value)}
               value={name}
               isRequired
+              autoFocus
             />
           </FormGroup>
           <FormGroup label={t('Labels')}>

--- a/frontend/packages/console-shared/src/components/modals/CreateProjectModal.tsx
+++ b/frontend/packages/console-shared/src/components/modals/CreateProjectModal.tsx
@@ -157,6 +157,7 @@ const DefaultCreateProjectModal: OverlayComponent<CreateProjectModalProps> = ({
               onChange={(_event, value) => setName(value)}
               value={name}
               isRequired
+              autoFocus
             />
           </FormGroup>
           <FormGroup label={t('Display name')} fieldId="input-display-name">


### PR DESCRIPTION
**Analysis / Root cause**:
The Name field in `CreateProjectModal` and `CreateNamespaceModal` wasn't autofocused, so on open, keyboard/screen-reader focus landed on the first tabbable element in the modal (the "Learn more about working with projects" link, or the field-level help icon) instead of the input. This appears to be an oversight from the PatternFly v6 modal migration rather than an intentional choice — sibling modals like TextInputModal already autofocus their primary field.

**Solution description**:
Added `autoFocus` to the Name `TextInput` in both `CreateProjectModal.tsx` and `CreateNamespaceModal.tsx`, matching the existing pattern used elsewhere in `console-shared`.


**Test cases:**
- Open "Create Project" — Name field should be focused immediately.
- Open "Create Namespace" — Name field should be focused immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Usability Improvements**
  * Namespace and project name fields now focus automatically when their creation dialogs open, enabling faster data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->