### PR TITLE
OCPBUGS-105316: Fix flaky PollConsoleUpdates e2e test timeout in CI

### DIFF
--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -78,6 +78,10 @@ async function navigateAndWaitForInit(page: Page) {
 }
 
 test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
+  // Each test needs multiple 15s polling cycles (init + change detection + endpoint readiness).
+  // The default 120s is too tight for CI where auth redirects add overhead.
+  test.setTimeout(300_000);
+
   test('triggers the console update toast when consoleCommit changes', async ({ page }) => {
     const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_DEFAULT }),
@@ -121,8 +125,6 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
     page,
   }) => {
-    test.setTimeout(300_000);
-
     const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );

--- a/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
+++ b/frontend/e2e/tests/console/app/poll-console-updates.spec.ts
@@ -121,6 +121,8 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
   test('triggers the console update toast when a plugin is added and a different plugin endpoint is erroring', async ({
     page,
   }) => {
+    test.setTimeout(300_000);
+
     const updates = createMutableHandler((route) =>
       route.fulfill({ json: UPDATES_NEW_PLUGIN }),
     );
@@ -138,7 +140,10 @@ test.describe('PollConsoleUpdates', { tag: ['@admin'] }, () => {
 
     updates.setHandler((route) => route.fulfill({ json: UPDATES_NEW_PLUGIN2 }));
 
-    await page.waitForResponse((resp) => resp.url().includes('/api/check-updates'));
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/check-updates') && resp.status() === 200,
+      { timeout: 30_000 },
+    );
 
     await expect(page.getByTestId('refresh-web-console')).not.toBeAttached({
       timeout: 30_000,


### PR DESCRIPTION
**Analysis / Root cause**:

The Playwright e2e test "triggers the console update toast when a plugin is added and a different plugin endpoint is erroring" in `poll-console-updates.spec.ts` flakes in CI with `Test timeout of 120000ms exceeded`.

The test requires multiple 15-second polling cycles to complete:
- Init: 2 poll cycles (~30s)
- Detect new plugin: 1 poll cycle (~15s)
- Endpoint readiness retry: 1+ poll cycles (~15s+)

Under ideal conditions this totals ~60–75s, but in CI the OAuth redirect flow and slower environment add significant overhead. The `navigateAndWaitForInit` helper alone allows up to 90s for init, leaving very little of the default 120s test timeout for the remaining assertions. When a mid-test auth redirect occurs, the PollConsoleUpdates component remounts and needs additional poll cycles to re-initialize, pushing past the 120s limit.

Additionally, `page.waitForResponse` had no explicit timeout and no status code filter, making it possible to match stale or non-200 responses.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-105316

**Solution description**:

- Add `test.setTimeout(300_000)` to give CI ample headroom for the multi-cycle polling sequence plus potential auth redirects.
- Add explicit `{ timeout: 30_000 }` and `resp.status() === 200` filter to `waitForResponse` for more robust synchronization with the poll cycle.

**Screenshots / screen recording**:

N/A — no visual changes.

**Test setup:**

Console running at localhost:9000.

**Test cases:**

- Ran the specific test 3x with `--repeat-each=3` — all 3 passed.
- Ran all 5 tests in `poll-console-updates.spec.ts` — all passed with no regressions.

**Browser conformance**:

N/A — test-only change, no UI changes.

**Additional info:**

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by allowing more time for plugin endpoint error scenarios.
  * Updated polling checks to proceed only after receiving a successful response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->