### PR TITLE
CONSOLE-5452: Disable flaky debug-pod Cypress test

### DIFF
--- a/frontend/packages/integration-tests/tests/app/debug-pod.cy.ts
+++ b/frontend/packages/integration-tests/tests/app/debug-pod.cy.ts
@@ -25,7 +25,7 @@ spec:
           - ALL
   restartPolicy: Always`;
 
-describe('Debug pod', () => {
+xdescribe('Debug pod', () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);


### PR DESCRIPTION
**Analysis / Root cause**:
The `debug-pod.cy.ts` Cypress test has a high flake rate due to an xterm race condition (`Cannot read properties of undefined (reading 'dimensions')`). The terminal widget attempts to read container dimensions before the DOM element is fully rendered, causing spurious failures that block unrelated PRs in `e2e-gcp-console` CI.

**Solution description**:
Changed `describe` to `xdescribe` in `debug-pod.cy.ts` to skip the flaky test suite. The Playwright migration for this test is already in progress (console#16449), so the Cypress version can be safely disabled.

**Screenshots / screen recording**:
N/A — no visual changes.

**Test setup:**
N/A

**Test cases:**
1. Verify the `Debug pod` Cypress tests are skipped in CI
2. Verify no other test suites are affected

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
This test has been causing repeated `e2e-gcp-console` failures across multiple PRs due to an xterm race condition. The Playwright replacement is in progress via console#16449.

**Reviewers and assignees:**
/cc @jcaianirh