### PR TITLE
NO-JIRA: Prepare for publishing new 4.23 prerelease plugin SDK packages

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,7 +10,7 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
-## 4.23.0-prerelease.5 - TBD
+## 4.23.0-prerelease.5 - 2026-08-04
 
 - **Deprecated**: The use of multiple predicates in the `useResolvedExtensions` hook is deprecated ([#16115], [CONSOLE-5065])
 - **Type breaking**: Replace `ExtensionTypeGuard` with `ExtensionPredicate` from `@openshift/dynamic-plugin-sdk` ([#16115], [CONSOLE-5065])

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-webpack.md
@@ -10,13 +10,14 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
-## 4.23.0-prerelease.5 - TBD
+## 4.23.0-prerelease.5 - 2026-08-04
 
 - Dependency bumps for `semver` and `glob` ([CONSOLE-5065], [#16115])
 
 ## 4.23.0-prerelease.4 - 2026-07-14
 
-- Add support for building with `rspack`. Both `webpack` and `rspack` are optional peer dependencies, but one of them must be installed ([CONSOLE-5423], [#16752])
+- Add support for building plugins with rspack ([CONSOLE-5423], [#16752])
+- `webpack` and `rspack` peer dependencies are now optional, but one of them must be installed ([CONSOLE-5423], [#16752])
 
 ## 4.23.0-prerelease.3 - 2026-07-07
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes with the `4.23.0-prerelease.5` release date.
  * Clarified rspack support details and documented optional peer dependency behavior for `4.23.0-prerelease.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->