### PR TITLE
OCPBUGS-105273: Fix nested interactive controls on Search page

### DIFF
--- a/frontend/public/components/_resource-dropdown.scss
+++ b/frontend/public/components/_resource-dropdown.scss
@@ -7,6 +7,11 @@
   align-items: center;
   flex: 1;
 }
+
+.co-search__accordion {
+  position: relative;
+}
+
 .co-search__accordion-toggle {
   .pf-v6-c-accordion__toggle-text {
     display: flex;
@@ -17,16 +22,18 @@
       flex-direction: row;
     }
   }
+}
 
-  .co-search-group__pin-toggle {
-    padding-left: var(--pf-t--global--spacer--xs);
-    padding-right: var(--pf-t--global--spacer--xs);
-    margin-right: var(--pf-t--global--spacer--sm);
-    text-align: left;
-  }
-  .co-search-group__pin-toggle__icon {
-    margin-right: var(--pf-t--global--spacer--xs);
-  }
+.co-search-group__pin-toggle {
+  position: absolute;
+  right: var(--pf-t--global--spacer--xl);
+  top: 0;
+  text-align: left;
+  z-index: var(--pf-t--global--z-index--xs);
+}
+
+.co-search-group__pin-toggle__icon {
+  margin-right: var(--pf-t--global--spacer--xs);
 }
 
 .span--icon__right-margin {

--- a/frontend/public/components/search.tsx
+++ b/frontend/public/components/search.tsx
@@ -324,26 +324,26 @@ const InnerSearchPage: FC<SearchProps> = (props) => {
                   id={`${resource}-toggle`}
                 >
                   {getToggleText(resource)}
-                  {perspective !== 'admin' && pinnedResourcesLoaded && (
-                    <Button
-                      className="co-search-group__pin-toggle"
-                      variant={ButtonVariant.link}
-                      onClick={(e) => pinToggle(e, resource)}
-                    >
-                      {pinnedResources.includes(resource) ? (
-                        <>
-                          <RhUiMinusCircleIcon className="co-search-group__pin-toggle__icon" />
-                          {t('Remove from navigation')}
-                        </>
-                      ) : (
-                        <>
-                          <RhUiAddCircleFillIcon className="co-search-group__pin-toggle__icon" />
-                          {t('Add to navigation')}
-                        </>
-                      )}
-                    </Button>
-                  )}
                 </AccordionToggle>
+                {perspective !== 'admin' && pinnedResourcesLoaded && (
+                  <Button
+                    className="co-search-group__pin-toggle"
+                    variant={ButtonVariant.link}
+                    onClick={(e) => pinToggle(e, resource)}
+                  >
+                    {pinnedResources.includes(resource) ? (
+                      <>
+                        <RhUiMinusCircleIcon className="co-search-group__pin-toggle__icon" />
+                        {t('Remove from navigation')}
+                      </>
+                    ) : (
+                      <>
+                        <RhUiAddCircleFillIcon className="co-search-group__pin-toggle__icon" />
+                        {t('Add to navigation')}
+                      </>
+                    )}
+                  </Button>
+                )}
                 <AccordionContent>
                   {!isCollapsed && (
                     <ResourceList


### PR DESCRIPTION
**Analysis / Root cause**:
The Search page accordion toggle (`co-search__accordion-toggle`) renders an "Add to navigation" / "Remove from navigation" `<Button>` as a child of `<AccordionToggle>`, which itself renders as a `<button>`. This creates a `<button>` nested inside a `<button>`, violating WCAG 4.1.2 (`nested-interactive`). Axe flags this as a "serious" accessibility violation — nested interactive controls are not always announced by screen readers and cause focus problems for assistive technologies.  Example failure: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_console/16741/pull-ci-openshift-console-main-e2e-playwright/2085257705513029632/artifacts/e2e-playwright/test/artifacts/playwright-report/index.html#?q=s%3Afailed&testId=8a1e1e4ea9c5d3c5a917-c26f79b8e02bada30d0e

**Solution description**:
Move the pin toggle `<Button>` out of `<AccordionToggle>` and into `<AccordionItem>` as a sibling element. Updated SCSS positions it absolutely over the accordion header to maintain the same visual layout.

**Screenshots / screen recording**:

https://github.com/user-attachments/assets/c3aa2f75-43c1-477d-a6f5-2d201213479e



**Test setup:**
None required.

**Test cases:**
- Verify the "Add to navigation" / "Remove from navigation" button on the Search page still functions correctly
- Run axe accessibility audit and confirm no `nested-interactive` violations
- Verify keyboard navigation works correctly for both the accordion toggle and the pin button
- Run `resource-crud.spec.ts` Playwright tests (PersistentVolume CRUD lifecycle) and confirm the a11y check passes

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
https://redhat.atlassian.net/browse/OCPBUGS-105273

**Reviewers and assignees:**
<!--
Tag reviewers as needed.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of the pin/unpin control in search accordion items.
  * Ensured the pin control remains accessible and visually aligned independently of the accordion toggle.
  * Preserved existing pinning behavior, labels, and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->