### PR TITLE
OCPBUGS-105314: Fix xterm ResizeObserver crash on uninitialized dimensions

### DIFF
--- a/frontend/public/components/terminal.tsx
+++ b/frontend/public/components/terminal.tsx
@@ -89,17 +89,16 @@ export const Terminal = forwardRef<ImperativeTerminalType, TerminalProps>(
             if (!terminal.current) {
               return;
             }
-            // @ts-expect-error Guard: skip resize if xterm's render service hasn't initialized yet.
-            // ResizeObserver can fire before the internal dimensions are available.
-            if (!terminal.current._core?._renderService?.dimensions) {
-              return;
+            try {
+              fit.fit();
+              onResize(terminal.current.rows, terminal.current.cols);
+              // @ts-expect-error The internal xterm textarea was not repositioned when the window was resized.
+              // See https://bugzilla.redhat.com/show_bug.cgi?id=1983220
+              // and https://github.com/xtermjs/xterm.js/issues/3390
+              terminal.current._core?._syncTextArea?.();
+            } catch {
+              // xterm render service not yet initialized
             }
-            fit.fit();
-            onResize(terminal.current.rows, terminal.current.cols);
-            // @ts-expect-error The internal xterm textarea was not repositioned when the window was resized.
-            // See https://bugzilla.redhat.com/show_bug.cgi?id=1983220
-            // and https://github.com/xtermjs/xterm.js/issues/3390
-            terminal.current._core?._syncTextArea?.();
           },
           true,
         );


### PR DESCRIPTION
**Analysis / Root cause**:
PR #16498 (OCPBUGS-84649, merged Jul 30) replaced the terminal resize logic in `terminal.tsx` with a ResizeObserver-based pattern. The guard on line 94 used optional chaining (`_renderService?.dimensions`) to check if xterm's render service was initialized, but `dimensions` is a getter — when `_renderService` exists but is partially initialized, the getter throws `Cannot read properties of undefined (reading 'dimensions')` instead of returning `undefined`. This uncaught error fails any Cypress test that navigates to a debug terminal page, causing a 74% flake rate on `e2e-gcp-console`.

**Solution description**:
Replaced the broken optional chaining guard with a try-catch around `fit.fit()`. If the fit addon throws because xterm's render service isn't ready, the callback safely returns without crashing.

**Screenshots / screen recording**:
N/A — no visual changes.

**Test setup:**
N/A — fix is verified by existing `debug-pod.cy.ts` Cypress tests passing consistently.

**Test cases:**
1. Verify debug terminal page loads without uncaught TypeError
2. Verify terminal still resizes correctly after initialization
3. Verify `e2e-gcp-console` CI passes without the debug-pod flake

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
This bug has caused a 74% failure rate on `e2e-gcp-console` since PR #16498 merged, affecting 17 unique PRs.

Jira: https://issues.redhat.com/browse/OCPBUGS-105314

**Reviewers and assignees:**
/cc @jcaianirh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resizing reliability by safely handling errors during fitting, resize notifications, and input synchronization.
  * Prevented incomplete resize operations when an internal error occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->