### PR TITLE
HELM-827: Add RTL unit tests for 9 critical Helm plugin components

### DIFF
--- a/frontend/packages/helm-plugin/src/components/details-page/history/__tests__/HelmReleaseHistory.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/__tests__/HelmReleaseHistory.spec.tsx
@@ -146,7 +146,7 @@ describe('HelmReleaseHistory', () => {
     await waitFor(() => {
       expect(screen.getByTestId('status-box')).toBeTruthy();
     });
-    expect(screen.getByText('Unable to load Helm Release history')).toBeTruthy();
+    expect(screen.getByText('Unable to load Helm release history')).toBeTruthy();
   });
 
   it('should render within PaneBody when loaded successfully', async () => {

--- a/frontend/packages/helm-plugin/src/components/details-page/history/__tests__/HelmReleaseHistory.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/details-page/history/__tests__/HelmReleaseHistory.spec.tsx
@@ -1,0 +1,169 @@
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { fetchHelmReleaseHistory } from '../../../../utils/helm-utils';
+import HelmReleaseHistory from '../HelmReleaseHistory';
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: jest.fn().mockReturnValue({ ns: 'test-ns', name: 'my-release' }),
+}));
+
+jest.mock('../../../../utils/helm-utils', () => ({
+  ...jest.requireActual('../../../../utils/helm-utils'),
+  fetchHelmReleaseHistory: jest.fn(),
+}));
+
+jest.mock('../HelmReleaseHistoryTable', () => {
+  const MockTable = (props: { releaseHistory: unknown[]; isLoading: boolean }) => (
+    <div
+      data-test="mock-history-table"
+      data-loading={String(props.isLoading)}
+      data-count={String(props.releaseHistory?.length ?? 0)}
+    />
+  );
+  return { __esModule: true, default: MockTable };
+});
+
+jest.mock('../HelmReleaseHistoryTableHelpers', () => ({
+  useHelmReleaseHistoryColumns: jest.fn(),
+  getHelmReleaseHistoryRows: jest.fn().mockReturnValue([]),
+  getHistoryColumnIndexById: jest.fn().mockReturnValue(0),
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  StatusBox: (props: { loadError: string; label: string }) => (
+    <div data-test="status-box">{props.loadError}</div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/layout/PaneBody', () => {
+  const MockPaneBody = (props: { children: unknown }) => (
+    <div data-test="pane-body">{props.children as string}</div>
+  );
+  return { __esModule: true, default: MockPaneBody };
+});
+
+jest.mock('@console/shared/src/hooks/useDeepCompareMemoize', () => ({
+  useDeepCompareMemoize: (value: unknown) => value,
+}));
+
+const mockFetchHistory = fetchHelmReleaseHistory as jest.Mock;
+
+const mockObj = {
+  metadata: { name: 'my-release', namespace: 'test-ns' },
+};
+
+const mockHelmRelease = {
+  name: 'my-release',
+  namespace: 'test-ns',
+  version: 3,
+  chart: {
+    metadata: { name: 'my-chart', version: '1.0.0', apiVersion: 'v2', urls: [] },
+    files: [],
+    templates: [],
+    values: {},
+  },
+  info: {
+    description: 'Install complete',
+    deleted: '',
+    first_deployed: '2024-01-01T00:00:00Z',
+    last_deployed: '2024-01-03T00:00:00Z',
+    status: 'deployed',
+    notes: '',
+  },
+};
+
+const mockRevisions = [
+  {
+    ...mockHelmRelease,
+    version: 1,
+    info: { ...mockHelmRelease.info, last_deployed: '2024-01-01T00:00:00Z' },
+  },
+  {
+    ...mockHelmRelease,
+    version: 2,
+    info: { ...mockHelmRelease.info, last_deployed: '2024-01-02T00:00:00Z' },
+  },
+  {
+    ...mockHelmRelease,
+    version: 3,
+    info: { ...mockHelmRelease.info, last_deployed: '2024-01-03T00:00:00Z' },
+  },
+];
+
+const defaultProps = {
+  obj: mockObj,
+  customData: mockHelmRelease,
+};
+
+describe('HelmReleaseHistory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the history table when revisions load successfully', async () => {
+    mockFetchHistory.mockResolvedValue(mockRevisions);
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-history-table')).toBeTruthy();
+    });
+  });
+
+  it('should show loading state while fetching revisions', () => {
+    mockFetchHistory.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    const table = screen.getByTestId('mock-history-table');
+    expect(table.getAttribute('data-loading')).toBe('true');
+  });
+
+  it('should show StatusBox with error when fetchHelmReleaseHistory fails', async () => {
+    mockFetchHistory.mockRejectedValue(new Error('Network error'));
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('status-box')).toBeTruthy();
+    });
+    expect(screen.getByText('Network error')).toBeTruthy();
+  });
+
+  it('should pass revisions to HelmReleaseHistoryTable', async () => {
+    mockFetchHistory.mockResolvedValue(mockRevisions);
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    await waitFor(() => {
+      const table = screen.getByTestId('mock-history-table');
+      expect(table.getAttribute('data-count')).toBe('3');
+    });
+  });
+
+  it('should fetch history with the correct namespace and release name', () => {
+    mockFetchHistory.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    expect(mockFetchHistory).toHaveBeenCalledWith('my-release', 'test-ns');
+  });
+
+  it('should show default error message when error has no message', async () => {
+    mockFetchHistory.mockRejectedValue(new Error());
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('status-box')).toBeTruthy();
+    });
+    expect(screen.getByText('Unable to load Helm Release history')).toBeTruthy();
+  });
+
+  it('should render within PaneBody when loaded successfully', async () => {
+    mockFetchHistory.mockResolvedValue(mockRevisions);
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pane-body')).toBeTruthy();
+    });
+    expect(screen.getByTestId('mock-history-table')).toBeTruthy();
+  });
+
+  it('should not render PaneBody when there is a load error', async () => {
+    mockFetchHistory.mockRejectedValue(new Error('Server error'));
+    renderWithProviders(<HelmReleaseHistory {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('status-box')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('pane-body')).toBeNull();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/CreateHelmChartRepositoryForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/CreateHelmChartRepositoryForm.spec.tsx
@@ -199,6 +199,6 @@ describe('CreateHelmChartRepositoryForm', () => {
   it('should show the form description text', () => {
     renderWithProviders(<CreateHelmChartRepositoryForm {...defaultProps} />);
 
-    expect(screen.getByText('Add helm chart repository.')).toBeVisible();
+    expect(screen.getByText('Add Helm Chart repository.')).toBeVisible();
   });
 });

--- a/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/CreateHelmChartRepositoryForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/HelmChartRepository/__tests__/CreateHelmChartRepositoryForm.spec.tsx
@@ -1,0 +1,204 @@
+import { screen } from '@testing-library/react';
+import { EditorType } from '@console/shared/src/components/synced-editor/editor-toggle';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import CreateHelmChartRepositoryForm from '../CreateHelmChartRepositoryForm';
+
+jest.mock('@console/shared/src/components/form-utils/FlexForm', () => ({
+  FlexForm: ({ children, onSubmit }: any) => (
+    <form data-test="flex-form" onSubmit={onSubmit}>
+      {children}
+    </form>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormBody', () => ({
+  FormBody: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormHeader', () => ({
+  FormHeader: ({ title, helpText }: any) => (
+    <div data-test="form-header">
+      <h1>{title}</h1>
+      {helpText && <span>{helpText}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormFooter', () => ({
+  FormFooter: ({ submitLabel, disableSubmit, errorMessage, successMessage, handleCancel }: any) => (
+    <div data-test="form-footer">
+      <button type="submit" disabled={disableSubmit}>
+        {submitLabel}
+      </button>
+      <button type="button" onClick={handleCancel}>
+        Cancel
+      </button>
+      {errorMessage && <div data-test="error-message">{errorMessage}</div>}
+      {successMessage && <div data-test="success-message">{successMessage}</div>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/SyncedEditorField', () => ({
+  SyncedEditorField: ({ formContext, yamlContext }: any) => (
+    <div data-test="synced-editor">
+      {formContext?.editor}
+      {yamlContext?.editor}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/CodeEditorField', () => ({
+  CodeEditorField: () => <div data-test="code-editor">YAML Editor</div>,
+}));
+
+jest.mock('../CreateHelmChartRepositoryFormEditor', () => ({
+  __esModule: true,
+  default: () => <div data-test="form-editor">Form Editor</div>,
+}));
+
+jest.mock('../helmchartrepository-create-utils', () => ({
+  convertToForm: jest.fn((v: any) => v),
+  convertToHelmChartRepository: jest.fn(() => ({})),
+}));
+
+jest.mock('@console/shared/src/components/editor/yaml-download-utils', () => ({
+  downloadYaml: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/utils/yaml', () => ({
+  safeJSToYAML: jest.fn(() => 'yaml: data'),
+}));
+
+const defaultFormData = {
+  repoName: 'my-repo',
+  repoUrl: 'https://example.com/charts',
+  scope: 'HelmChartRepository',
+  repoDisplayName: '',
+  repoDescription: '',
+};
+
+const defaultFormikProps = {
+  values: {
+    editorType: EditorType.Form,
+    formData: defaultFormData,
+    yamlData: 'apiVersion: v1',
+  },
+  errors: {},
+  touched: {},
+  isSubmitting: false,
+  isValidating: false,
+  status: undefined,
+  submitCount: 0,
+  dirty: false,
+  isValid: true,
+  initialValues: {
+    editorType: EditorType.Form,
+    formData: defaultFormData,
+    yamlData: 'apiVersion: v1',
+  },
+  initialErrors: {},
+  initialTouched: {},
+  initialStatus: undefined,
+  handleSubmit: jest.fn(),
+  handleReset: jest.fn(),
+  handleBlur: jest.fn(),
+  handleChange: jest.fn(),
+  resetForm: jest.fn(),
+  setErrors: jest.fn(),
+  setFieldError: jest.fn(),
+  setFieldTouched: jest.fn(),
+  setFieldValue: jest.fn(),
+  setFormikState: jest.fn(),
+  setStatus: jest.fn(),
+  setSubmitting: jest.fn(),
+  setTouched: jest.fn(),
+  setValues: jest.fn(),
+  submitForm: jest.fn(),
+  validateForm: jest.fn(),
+  validateField: jest.fn(),
+  getFieldProps: jest.fn(),
+  getFieldMeta: jest.fn(),
+  getFieldHelpers: jest.fn(),
+  registerField: jest.fn(),
+  unregisterField: jest.fn(),
+};
+
+const defaultProps = {
+  ...defaultFormikProps,
+  namespace: 'test-ns',
+  handleCancel: jest.fn(),
+  showScopeType: true,
+  existingRepo: null,
+};
+
+describe('CreateHelmChartRepositoryForm', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the form title for creating a new repository', () => {
+    renderWithProviders(<CreateHelmChartRepositoryForm {...defaultProps} />);
+
+    expect(screen.getByText('Create Helm Chart Repository')).toBeVisible();
+  });
+
+  it('should render the form and YAML editors via SyncedEditorField', () => {
+    renderWithProviders(<CreateHelmChartRepositoryForm {...defaultProps} />);
+
+    expect(screen.getByTestId('synced-editor')).toBeVisible();
+    expect(screen.getByTestId('form-editor')).toBeVisible();
+    expect(screen.getByTestId('code-editor')).toBeVisible();
+  });
+
+  it('should render Create as the submit button label for new repos', () => {
+    renderWithProviders(<CreateHelmChartRepositoryForm {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeVisible();
+  });
+
+  it('should render Save as the submit button label when editing existing repo', () => {
+    const existingRepo = {
+      apiVersion: 'helm.openshift.io/v1beta1',
+      kind: 'HelmChartRepository',
+      metadata: { name: 'existing-repo' },
+      spec: { connectionConfig: { url: 'https://example.com' } },
+    };
+    renderWithProviders(
+      <CreateHelmChartRepositoryForm {...defaultProps} existingRepo={existingRepo} />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeVisible();
+  });
+
+  it('should disable submit button when form is not dirty', () => {
+    renderWithProviders(<CreateHelmChartRepositoryForm {...defaultProps} dirty={false} />);
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('should enable submit button when form is dirty and has no errors', () => {
+    renderWithProviders(
+      <CreateHelmChartRepositoryForm {...defaultProps} dirty isSubmitting={false} />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Create' })).not.toBeDisabled();
+  });
+
+  it('should display submit error message', () => {
+    renderWithProviders(
+      <CreateHelmChartRepositoryForm
+        {...defaultProps}
+        status={{ submitError: 'Failed to create' }}
+      />,
+    );
+
+    expect(screen.getByText('Failed to create')).toBeVisible();
+  });
+
+  it('should show the form description text', () => {
+    renderWithProviders(<CreateHelmChartRepositoryForm {...defaultProps} />);
+
+    expect(screen.getByText('Add helm chart repository.')).toBeVisible();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmChartVersionDropdown.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmChartVersionDropdown.spec.tsx
@@ -1,0 +1,182 @@
+import { screen, waitFor } from '@testing-library/react';
+import { Formik } from 'formik';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { HelmActionType } from '../../../../types/helm-types';
+import { getChartEntriesByName, getChartVersions } from '../../../../utils/helm-utils';
+import HelmChartVersionDropdown from '../HelmChartVersionDropdown';
+
+jest.mock('@console/shared/src/components/formik-fields/DropdownField', () => ({
+  DropdownField: ({ label, title, disabled, helpText, name }: any) => (
+    <div data-test="dropdown-field">
+      <label>{label}</label>
+      <span data-test="dropdown-title">{title}</span>
+      {disabled && <span data-test="dropdown-disabled">disabled</span>}
+      {helpText && <span data-test="dropdown-help">{helpText}</span>}
+      <input type="hidden" name={name} />
+    </div>
+  ),
+}));
+
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: jest.fn(() => [[], true, null]),
+}));
+
+jest.mock('@console/shared/src/hooks/useWarningModal', () => ({
+  useWarningModal: jest.fn(() => jest.fn()),
+}));
+
+const mockCoFetch = jest.fn();
+jest.mock('@console/shared/src/utils/console-fetch', () => ({
+  coFetchJSON: jest.fn(),
+  coFetch: (...args: any[]) => mockCoFetch(...args),
+}));
+
+jest.mock('../../../../models/helm', () => ({
+  HelmChartRepositoryModel: {
+    apiGroup: 'helm.openshift.io',
+    apiVersion: 'v1beta1',
+    kind: 'HelmChartRepository',
+    plural: 'helmchartrepositories',
+  },
+}));
+
+jest.mock('@console/internal/module/k8s', () => ({
+  referenceForModel: jest.fn(() => 'helm.openshift.io~v1beta1~HelmChartRepository'),
+}));
+
+jest.mock('../../../../utils/helm-utils', () => ({
+  getChartEntriesByName: jest.fn(() => []),
+  getChartVersions: jest.fn(() => ({})),
+  getChartIndexEntry: jest.fn(() => 'test-chart--my-repo'),
+  concatVersions: jest.fn((version: string) => version),
+  getChartURL: jest.fn(() => ''),
+  getChartReadme: jest.fn(() => ''),
+  getChartRepositoryTitle: jest.fn(() => ''),
+  mergeHelmValuesOnChartVersionChange: jest.fn(() => ({})),
+}));
+
+const indexYaml = `entries:
+  test-chart:
+    - name: test-chart
+      version: "2.0.0"
+    - name: test-chart
+      version: "1.0.0"`;
+
+const formikInitialValues = {
+  chartVersion: '1.0.0',
+  chartURL: 'https://example.com/charts/test-chart-1.0.0.tgz',
+  chartRepoName: 'my-repo',
+  chartName: 'test-chart',
+  chartReadme: '',
+  appVersion: '1.0',
+  yamlData: 'key: value',
+  formData: {},
+  formSchema: {},
+  editorType: 'form',
+  releaseName: 'my-release',
+  chartIndexEntry: '',
+};
+
+const defaultProps = {
+  chartVersion: '1.0.0',
+  chartName: 'test-chart',
+  helmAction: HelmActionType.Create,
+  onVersionChange: jest.fn(),
+  namespace: 'test-ns',
+  chartIndexEntry: 'test-chart--my-repo',
+};
+
+const renderDropdown = (props = {}) => {
+  return renderWithProviders(
+    <Formik initialValues={formikInitialValues} onSubmit={jest.fn()}>
+      <HelmChartVersionDropdown {...defaultProps} {...props} />
+    </Formik>,
+  );
+};
+
+describe('HelmChartVersionDropdown', () => {
+  beforeEach(() => {
+    mockCoFetch.mockResolvedValue({ text: () => Promise.resolve(indexYaml) });
+    (getChartEntriesByName as jest.Mock).mockReturnValue([
+      { version: '2.0.0', repoName: 'my-repo' },
+      { version: '1.0.0', repoName: 'my-repo' },
+    ]);
+    (getChartVersions as jest.Mock).mockReturnValue({
+      '2.0.0': '2.0.0',
+      '1.0.0': '1.0.0',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the Chart version label', async () => {
+    renderDropdown();
+
+    expect(screen.getByText('Chart version')).toBeVisible();
+    await waitFor(() => {
+      expect(screen.queryByTestId('dropdown-disabled')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should display the current chart version in the dropdown title', async () => {
+    renderDropdown();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-title')).toHaveTextContent('1.0.0');
+    });
+  });
+
+  it('should show help text for upgrade action', async () => {
+    renderDropdown({ helmAction: HelmActionType.Upgrade });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-help')).toHaveTextContent(
+        'Select the version to upgrade to.',
+      );
+    });
+  });
+
+  it('should not show help text for create action', async () => {
+    renderDropdown({ helmAction: HelmActionType.Create });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('dropdown-disabled')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('dropdown-help')).not.toBeInTheDocument();
+  });
+
+  it('should show "No versions available" when no chart versions are loaded and no chartVersion', async () => {
+    (getChartEntriesByName as jest.Mock).mockReturnValue([]);
+    (getChartVersions as jest.Mock).mockReturnValue({});
+
+    renderDropdown({ chartVersion: '' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-title')).toHaveTextContent('No versions available');
+    });
+  });
+
+  it('should disable dropdown when only one version is available', async () => {
+    (getChartEntriesByName as jest.Mock).mockReturnValue([
+      { version: '1.0.0', repoName: 'my-repo' },
+    ]);
+    (getChartVersions as jest.Mock).mockReturnValue({ '1.0.0': '1.0.0' });
+
+    renderDropdown();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-disabled')).toBeVisible();
+    });
+  });
+
+  it('should fetch chart index from the correct namespace', async () => {
+    renderDropdown({ namespace: 'my-namespace' });
+
+    expect(mockCoFetch).toHaveBeenCalledWith('/api/helm/charts/index.yaml?namespace=my-namespace');
+    await waitFor(() => {
+      expect(screen.queryByTestId('dropdown-disabled')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmChartVersionDropdown.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmChartVersionDropdown.spec.tsx
@@ -86,13 +86,12 @@ const defaultProps = {
   chartIndexEntry: 'test-chart--my-repo',
 };
 
-const renderDropdown = (props = {}) => {
-  return renderWithProviders(
+const renderDropdown = (props = {}) =>
+  renderWithProviders(
     <Formik initialValues={formikInitialValues} onSubmit={jest.fn()}>
       <HelmChartVersionDropdown {...defaultProps} {...props} />
     </Formik>,
   );
-};
 
 describe('HelmChartVersionDropdown', () => {
   beforeEach(() => {

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmInstallUpgradeForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmInstallUpgradeForm.spec.tsx
@@ -1,0 +1,290 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { HelmActionType } from '../../../../types/helm-types';
+import type { HelmInstallUpgradeFormData } from '../HelmInstallUpgradeForm';
+import HelmInstallUpgradeForm from '../HelmInstallUpgradeForm';
+
+jest.mock('@console/shared/src/components/formik-fields/InputField', () => ({
+  InputField: (props: any) => (
+    <div data-test={props['data-test']}>
+      <label htmlFor={props.name}>
+        {props.label}
+        {props.required && ' *'}
+      </label>
+      <input
+        id={props.name}
+        name={props.name}
+        type={props.type}
+        disabled={props.isDisabled}
+        aria-label={props.label}
+      />
+      {props.helpText && <span>{props.helpText}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/ResourceDropdownField', () => ({
+  ResourceDropdownField: (props: any) => (
+    <div data-test="resource-dropdown">
+      <label>{props.label}</label>
+      {props.helpText && <span>{props.helpText}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/SyncedEditorField', () => ({
+  SyncedEditorField: ({ formContext, yamlContext }: any) => (
+    <div data-test="synced-editor">
+      {formContext?.editor}
+      {yamlContext?.editor}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/DynamicFormField', () => ({
+  DynamicFormField: ({ formDescription }: any) => (
+    <div data-test="dynamic-form">{formDescription}</div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/CodeEditorField', () => ({
+  CodeEditorField: ({ label }: any) => <div data-test="code-editor">{label}</div>,
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FlexForm', () => ({
+  FlexForm: ({ children, onSubmit }: any) => (
+    <form data-test="flex-form" onSubmit={onSubmit}>
+      {children}
+    </form>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormBody', () => ({
+  FormBody: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormHeader', () => ({
+  FormHeader: ({ title, helpText }: any) => (
+    <div data-test="form-header">
+      <h1>{title}</h1>
+      <div data-test="form-help-text">{helpText}</div>
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormFooter', () => ({
+  FormFooter: ({ submitLabel, disableSubmit, resetLabel, errorMessage }: any) => (
+    <div data-test="form-footer">
+      <button type="submit" disabled={disableSubmit}>
+        {submitLabel}
+      </button>
+      <button type="button">{resetLabel}</button>
+      {errorMessage && <div data-test="error-message">{errorMessage}</div>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('../HelmChartVersionDropdown', () => ({
+  __esModule: true,
+  default: ({ chartName, chartVersion }: any) => (
+    <div data-test="chart-version-dropdown">
+      {chartName} - {chartVersion}
+    </div>
+  ),
+}));
+
+jest.mock('../HelmReadmeModal', () => ({
+  useHelmReadmeModalLauncher: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../url-chart/useBasicAuthSecretDropdown', () => ({
+  useBasicAuthSecretDropdown: jest.fn(() => ({ handleSecretChange: jest.fn() })),
+  CREATE_SECRET_KEY: '__create_secret__',
+  NONE_SECRET_KEY: '__none__',
+}));
+
+jest.mock('../../url-chart/useSecretResources', () => ({
+  useSecretResources: jest.fn(() => [{ data: [], loaded: true, loadError: null, kind: 'Secret' }]),
+}));
+
+jest.mock('@console/shared/src/components/dynamic-form/utils', () => ({
+  getJSONSchemaOrder: jest.fn(() => ({})),
+  prune: jest.fn((v: any) => v),
+}));
+
+const defaultValues: HelmInstallUpgradeFormData = {
+  releaseName: 'my-release',
+  chartName: 'my-chart',
+  chartRepoName: 'my-repo',
+  chartVersion: '1.0.0',
+  chartReadme: '',
+  appVersion: '1.0.0',
+  yamlData: 'key: value',
+  formData: { replicas: 1 },
+  formSchema: { type: 'object', properties: { replicas: { type: 'number' } } },
+  editorType: 'form' as any,
+  basicAuthSecretName: '',
+  isURLInstall: false,
+};
+
+const defaultFormikProps = {
+  values: defaultValues,
+  errors: {},
+  touched: {},
+  isSubmitting: false,
+  isValidating: false,
+  status: undefined,
+  submitCount: 0,
+  dirty: false,
+  isValid: true,
+  initialValues: defaultValues,
+  initialErrors: {},
+  initialTouched: {},
+  initialStatus: undefined,
+  handleSubmit: jest.fn(),
+  handleReset: jest.fn(),
+  handleBlur: jest.fn(),
+  handleChange: jest.fn(),
+  resetForm: jest.fn(),
+  setErrors: jest.fn(),
+  setFieldError: jest.fn(),
+  setFieldTouched: jest.fn(),
+  setFieldValue: jest.fn(),
+  setFormikState: jest.fn(),
+  setStatus: jest.fn(),
+  setSubmitting: jest.fn(),
+  setTouched: jest.fn(),
+  setValues: jest.fn(),
+  submitForm: jest.fn(),
+  validateForm: jest.fn(),
+  validateField: jest.fn(),
+  getFieldProps: jest.fn(),
+  getFieldMeta: jest.fn(),
+  getFieldHelpers: jest.fn(),
+  registerField: jest.fn(),
+  unregisterField: jest.fn(),
+};
+
+const defaultProps = {
+  ...defaultFormikProps,
+  chartHasValues: true,
+  helmActionConfig: {
+    type: HelmActionType.Create,
+    title: 'Install Helm Chart',
+    subTitle: 'Install a Helm Chart to create a Helm Release.',
+    helmReleaseApi: '/api/helm/release',
+    fetch: jest.fn(),
+    redirectURL: '/helm-releases',
+  },
+  chartMetaDescription: 'A test chart description',
+  onVersionChange: jest.fn(),
+  chartError: null as Error,
+  namespace: 'test-ns',
+};
+
+describe('HelmInstallUpgradeForm', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the form title and release name field', () => {
+    renderWithProviders(<HelmInstallUpgradeForm {...defaultProps} />);
+
+    expect(screen.getByText('Install Helm Chart')).toBeVisible();
+    expect(screen.getByLabelText('Release name')).toBeVisible();
+    expect(screen.getByText('A unique name for the Helm Release.')).toBeVisible();
+  });
+
+  it('should render the chart version dropdown with chart name and version', () => {
+    renderWithProviders(<HelmInstallUpgradeForm {...defaultProps} />);
+
+    expect(screen.getByText('my-chart - 1.0.0')).toBeVisible();
+  });
+
+  it('should render the synced editor when chart has values and no chart error', () => {
+    renderWithProviders(<HelmInstallUpgradeForm {...defaultProps} />);
+
+    expect(screen.getByTestId('synced-editor')).toBeVisible();
+  });
+
+  it('should show non-configurable alert when chart has no values and no schema', () => {
+    renderWithProviders(
+      <HelmInstallUpgradeForm
+        {...defaultProps}
+        chartHasValues={false}
+        values={{ ...defaultValues, formSchema: null, formData: null }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        /Helm release is not configurable since the Helm Chart doesn't define any values/,
+      ),
+    ).toBeVisible();
+  });
+
+  it('should display chart error alert and disable the release name field when chartError is set', () => {
+    const chartError = new Error('Chart fetch failed');
+    renderWithProviders(<HelmInstallUpgradeForm {...defaultProps} chartError={chartError} />);
+
+    expect(screen.getByText('Helm Chart cannot be installed')).toBeVisible();
+    expect(screen.getByLabelText('Release name')).toBeDisabled();
+  });
+
+  it('should disable submit button when form is submitting', () => {
+    renderWithProviders(<HelmInstallUpgradeForm {...defaultProps} isSubmitting />);
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('should disable submit button on upgrade when form is not dirty', () => {
+    renderWithProviders(
+      <HelmInstallUpgradeForm
+        {...defaultProps}
+        dirty={false}
+        helmActionConfig={{
+          ...defaultProps.helmActionConfig,
+          type: HelmActionType.Upgrade,
+          title: 'Upgrade Helm Release',
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Upgrade' })).toBeDisabled();
+  });
+
+  it('should show the README link when chartReadme is provided', () => {
+    renderWithProviders(
+      <HelmInstallUpgradeForm
+        {...defaultProps}
+        values={{ ...defaultValues, chartReadme: '# My Chart README' }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'README' })).toBeVisible();
+  });
+
+  it('should display submit error message when status has submitError', () => {
+    renderWithProviders(
+      <HelmInstallUpgradeForm {...defaultProps} status={{ submitError: 'Something went wrong' }} />,
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeVisible();
+  });
+
+  it('should show secret dropdown when isURLInstall is true', () => {
+    renderWithProviders(
+      <HelmInstallUpgradeForm
+        {...defaultProps}
+        values={{ ...defaultValues, isURLInstall: true }}
+      />,
+    );
+
+    expect(screen.getByText('Secret for Basic authentication')).toBeVisible();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmInstallUpgradeForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/install-upgrade/__tests__/HelmInstallUpgradeForm.spec.tsx
@@ -197,7 +197,7 @@ describe('HelmInstallUpgradeForm', () => {
 
     expect(screen.getByText('Install Helm Chart')).toBeVisible();
     expect(screen.getByLabelText('Release name')).toBeVisible();
-    expect(screen.getByText('A unique name for the Helm Release.')).toBeVisible();
+    expect(screen.getByText('A unique name for the Helm release.')).toBeVisible();
   });
 
   it('should render the chart version dropdown with chart name and version', () => {
@@ -250,7 +250,7 @@ describe('HelmInstallUpgradeForm', () => {
         helmActionConfig={{
           ...defaultProps.helmActionConfig,
           type: HelmActionType.Upgrade,
-          title: 'Upgrade Helm Release',
+          title: 'Upgrade Helm release',
         }}
       />,
     );

--- a/frontend/packages/helm-plugin/src/components/forms/rollback/__tests__/HelmReleaseRollbackForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/rollback/__tests__/HelmReleaseRollbackForm.spec.tsx
@@ -149,7 +149,7 @@ const defaultProps = {
   releaseHistory: mockReleaseHistory,
   helmActionConfig: {
     type: HelmActionType.Rollback,
-    title: 'Rollback Helm Release',
+    title: 'Rollback Helm release',
     subTitle: 'Select a version to rollback to.',
     helmReleaseApi: '/api/helm/release',
     fetch: jest.fn(),
@@ -165,7 +165,7 @@ describe('HelmReleaseRollbackForm', () => {
   it('should render the form title', () => {
     renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} />);
 
-    expect(screen.getByText('Rollback Helm Release')).toBeVisible();
+    expect(screen.getByText('Rollback Helm release')).toBeVisible();
   });
 
   it('should display the rollback help text', () => {

--- a/frontend/packages/helm-plugin/src/components/forms/rollback/__tests__/HelmReleaseRollbackForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/rollback/__tests__/HelmReleaseRollbackForm.spec.tsx
@@ -1,0 +1,221 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { HelmActionType } from '../../../../types/helm-types';
+import type { HelmRelease } from '../../../../types/helm-types';
+import HelmReleaseRollbackForm from '../HelmReleaseRollbackForm';
+
+jest.mock('react-i18next', () => ({
+  ...jest.requireActual('react-i18next'),
+  useTranslation: () => ({
+    t: (key: string) => key.replace(/^helm-plugin~/, ''),
+    i18n: { language: 'en' },
+  }),
+  Trans: () => <span>Select the version to rollback to</span>,
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormBody', () => ({
+  FormBody: ({ children }: any) => <div data-test="form-body">{children}</div>,
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormHeader', () => ({
+  FormHeader: ({ title, helpText }: any) => (
+    <div data-test="form-header">
+      <h1>{title}</h1>
+      <div data-test="form-help-text">{helpText}</div>
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormFooter', () => ({
+  FormFooter: ({ submitLabel, disableSubmit, resetLabel, errorMessage }: any) => (
+    <div data-test="form-footer">
+      <button type="submit" disabled={disableSubmit}>
+        {submitLabel}
+      </button>
+      <button type="button">{resetLabel}</button>
+      {errorMessage && <div data-test="error-message">{errorMessage}</div>}
+    </div>
+  ),
+}));
+
+jest.mock('../../../details-page/history/HelmReleaseHistoryTable', () => ({
+  __esModule: true,
+  default: ({ releaseHistory }: any) => (
+    <table data-test="history-table">
+      <tbody>
+        {releaseHistory.map((r: HelmRelease) => (
+          <tr key={r.version}>
+            <td>{r.name}</td>
+            <td>{r.version}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+const mockReleaseHistory: HelmRelease[] = [
+  {
+    name: 'my-release',
+    namespace: 'test-ns',
+    chart: {
+      files: [],
+      metadata: {
+        name: 'test-chart',
+        version: '1.0.0',
+        apiVersion: 'v2',
+        urls: [],
+      },
+      templates: [],
+      values: {},
+    },
+    info: {
+      description: 'Revision 1',
+      deleted: '',
+      first_deployed: '2026-01-01T00:00:00Z',
+      last_deployed: '2026-01-01T00:00:00Z',
+      status: 'deployed',
+      notes: '',
+    },
+    version: 1,
+  },
+  {
+    name: 'my-release',
+    namespace: 'test-ns',
+    chart: {
+      files: [],
+      metadata: {
+        name: 'test-chart',
+        version: '1.0.0',
+        apiVersion: 'v2',
+        urls: [],
+      },
+      templates: [],
+      values: {},
+    },
+    info: {
+      description: 'Revision 2',
+      deleted: '',
+      first_deployed: '2026-01-01T00:00:00Z',
+      last_deployed: '2026-01-02T00:00:00Z',
+      status: 'deployed',
+      notes: '',
+    },
+    version: 2,
+  },
+];
+
+const defaultFormikProps = {
+  values: { version: 1 },
+  errors: {},
+  touched: {},
+  isSubmitting: false,
+  isValidating: false,
+  status: undefined,
+  submitCount: 0,
+  dirty: false,
+  isValid: true,
+  initialValues: { version: 1 },
+  initialErrors: {},
+  initialTouched: {},
+  initialStatus: undefined,
+  handleSubmit: jest.fn(),
+  handleReset: jest.fn(),
+  handleBlur: jest.fn(),
+  handleChange: jest.fn(),
+  resetForm: jest.fn(),
+  setErrors: jest.fn(),
+  setFieldError: jest.fn(),
+  setFieldTouched: jest.fn(),
+  setFieldValue: jest.fn(),
+  setFormikState: jest.fn(),
+  setStatus: jest.fn(),
+  setSubmitting: jest.fn(),
+  setTouched: jest.fn(),
+  setValues: jest.fn(),
+  submitForm: jest.fn(),
+  validateForm: jest.fn(),
+  validateField: jest.fn(),
+  getFieldProps: jest.fn(),
+  getFieldMeta: jest.fn(),
+  getFieldHelpers: jest.fn(),
+  registerField: jest.fn(),
+  unregisterField: jest.fn(),
+};
+
+const defaultProps = {
+  ...defaultFormikProps,
+  releaseName: 'my-release',
+  releaseHistory: mockReleaseHistory,
+  helmActionConfig: {
+    type: HelmActionType.Rollback,
+    title: 'Rollback Helm Release',
+    subTitle: 'Select a version to rollback to.',
+    helmReleaseApi: '/api/helm/release',
+    fetch: jest.fn(),
+    redirectURL: '/helm-releases',
+  },
+};
+
+describe('HelmReleaseRollbackForm', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the form title', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} />);
+
+    expect(screen.getByText('Rollback Helm Release')).toBeVisible();
+  });
+
+  it('should display the rollback help text', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} />);
+
+    expect(screen.getByText('Select the version to rollback to')).toBeVisible();
+  });
+
+  it('should render the revision history table with release entries', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} />);
+
+    expect(screen.getByTestId('history-table')).toBeVisible();
+    expect(screen.getByText('Revision history')).toBeVisible();
+  });
+
+  it('should render Rollback as the submit button label', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Rollback' })).toBeVisible();
+  });
+
+  it('should disable submit button when form is not dirty', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} dirty={false} />);
+
+    expect(screen.getByRole('button', { name: 'Rollback' })).toBeDisabled();
+  });
+
+  it('should disable submit button when form is submitting', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} dirty isSubmitting />);
+
+    expect(screen.getByRole('button', { name: 'Rollback' })).toBeDisabled();
+  });
+
+  it('should enable submit button when form is dirty and has no errors', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} dirty isSubmitting={false} />);
+
+    expect(screen.getByRole('button', { name: 'Rollback' })).not.toBeDisabled();
+  });
+
+  it('should display submit error when status has submitError', () => {
+    renderWithProviders(
+      <HelmReleaseRollbackForm {...defaultProps} status={{ submitError: 'Rollback failed' }} />,
+    );
+
+    expect(screen.getByText('Rollback failed')).toBeVisible();
+  });
+
+  it('should render Cancel button', () => {
+    renderWithProviders(<HelmReleaseRollbackForm {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/__tests__/HelmURLChartForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/__tests__/HelmURLChartForm.spec.tsx
@@ -138,7 +138,7 @@ describe('HelmURLChartForm', () => {
   it('should render the form title and description', () => {
     renderWithProviders(<HelmURLChartForm {...defaultProps} />);
 
-    expect(screen.getByText('Install Helm chart from URL')).toBeVisible();
+    expect(screen.getByText('Install Helm Chart from URL')).toBeVisible();
   });
 
   it('should render Chart URL, Release name, and Chart version input fields', () => {

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/__tests__/HelmURLChartForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/__tests__/HelmURLChartForm.spec.tsx
@@ -83,6 +83,7 @@ const defaultValues = {
   releaseName: '',
   chartVersion: '',
   basicAuthSecretName: '',
+  namespace: 'test-ns',
 };
 
 const defaultFormikProps = {

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/__tests__/HelmURLChartForm.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/__tests__/HelmURLChartForm.spec.tsx
@@ -1,0 +1,194 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import HelmURLChartForm from '../HelmURLChartForm';
+
+jest.mock('@console/shared/src/components/formik-fields/InputField', () => ({
+  InputField: (props: any) => (
+    <div data-test={props['data-test']}>
+      <label htmlFor={props.name}>
+        {props.label}
+        {props.required && ' *'}
+      </label>
+      <input
+        id={props.name}
+        name={props.name}
+        type={props.type}
+        disabled={props.isDisabled}
+        aria-label={props.label}
+        placeholder={props.placeholder}
+      />
+      {props.helpText && <span>{props.helpText}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/formik-fields/ResourceDropdownField', () => ({
+  ResourceDropdownField: (props: any) => (
+    <div data-test="resource-dropdown">
+      <label>{props.label}</label>
+      {props.helpText && <span>{props.helpText}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FlexForm', () => ({
+  FlexForm: ({ children, onSubmit }: any) => (
+    <form data-test="flex-form" onSubmit={onSubmit}>
+      {children}
+    </form>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormBody', () => ({
+  FormBody: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormHeader', () => ({
+  FormHeader: ({ title, helpText }: any) => (
+    <div data-test="form-header">
+      <h1>{title}</h1>
+      {helpText && <span>{helpText}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/shared/src/components/form-utils/FormFooter', () => ({
+  FormFooter: ({ submitLabel, disableSubmit, resetLabel, errorMessage }: any) => (
+    <div data-test="form-footer">
+      <button type="submit" disabled={disableSubmit}>
+        {submitLabel}
+      </button>
+      <button type="button">{resetLabel}</button>
+      {errorMessage && <div data-test="error-message">{errorMessage}</div>}
+    </div>
+  ),
+}));
+
+jest.mock('@console/dev-console/src/components/import/section/FormSection', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('../useBasicAuthSecretDropdown', () => ({
+  useBasicAuthSecretDropdown: jest.fn(() => ({ handleSecretChange: jest.fn() })),
+  CREATE_SECRET_KEY: '__create_secret__',
+}));
+
+jest.mock('../useSecretResources', () => ({
+  useSecretResources: jest.fn(() => [{ data: [], loaded: true, loadError: null, kind: 'Secret' }]),
+}));
+
+const defaultValues = {
+  chartURL: '',
+  releaseName: '',
+  chartVersion: '',
+  basicAuthSecretName: '',
+};
+
+const defaultFormikProps = {
+  values: defaultValues,
+  errors: {},
+  touched: {},
+  isSubmitting: false,
+  isValidating: false,
+  status: undefined,
+  submitCount: 0,
+  dirty: false,
+  isValid: true,
+  initialValues: defaultValues,
+  initialErrors: {},
+  initialTouched: {},
+  initialStatus: undefined,
+  handleSubmit: jest.fn(),
+  handleReset: jest.fn(),
+  handleBlur: jest.fn(),
+  handleChange: jest.fn(),
+  resetForm: jest.fn(),
+  setErrors: jest.fn(),
+  setFieldError: jest.fn(),
+  setFieldTouched: jest.fn(),
+  setFieldValue: jest.fn(),
+  setFormikState: jest.fn(),
+  setStatus: jest.fn(),
+  setSubmitting: jest.fn(),
+  setTouched: jest.fn(),
+  setValues: jest.fn(),
+  submitForm: jest.fn(),
+  validateForm: jest.fn(),
+  validateField: jest.fn(),
+  getFieldProps: jest.fn(),
+  getFieldMeta: jest.fn(),
+  getFieldHelpers: jest.fn(),
+  registerField: jest.fn(),
+  unregisterField: jest.fn(),
+};
+
+const defaultProps = {
+  ...defaultFormikProps,
+  namespace: 'test-ns',
+  onNext: jest.fn(),
+};
+
+describe('HelmURLChartForm', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the form title and description', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} />);
+
+    expect(screen.getByText('Install Helm chart from URL')).toBeVisible();
+  });
+
+  it('should render Chart URL, Release name, and Chart version input fields', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} />);
+
+    expect(screen.getByLabelText('Chart URL')).toBeVisible();
+    expect(screen.getByLabelText('Release name')).toBeVisible();
+    expect(screen.getByLabelText('Chart version')).toBeVisible();
+  });
+
+  it('should render the Secret for Basic authentication dropdown', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} />);
+
+    expect(screen.getByText('Secret for Basic authentication')).toBeVisible();
+  });
+
+  it('should render Next as the submit button label', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Next' })).toBeVisible();
+  });
+
+  it('should disable Next button when form is not dirty', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} dirty={false} />);
+
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('should disable Next button when form is invalid', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} dirty isValid={false} />);
+
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
+  });
+
+  it('should enable Next button when form is valid and dirty', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} dirty isValid isSubmitting={false} />);
+
+    expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled();
+  });
+
+  it('should display submit error message when status has submitError', () => {
+    renderWithProviders(
+      <HelmURLChartForm {...defaultProps} status={{ submitError: 'Chart not found' }} />,
+    );
+
+    expect(screen.getByText('Chart not found')).toBeVisible();
+  });
+
+  it('should render Cancel button', () => {
+    renderWithProviders(<HelmURLChartForm {...defaultProps} />);
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmReleaseList.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmReleaseList.spec.tsx
@@ -123,8 +123,8 @@ describe('HelmReleaseList', () => {
 
     renderWithProviders(<HelmReleaseList />);
 
-    expect(screen.getAllByText('Helm Releases')).toHaveLength(2);
-    expect(screen.getByTestId('data-view-label')).toHaveTextContent('Helm Releases');
+    expect(screen.getAllByText('Helm releases')).toHaveLength(2);
+    expect(screen.getByTestId('data-view-label')).toHaveTextContent('Helm releases');
   });
 
   it('should show ConsoleDataView in loading state when secrets are not loaded', () => {
@@ -141,7 +141,7 @@ describe('HelmReleaseList', () => {
     renderWithProviders(<HelmReleaseList />);
 
     await waitFor(() => {
-      expect(screen.getByText('No Helm Releases found')).toBeVisible();
+      expect(screen.getByText('No Helm releases found')).toBeVisible();
     });
   });
 
@@ -195,6 +195,6 @@ describe('HelmReleaseList', () => {
     renderWithProviders(<HelmReleaseList mock />);
 
     expect(screen.getByTestId('console-data-view')).toBeVisible();
-    expect(screen.queryByText('No Helm Releases found')).not.toBeInTheDocument();
+    expect(screen.queryByText('No Helm releases found')).not.toBeInTheDocument();
   });
 });

--- a/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmReleaseList.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmReleaseList.spec.tsx
@@ -1,0 +1,200 @@
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { fetchHelmReleases } from '../../../utils/helm-utils';
+import HelmReleaseList from '../HelmReleaseList';
+
+const mockUseParams = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: () => mockUseParams(),
+  Link: ({ children, to }: any) => (
+    <a href={typeof to === 'string' ? to : to.pathname}>{children}</a>
+  ),
+}));
+
+const mockUseK8sWatchResource = jest.fn();
+jest.mock('@console/internal/components/utils/k8s-watch-hook', () => ({
+  useK8sWatchResource: (...args: any[]) => mockUseK8sWatchResource(...args),
+}));
+
+jest.mock('@console/app/src/components/data-view/ConsoleDataView', () => ({
+  ConsoleDataView: ({ label, data, loaded, loadError }: any) => (
+    <div data-test="console-data-view">
+      <span data-test="data-view-label">{label}</span>
+      {!loaded && <span>Loading...</span>}
+      {loadError && <span data-test="load-error">{String(loadError)}</span>}
+      {loaded && !loadError && <span data-test="data-count">{data?.length ?? 0} releases</span>}
+    </div>
+  ),
+  initialFiltersDefault: { name: '' },
+  actionsCellProps: {},
+  nameCellProps: {},
+}));
+
+jest.mock('@console/app/src/components/data-view/useResizableColumnProps', () => ({
+  useColumnWidthSettings: jest.fn(() => ({
+    getResizableProps: jest.fn(() => ({})),
+    resetAllColumnWidths: jest.fn(),
+  })),
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  LoadingBox: () => <div data-test="loading-box">Loading...</div>,
+}));
+
+jest.mock('@console/shared/src/components/catalog/utils/catalog-utils', () => ({
+  isCatalogTypeEnabled: jest.fn(() => true),
+}));
+
+jest.mock('@console/shared/src/components/document-title/DocumentTitle', () => ({
+  DocumentTitle: ({ children }: any) => <title>{children}</title>,
+}));
+
+jest.mock('@console/shared/src/components/layout/PaneBody', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-test="pane-body">{children}</div>,
+}));
+
+jest.mock('../../../utils/icons', () => ({
+  HelmCatalogIcon: () => null,
+}));
+
+jest.mock('../HelmReleaseListRow', () => ({
+  getDataViewRows: jest.fn(() => []),
+  tableColumnInfo: [
+    { id: 'name' },
+    { id: 'namespace' },
+    { id: 'revision' },
+    { id: 'updated' },
+    { id: 'status' },
+    { id: 'chart-name' },
+    { id: 'chart-version' },
+    { id: 'app-version' },
+    { id: 'actions' },
+  ],
+}));
+
+jest.mock('@patternfly/react-data-view', () => ({
+  DataViewCheckboxFilter: () => null,
+}));
+
+jest.mock('../../../utils/helm-utils', () => ({
+  ...jest.requireActual('../../../utils/helm-utils'),
+  fetchHelmReleases: jest.fn(),
+}));
+
+const mockHelmRelease = {
+  name: 'test-release',
+  namespace: 'test-ns',
+  chart: {
+    files: [],
+    metadata: {
+      name: 'test-chart',
+      version: '1.0.0',
+      apiVersion: 'v2',
+      appVersion: '2.0.0',
+      urls: [],
+    },
+    templates: [],
+    values: {},
+  },
+  info: {
+    description: 'A test release',
+    deleted: '',
+    first_deployed: '2026-01-01T00:00:00Z',
+    last_deployed: '2026-01-01T00:00:00Z',
+    status: 'deployed',
+    notes: '',
+  },
+  version: 1,
+};
+
+describe('HelmReleaseList', () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ ns: 'test-ns' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the document title and data view label as Helm Releases', () => {
+    mockUseK8sWatchResource.mockReturnValue([[], false, null]);
+
+    renderWithProviders(<HelmReleaseList />);
+
+    expect(screen.getAllByText('Helm Releases')).toHaveLength(2);
+    expect(screen.getByTestId('data-view-label')).toHaveTextContent('Helm Releases');
+  });
+
+  it('should show ConsoleDataView in loading state when secrets are not loaded', () => {
+    mockUseK8sWatchResource.mockReturnValue([[], false, null]);
+
+    renderWithProviders(<HelmReleaseList />);
+
+    expect(screen.getByText('Loading...')).toBeVisible();
+  });
+
+  it('should show empty state when no Helm releases exist', async () => {
+    mockUseK8sWatchResource.mockReturnValue([[], true, null]);
+
+    renderWithProviders(<HelmReleaseList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No Helm Releases found')).toBeVisible();
+    });
+  });
+
+  it('should show a link to browse the catalog in empty state', async () => {
+    mockUseK8sWatchResource.mockReturnValue([[], true, null]);
+
+    renderWithProviders(<HelmReleaseList />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Browse the catalog to discover available Helm Charts'),
+      ).toBeVisible();
+    });
+  });
+
+  it('should render ConsoleDataView with fetched releases when secrets exist', async () => {
+    const secretsData = [{ metadata: { name: 'helm-secret-1' } }];
+    mockUseK8sWatchResource.mockReturnValue([secretsData, true, null]);
+    (fetchHelmReleases as jest.Mock).mockResolvedValue([mockHelmRelease as any]);
+
+    renderWithProviders(<HelmReleaseList />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-count')).toHaveTextContent('1 releases');
+    });
+  });
+
+  it('should display load error from secrets watch', () => {
+    mockUseK8sWatchResource.mockReturnValue([[], true, 'Failed to load secrets']);
+
+    renderWithProviders(<HelmReleaseList />);
+
+    expect(screen.getByTestId('load-error')).toHaveTextContent('Failed to load secrets');
+  });
+
+  it('should display error when fetchHelmReleases fails', async () => {
+    const secretsData = [{ metadata: { name: 'helm-secret-1' } }];
+    mockUseK8sWatchResource.mockReturnValue([secretsData, true, null]);
+    (fetchHelmReleases as jest.Mock).mockRejectedValue(new Error('Network failure'));
+
+    renderWithProviders(<HelmReleaseList />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('load-error')).toHaveTextContent('Network failure');
+    });
+  });
+
+  it('should use mock mode and show ConsoleDataView without empty state', () => {
+    mockUseK8sWatchResource.mockReturnValue([[], true, null]);
+
+    renderWithProviders(<HelmReleaseList mock />);
+
+    expect(screen.getByTestId('console-data-view')).toBeVisible();
+    expect(screen.queryByText('No Helm Releases found')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmTabbedPage.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmTabbedPage.spec.tsx
@@ -1,0 +1,195 @@
+import { screen } from '@testing-library/react';
+import * as Router from 'react-router';
+import * as MultiTabListPageModule from '@console/shared/src/components/multi-tab-list/MultiTabListPage';
+import { useFlag } from '@console/shared/src/hooks/useFlag';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import HelmTabbedPage from '../HelmTabbedPage';
+
+const mockUseAccessReview = jest.fn();
+const mockUseActivePerspective = jest.fn();
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: jest.fn(),
+}));
+
+jest.mock('@console/dynamic-plugin-sdk/src', () => ({
+  useAccessReview: (...args: unknown[]) => mockUseAccessReview(...args),
+  useActivePerspective: () => mockUseActivePerspective(),
+}));
+
+jest.mock('@console/shared/src/hooks/useFlag', () => ({
+  useFlag: jest.fn(),
+}));
+
+jest.mock('@console/internal/components/start-guide', () => ({
+  withStartGuide: (Component: React.ComponentType) => Component,
+}));
+
+jest.mock('@console/dev-console/src/components/NamespacedPage', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+  NamespacedPageVariants: { light: 'light' },
+}));
+
+jest.mock('@console/dev-console/src/components/projects/CreateProjectListPage', () => ({
+  __esModule: true,
+  default: ({
+    title,
+    children,
+  }: {
+    title: string;
+    children: (fn: () => void) => React.ReactNode;
+  }) => (
+    <div data-test="create-project-list-page">
+      <span>{title}</span>
+      {typeof children === 'function' ? children(jest.fn()) : children}
+    </div>
+  ),
+  CreateAProjectButton: () => null,
+}));
+
+jest.mock('@console/shared/src/components/multi-tab-list/MultiTabListPage', () => ({
+  MultiTabListPage: jest.fn(({ title }: { title: string }) => (
+    <div data-test="multi-tab-list-page">
+      <span>{title}</span>
+    </div>
+  )),
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  LoadingBox: () => <div data-test="loading-box">Loading...</div>,
+}));
+
+jest.mock('../HelmReleaseList', () => ({
+  __esModule: true,
+  default: 'HelmReleaseList',
+}));
+
+jest.mock('../HelmReleaseListPage', () => ({
+  __esModule: true,
+  default: () => <div data-test="helm-release-list-page">Helm Release List Page</div>,
+}));
+
+jest.mock('../RepositoriesListPage', () => ({
+  __esModule: true,
+  default: 'RepositoriesPage',
+}));
+
+jest.mock('../../../models/helm', () => ({
+  HelmChartRepositoryModel: {
+    apiGroup: 'helm.openshift.io',
+    plural: 'helmchartrepositories',
+  },
+  ProjectHelmChartRepositoryModel: {
+    apiGroup: 'helm.openshift.io',
+    plural: 'projecthelmchartrepositories',
+  },
+}));
+
+const useParamsMock = Router.useParams as jest.Mock;
+const useFlagMock = useFlag as jest.Mock;
+const mockMultiTabListPage = MultiTabListPageModule.MultiTabListPage as jest.Mock;
+
+/** Helper: configure all 6 useAccessReview calls to return the same tuple. */
+const setAllAccessReviews = (allowed: boolean, loading: boolean) => {
+  mockUseAccessReview.mockReturnValue([allowed, loading]);
+};
+
+describe('HelmTabbedPage', () => {
+  beforeEach(() => {
+    useParamsMock.mockReturnValue({ ns: 'test-ns' });
+    useFlagMock.mockReturnValue(true);
+    mockUseActivePerspective.mockReturnValue(['dev']);
+    mockMultiTabListPage.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should show LoadingBox when access reviews are loading', () => {
+    setAllAccessReviews(false, true);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    expect(screen.getByTestId('loading-box')).toBeVisible();
+    expect(screen.getByText('Loading...')).toBeVisible();
+  });
+
+  it('should show MultiTabListPage with "Helm" title when user has full access', () => {
+    setAllAccessReviews(true, false);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    expect(screen.getByTestId('multi-tab-list-page')).toBeVisible();
+    expect(screen.getByText('Helm')).toBeVisible();
+  });
+
+  it('should show HelmReleaseListPage when user has no repository access', () => {
+    setAllAccessReviews(false, false);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    expect(screen.getByTestId('helm-release-list-page')).toBeVisible();
+    expect(screen.queryByTestId('multi-tab-list-page')).not.toBeInTheDocument();
+  });
+
+  it('should pass "Helm Releases" and "Repositories" pages to MultiTabListPage', () => {
+    setAllAccessReviews(true, false);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    const callArgs = mockMultiTabListPage.mock.calls[0][0];
+    expect(callArgs.pages).toHaveLength(2);
+    expect(callArgs.pages[0].nameKey).toBe('helm-plugin~Helm Releases');
+    expect(callArgs.pages[1].nameKey).toBe('helm-plugin~Repositories');
+  });
+
+  it('should show CreateProjectListPage when no namespace and dev perspective', () => {
+    useParamsMock.mockReturnValue({});
+    mockUseActivePerspective.mockReturnValue(['dev']);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    expect(screen.getByTestId('create-project-list-page')).toBeVisible();
+    expect(screen.queryByTestId('multi-tab-list-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('loading-box')).not.toBeInTheDocument();
+  });
+
+  it('should show HelmPage when admin perspective even without namespace', () => {
+    useParamsMock.mockReturnValue({});
+    mockUseActivePerspective.mockReturnValue(['admin']);
+    setAllAccessReviews(true, false);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    expect(screen.getByTestId('multi-tab-list-page')).toBeVisible();
+    expect(screen.queryByTestId('create-project-list-page')).not.toBeInTheDocument();
+  });
+
+  it('should pass correct telemetryPrefix to MultiTabListPage', () => {
+    setAllAccessReviews(true, false);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    const callArgs = mockMultiTabListPage.mock.calls[0][0];
+    expect(callArgs.telemetryPrefix).toBe('Helm');
+  });
+
+  it('should pass menuActions with helmRelease, projectHelmChartRepository, and helmChartInstallation', () => {
+    setAllAccessReviews(true, false);
+
+    renderWithProviders(<HelmTabbedPage />);
+
+    const callArgs = mockMultiTabListPage.mock.calls[0][0];
+    const actionKeys = Object.keys(callArgs.menuActions);
+    expect(actionKeys).toEqual(
+      expect.arrayContaining([
+        'helmRelease',
+        'projectHelmChartRepository',
+        'helmChartInstallation',
+      ]),
+    );
+  });
+});

--- a/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmTabbedPage.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/__tests__/HelmTabbedPage.spec.tsx
@@ -142,7 +142,7 @@ describe('HelmTabbedPage', () => {
 
     const callArgs = mockMultiTabListPage.mock.calls[0][0];
     expect(callArgs.pages).toHaveLength(2);
-    expect(callArgs.pages[0].nameKey).toBe('helm-plugin~Helm Releases');
+    expect(callArgs.pages[0].nameKey).toBe('helm-plugin~Helm releases');
     expect(callArgs.pages[1].nameKey).toBe('helm-plugin~Repositories');
   });
 

--- a/frontend/packages/helm-plugin/src/components/list-page/__tests__/RepositoriesList.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/__tests__/RepositoriesList.spec.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import type { TableProps } from '@console/internal/components/factory';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import RepositoriesList from '../RepositoriesList';
@@ -62,6 +63,13 @@ const mockData: K8sResourceKind[] = [
   },
 ];
 
+const defaultProps: TableProps = {
+  data: [],
+  loaded: false,
+  Header: () => [],
+  'aria-label': 'Repositories',
+};
+
 describe('RepositoriesList', () => {
   beforeEach(() => {
     mockConsoleDataView.mockClear();
@@ -69,7 +77,7 @@ describe('RepositoriesList', () => {
   });
 
   it('should render ConsoleDataView with HelmChartRepositories label', () => {
-    renderWithProviders(<RepositoriesList data={[]} loaded={false} />);
+    renderWithProviders(<RepositoriesList {...defaultProps} />);
 
     expect(screen.getByText('HelmChartRepositories')).toBeInTheDocument();
     expect(mockConsoleDataView).toHaveBeenCalledWith(
@@ -78,7 +86,7 @@ describe('RepositoriesList', () => {
   });
 
   it('should pass data and loaded props to ConsoleDataView', () => {
-    renderWithProviders(<RepositoriesList data={mockData} loaded />);
+    renderWithProviders(<RepositoriesList {...defaultProps} data={mockData} loaded />);
 
     expect(mockConsoleDataView).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -89,7 +97,7 @@ describe('RepositoriesList', () => {
   });
 
   it('should pass the correct data count when loaded with data', () => {
-    renderWithProviders(<RepositoriesList data={mockData} loaded />);
+    renderWithProviders(<RepositoriesList {...defaultProps} data={mockData} loaded />);
 
     const calledProps = mockConsoleDataView.mock.calls[0][0];
     expect(calledProps.data).toHaveLength(2);
@@ -97,7 +105,7 @@ describe('RepositoriesList', () => {
   });
 
   it('should pass loaded as false when not loaded', () => {
-    renderWithProviders(<RepositoriesList data={[]} loaded={false} />);
+    renderWithProviders(<RepositoriesList {...defaultProps} />);
 
     const calledProps = mockConsoleDataView.mock.calls[0][0];
     expect(calledProps.loaded).toBe(false);
@@ -105,7 +113,7 @@ describe('RepositoriesList', () => {
 
   it('should pass loadError to ConsoleDataView when loadError is set', () => {
     const loadError = 'Failed to fetch repositories';
-    renderWithProviders(<RepositoriesList data={[]} loaded loadError={loadError} />);
+    renderWithProviders(<RepositoriesList {...defaultProps} loaded loadError={loadError} />);
 
     expect(mockConsoleDataView).toHaveBeenCalledWith(
       expect.objectContaining({ loadError: 'Failed to fetch repositories' }),
@@ -113,7 +121,7 @@ describe('RepositoriesList', () => {
   });
 
   it('should pass columns and resetAllColumnWidths from useRepositoriesColumns', () => {
-    renderWithProviders(<RepositoriesList data={[]} loaded />);
+    renderWithProviders(<RepositoriesList {...defaultProps} loaded />);
 
     expect(mockConsoleDataView).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/frontend/packages/helm-plugin/src/components/list-page/__tests__/RepositoriesList.spec.tsx
+++ b/frontend/packages/helm-plugin/src/components/list-page/__tests__/RepositoriesList.spec.tsx
@@ -1,0 +1,125 @@
+import { screen } from '@testing-library/react';
+import type { K8sResourceKind } from '@console/internal/module/k8s';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import RepositoriesList from '../RepositoriesList';
+
+const mockConsoleDataView = jest.fn();
+jest.mock('@console/app/src/components/data-view/ConsoleDataView', () => ({
+  ConsoleDataView: (props: Record<string, unknown>) => {
+    mockConsoleDataView(props);
+    return props.label as string;
+  },
+}));
+
+jest.mock('@console/internal/components/utils', () => ({
+  LoadingBox: () => 'LoadingBox',
+}));
+
+const mockResetAllColumnWidths = jest.fn();
+const mockColumns = [
+  { id: 'name', title: 'Name' },
+  { id: 'repoUrl', title: 'Repo URL' },
+];
+
+jest.mock('../RepositoriesHeader', () => ({
+  useRepositoriesColumns: () => ({
+    columns: mockColumns,
+    resetAllColumnWidths: mockResetAllColumnWidths,
+  }),
+}));
+
+jest.mock('../RepositoriesRow', () => ({
+  getDataViewRows: jest.fn(),
+}));
+
+jest.mock('../../../models/helm', () => ({
+  HelmRepositoriesCombinedListModel: {
+    apiGroup: 'console.ui',
+    apiVersion: 'v1',
+    kind: 'HelmRepositoriesCombinedList',
+    id: 'helmrepositoriescombinedlist',
+    plural: 'helmrepositoriescombinedlists',
+    label: 'Helm Chart Repositories',
+    labelPlural: 'Helm Chart Repositories',
+    abbr: 'HCRL',
+    namespaced: false,
+    crd: true,
+  },
+}));
+
+const mockData: K8sResourceKind[] = [
+  {
+    apiVersion: 'helm.openshift.io/v1beta1',
+    kind: 'HelmChartRepository',
+    metadata: { name: 'repo-1', namespace: 'default' },
+    spec: { name: 'Test Repo 1' },
+  },
+  {
+    apiVersion: 'helm.openshift.io/v1beta1',
+    kind: 'HelmChartRepository',
+    metadata: { name: 'repo-2', namespace: 'test-ns' },
+    spec: { name: 'Test Repo 2' },
+  },
+];
+
+describe('RepositoriesList', () => {
+  beforeEach(() => {
+    mockConsoleDataView.mockClear();
+    mockResetAllColumnWidths.mockClear();
+  });
+
+  it('should render ConsoleDataView with HelmChartRepositories label', () => {
+    renderWithProviders(<RepositoriesList data={[]} loaded={false} />);
+
+    expect(screen.getByText('HelmChartRepositories')).toBeInTheDocument();
+    expect(mockConsoleDataView).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'HelmChartRepositories' }),
+    );
+  });
+
+  it('should pass data and loaded props to ConsoleDataView', () => {
+    renderWithProviders(<RepositoriesList data={mockData} loaded />);
+
+    expect(mockConsoleDataView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: mockData,
+        loaded: true,
+      }),
+    );
+  });
+
+  it('should pass the correct data count when loaded with data', () => {
+    renderWithProviders(<RepositoriesList data={mockData} loaded />);
+
+    const calledProps = mockConsoleDataView.mock.calls[0][0];
+    expect(calledProps.data).toHaveLength(2);
+    expect(calledProps.loaded).toBe(true);
+  });
+
+  it('should pass loaded as false when not loaded', () => {
+    renderWithProviders(<RepositoriesList data={[]} loaded={false} />);
+
+    const calledProps = mockConsoleDataView.mock.calls[0][0];
+    expect(calledProps.loaded).toBe(false);
+  });
+
+  it('should pass loadError to ConsoleDataView when loadError is set', () => {
+    const loadError = 'Failed to fetch repositories';
+    renderWithProviders(<RepositoriesList data={[]} loaded loadError={loadError} />);
+
+    expect(mockConsoleDataView).toHaveBeenCalledWith(
+      expect.objectContaining({ loadError: 'Failed to fetch repositories' }),
+    );
+  });
+
+  it('should pass columns and resetAllColumnWidths from useRepositoriesColumns', () => {
+    renderWithProviders(<RepositoriesList data={[]} loaded />);
+
+    expect(mockConsoleDataView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        columns: mockColumns,
+        resetAllColumnWidths: mockResetAllColumnWidths,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Adds React Testing Library tests covering user-facing behavior for HelmInstallUpgradeForm, HelmReleaseList, HelmReleaseRollbackForm, HelmTabbedPage, HelmURLChartForm, CreateHelmChartRepositoryForm, HelmChartVersionDropdown, HelmReleaseHistory, and RepositoriesList (79 new tests total) as part of the Helm testing SDLC Goal 3.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad automated coverage across Helm release history, repository management, install and upgrade, rollback, URL-based charts, release lists, tabbed navigation, and repository lists.
  * Verified loading, error, empty, and success states; form fields; validation; button states; version selection; access-based navigation; and data rendering.
  * Expanded coverage for chart configuration, authentication options, release revisions, namespace-specific requests, and cancellation or submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->