### PR TITLE
OCPBUGS-81511: Remove unscoped CSV watch from ClusterNotUpgradeableAlert

### DIFF
--- a/frontend/public/components/__tests__/cluster-settings.spec.tsx
+++ b/frontend/public/components/__tests__/cluster-settings.spec.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { clusterVersionUpgradeableFalseProps } from '../../../__mocks__/clusterVersionMock';
+import { ClusterNotUpgradeableAlert } from '../cluster-settings/cluster-settings-utils';
+
+jest.mock('react-i18next', () => ({
+  ...jest.requireActual('react-i18next'),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const text = key.replace('public~', '');
+      if (opts) {
+        return Object.entries(opts).reduce(
+          (acc, [k, v]) => acc.replace(`{{${k}}}`, String(v)),
+          text,
+        );
+      }
+      return text;
+    },
+  }),
+}));
+
+jest.mock('@console/shared/src/components/markdown/MarkdownView', () => ({
+  MarkdownView: ({ content }: { content: string }) => <span>{content}</span>,
+}));
+
+jest.mock('../utils/resource-link', () => ({
+  resourceListPathFromModel: jest.fn(() => '/k8s/all-namespaces/clusterserviceversions'),
+  resourcePathFromModel: jest.fn(() => '/k8s/cluster/clusterautoscalers'),
+  ResourceLink: jest.fn(() => null),
+}));
+
+describe('ClusterNotUpgradeableAlert', () => {
+  it('renders the alert body text from the ClusterVersion condition message', () => {
+    renderWithProviders(<ClusterNotUpgradeableAlert cv={clusterVersionUpgradeableFalseProps} />);
+
+    expect(
+      screen.getByText(
+        'Cluster operator testing cannot be upgraded between minor versions: The whatsits are broken.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('always renders the View ClusterOperators link', () => {
+    renderWithProviders(<ClusterNotUpgradeableAlert cv={clusterVersionUpgradeableFalseProps} />);
+
+    expect(screen.getByRole('link', { name: /View ClusterOperators/i })).toBeInTheDocument();
+  });
+
+  it('always renders the View installed Operators link with the correct all-namespaces URL', () => {
+    renderWithProviders(<ClusterNotUpgradeableAlert cv={clusterVersionUpgradeableFalseProps} />);
+
+    const link = screen.getByRole('link', { name: /View installed Operators/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/k8s/all-namespaces/clusterserviceversions');
+  });
+});

--- a/frontend/public/components/cluster-settings/cluster-settings-utils.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings-utils.tsx
@@ -3,33 +3,18 @@ import { Alert, Flex, FlexItem, Label } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import * as semver from 'semver';
-import type { WatchK8sResource } from '@console/dynamic-plugin-sdk';
-import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
-import type { ClusterServiceVersionKind } from '@console/operator-lifecycle-manager';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { ExternalLink } from '@console/shared/src/components/links/ExternalLink';
 import { MarkdownView } from '@console/shared/src/components/markdown/MarkdownView';
-import { ClusterOperatorModel } from '../../models';
-import type { ClusterOperator, ClusterVersionKind } from '../../module/k8s';
+import type { ClusterVersionKind } from '../../module/k8s';
 import {
   getConditionUpgradeableFalse,
   getLastCompletedUpdate,
   getNewerMinorVersionUpdate,
-  getNotUpgradeableResources,
   getSortedAvailableUpdates,
-  referenceForModel,
 } from '../../module/k8s';
 import { documentationURLs, getDocumentationURL } from '../utils/documentation';
-
-const ClusterOperatorsResource: WatchK8sResource = {
-  isList: true,
-  kind: referenceForModel(ClusterOperatorModel),
-};
-
-const ClusterServiceVersionResource: WatchK8sResource = {
-  isList: true,
-  kind: referenceForModel(ClusterServiceVersionModel),
-};
+import { resourceListPathFromModel } from '../utils/resource-link';
 
 const ClusterOperatorsLink: FC<ClusterOperatorsLinkProps> = ({
   onCancel,
@@ -73,15 +58,7 @@ export const ClusterNotUpgradeableAlert: FC<ClusterNotUpgradeableAlertProps> = (
   cv,
   onCancel,
 }) => {
-  const [clusterOperators] = useK8sWatchResource<ClusterOperator[]>(ClusterOperatorsResource);
-  const [clusterServiceVersions] = useK8sWatchResource<ClusterServiceVersionKind[]>(
-    ClusterServiceVersionResource,
-  );
   const { t } = useTranslation('public');
-  const notUpgradeableClusterOperators = getNotUpgradeableResources(clusterOperators);
-  const notUpgradeableClusterOperatorsPresent = notUpgradeableClusterOperators.length > 0;
-  const notUpgradeableClusterServiceVersions = getNotUpgradeableResources(clusterServiceVersions);
-  const notUpgradeableCSVsPresent = notUpgradeableClusterServiceVersions.length > 0;
   const clusterUpgradeableFalseCondition = getConditionUpgradeableFalse(cv);
   const currentVersion = getLastCompletedUpdate(cv);
   const currentVersionParsed = semver.parse(currentVersion);
@@ -105,28 +82,19 @@ export const ClusterNotUpgradeableAlert: FC<ClusterNotUpgradeableAlertProps> = (
       }
       className="co-alert"
       actionLinks={
-        (notUpgradeableClusterOperatorsPresent || notUpgradeableCSVsPresent) && (
-          <Flex>
-            {notUpgradeableClusterOperatorsPresent && (
-              <FlexItem>
-                <ClusterOperatorsLink onCancel={onCancel} queryString="?status=Cannot+update">
-                  {t('View ClusterOperators')}
-                </ClusterOperatorsLink>
-              </FlexItem>
-            )}
-            {notUpgradeableCSVsPresent && (
-              // TODO:  update link to include filter once installed Operators filters are updated
-              <FlexItem>
-                <Link
-                  onClick={onCancel}
-                  to={`/k8s/ns/all-namespaces/${ClusterServiceVersionModel.plural}`}
-                >
-                  {t('View installed Operators')}
-                </Link>
-              </FlexItem>
-            )}
-          </Flex>
-        )
+        <Flex>
+          <FlexItem>
+            <ClusterOperatorsLink onCancel={onCancel} queryString="?status=Cannot+update">
+              {t('View ClusterOperators')}
+            </ClusterOperatorsLink>
+          </FlexItem>
+          {/* TODO:  update link to include filter once installed Operators filters are updated */}
+          <FlexItem>
+            <Link onClick={onCancel} to={resourceListPathFromModel(ClusterServiceVersionModel)}>
+              {t('View installed Operators')}
+            </Link>
+          </FlexItem>
+        </Flex>
       }
       data-test="cluster-settings-alerts-not-upgradeable"
     >

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -323,9 +323,6 @@ export const getConditionUpgradeableFalse = (resource) =>
     (c) => c.type === 'Upgradeable' && c.status === K8sResourceConditionStatus.False,
   );
 
-export const getNotUpgradeableResources = (resources) =>
-  resources.filter((resource) => getConditionUpgradeableFalse(resource));
-
 export enum NodeTypes {
   master = 'master',
   worker = 'worker',


### PR DESCRIPTION
The ClusterNotUpgradeableAlert component fetched all ClusterServiceVersions cluster-wide (resulting in up to 600MB object sizes in the browser on clusters with 350+ namespaces and lot's of operators) on every visit to Cluster Settings when Upgradeable=False was set.

The only use of CSVs was to decide whether or not to show navigation links.

For installed operators this was ineffective: CSV status.conditions use phase/reason fields, not type/status, so getConditionUpgradeableFalse() always returned undefined on CSVs — meaning notUpgradeableCSVsPresent was permanently false and the 'View installed Operators' link was never shown.

Additionally the link URL used /k8s/ns/all-namespaces/ instead of /k8s/all-namespaces/, causing 'No Operators found' on navigation.

Fix: remove both the ClusterOperator and CSV watches. Both navigation links are now always shown when the alert renders — correct since the alert only mounts when Upgradeable=False is already confirmed on ClusterVersion. Use resourceListPathFromModel() for the correct all-namespaces URL.

https://issues.redhat.com/browse/OCPBUGS-81511


**Analysis / Root cause**:
The ClusterNotUpgradeableAlert component fetched all ClusterServiceVersions
cluster-wide (resulting in up to 600MB object sizes in the browser on clusters
with 350+ namespaces and lots of operators) on every visit to Cluster Settings
when Upgradeable=False was set.

The only use of CSVs was to decide whether or not to show navigation links.

For installed operators this was ineffective: CSV status.conditions use
phase/reason fields, not type/status, so getConditionUpgradeableFalse() always
returned undefined on CSVs — meaning notUpgradeableCSVsPresent was permanently
false and the 'View installed Operators' link was never shown.

Additionally the link URL used /k8s/ns/all-namespaces/ instead of
/k8s/all-namespaces/, causing 'No Operators found' on navigation.

**Solution description**:
Remove both the ClusterOperator and CSV watches. Both navigation links are now
always shown when the alert renders — correct since the alert only mounts when
Upgradeable=False is already confirmed on ClusterVersion. Use
resourceListPathFromModel() for the correct all-namespaces URL.

https://issues.redhat.com/browse/OCPBUGS-81511

**Test setup:**
1. Create fake ClusterOperators with Upgradeable=False to trigger the alert:
   oc apply -f - <<EOF
   apiVersion: config.openshift.io/v1
   kind: ClusterOperator
   metadata:
     name: test-upgrade-blocker
   spec: {}
   EOF
   oc patch co test-upgrade-blocker --subresource=status --type=merge -p '{"status":{"conditions":[{"type":"Upgradeable","status":"False","reason":"Test","message":"Test block","lastTransitionTime":"2026-08-04T10:00:00Z"},{"type":"Available","
status":"True","lastTransitionTime":"2026-08-04T10:00:00Z"},{"type":"Degraded","status":"False","lastTransitionTime":"2026-08-04T10:00:00Z"},{"type":"Progressing","status":"False","lastTransitionTime":"2026-08-04T10:00:00Z"}]}}'
2. Navigate to Administration → Cluster Settings
3. Open DevTools → Network, filter on clusterserviceversions

**Test cases:**
- With cluster upgradeable (normal state): no clusterserviceversions request fires on Cluster Settings page load
- With Upgradeable=False set: alert renders, no clusterserviceversions LIST request fires, both "View ClusterOperators" and "View installed Operators" links are visible
- Clicking "View installed Operators" navigates correctly to the all-namespaces installed operators list

**Browser conformance**:
- [x] Firefox




<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cluster upgrade warning with clearer links to ClusterOperators and installed Operators.
  * Updated the installed Operators link to use the appropriate resource list, including all namespaces.
  * Ensured the warning displays the relevant ClusterVersion condition message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->