### PR TITLE
 OCPBUGS-105318: Fix node-groups-filter test to use correct page-heading test ID

### DIFF
--- a/frontend/e2e/tests/console/nodes/node-groups-filter.spec.ts
+++ b/frontend/e2e/tests/console/nodes/node-groups-filter.spec.ts
@@ -231,7 +231,7 @@ test.describe('Edit Groups Button', () => {
     const editButton = page.getByRole('button', { name: /edit groups/i });
     await expect(editButton).toBeVisible();
 
-    const pageHeader = page.locator('[data-test="page-header"], .pf-v6-c-page__main-section').first();
+    const pageHeader = page.getByTestId('page-heading');
     const headerButton = pageHeader.getByRole('button', { name: /edit groups/i });
     await expect(headerButton).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- `data-test="page-header"` does not exist in any React component — `PageHeading.tsx` uses `data-test="page-heading"`
- The "Edit groups" button renders inside `PageHeading` via `ListPageHeader`'s `primaryAction` prop
- This causes the `Edit Groups Button` test to fail on every Playwright CI job

## Test plan
- [ ] `e2e-playwright` CI passes the `Edit Groups Button` test (`node-groups-filter.spec.ts:228`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the node groups end-to-end test to use the current page heading locator, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->