### PR TITLE
OCPBUGS-102342: Dismiss Quick Start drawer in Playwright e2e tests

### DIFF
--- a/frontend/e2e/clients/kubernetes-client.ts
+++ b/frontend/e2e/clients/kubernetes-client.ts
@@ -355,6 +355,7 @@ export default class KubernetesClient {
         admin: { completed: true },
         dev: { completed: true },
       }),
+      'console.quickstart.active': '',
     };
     if (defaultNamespace) {
       patchData['console.lastNamespace'] = defaultNamespace;

--- a/frontend/e2e/pages/base-page.ts
+++ b/frontend/e2e/pages/base-page.ts
@@ -31,6 +31,18 @@ export async function warmupSPA(page: Page): Promise<void> {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60_000 });
     await expect(page.locator('#page-sidebar')).toBeVisible({ timeout: 30_000 });
   }).toPass({ intervals: [1_000, 2_000, 5_000], timeout: 90_000 });
+  await dismissQuickStartDrawer(page);
+}
+
+export async function dismissQuickStartDrawer(page: Page): Promise<void> {
+  const closeButton = page.getByRole('button', { name: 'Close drawer panel' });
+  try {
+    // eslint-disable-next-line no-restricted-syntax
+    await closeButton.waitFor({ state: 'visible', timeout: 5_000 });
+    await closeButton.click();
+  } catch {
+    // No quickstart drawer open — continue
+  }
 }
 
 export async function ensureDeveloperPerspective(

--- a/frontend/e2e/tests/topology/topology-ci.spec.ts
+++ b/frontend/e2e/tests/topology/topology-ci.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 import { test, expect } from '../../fixtures';
+import { dismissQuickStartDrawer } from '../../pages/base-page';
 import { TopologyPage } from '../../pages/topology-page';
 import { TopologySidebarPage } from '../../pages/topology-sidebar-page';
 import type { Page } from '@playwright/test';
@@ -59,6 +60,7 @@ async function mockGitHubApi(page: Page, repoMock: any, contentsMock: any) {
 async function createWorkload(page: Page, workloadName: string) {
   const topology = new TopologyPage(page);
   await page.goto('/');
+  await dismissQuickStartDrawer(page);
   await topology.switchPerspective('Administrator');
   await topology.navigateToTopologyGraph(NS);
   
@@ -119,6 +121,7 @@ test.describe('Perform actions on topology', { tag: ['@smoke'] }, () => {
   test('empty state of topology: T-06-TC01', async ({ page }) => {
     const topology = new TopologyPage(page);
     await page.goto('/');
+    await dismissQuickStartDrawer(page);
     await topology.switchPerspective('Administrator');
     await topology.navigateToTopology(NS);
     


### PR DESCRIPTION
**Analysis / Root cause**:

The "Get started with a sample application" Quick Start drawer auto-opens on fresh CI clusters. It covers ~30% of the screen width on the right side, blocking test interactions with topology nodes, menus, and other UI elements. The existing `setupConsoleUserSettings()` suppresses the guided tour but does not suppress the Quick Start drawer.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-102342

CI failures: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_console/16741/pull-ci-openshift-console-main-e2e-playwright/2084317442368081920/artifacts/e2e-playwright/test/artifacts/playwright-report/index.html

**Solution description**:

1. **Server-side** (`kubernetes-client.ts`): Clear `console.quickstart.active` in the user settings ConfigMap during cluster setup to prevent the drawer from auto-opening.
2. **Browser-side** (`base-page.ts`): Add exported `dismissQuickStartDrawer()` helper that clicks the "Close drawer panel" button if visible (5s timeout, swallows errors if absent). Called from `warmupSPA()` as a safety net.
3. **Topology tests** (`topology-ci.spec.ts`): Call `dismissQuickStartDrawer()` after `page.goto('/')` in the two places that navigate directly instead of using `warmupSPA()`.

**Screenshots / screen recording**:

N/A — e2e test infrastructure fix, no visual changes.

**Test setup:**

No special setup required. Run the Playwright e2e suite on a fresh CI cluster.

**Test cases:**

- [ ] Topology tests (T-06-TC01, T-09-TC01, T-15-TC01, T-16-TC01) pass without quickstart drawer interference
- [ ] Tests using `warmupSPA()` dismiss the drawer if present
- [ ] Tests on clusters without the quickstart drawer are unaffected (5s timeout swallowed)

**Browser conformance**:
- [x] Chrome

**Additional info:**

The Quick Start drawer is rendered by `@patternfly/quickstarts` and configured via user preferences stored in a ConfigMap in `openshift-console-user-settings`. The `console.quickstart.active` key controls which quickstart is currently open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test stability by automatically dismissing the quick-start drawer when it appears.
  - Updated topology tests to close the drawer before performing page interactions.
  - Ensured console user settings correctly handle quick-start state data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->