### PR TITLE
OCPBUGS-95594: make cloud provider fields optional during operator install

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -97,7 +97,7 @@ const InputField: FC<InputFieldProps> = ({
 }) => (
   <div className="form-group">
     <fieldset>
-      <label className="co-required">{label}</label>
+      <label>{label}</label>
       <FieldLevelHelp>{helpText}</FieldLevelHelp>
       <div>
         <TextInput
@@ -109,7 +109,6 @@ const InputField: FC<InputFieldProps> = ({
           onChange={(_event, val) => {
             setValue(val);
           }}
-          required
         />
       </div>
     </fieldset>
@@ -483,60 +482,37 @@ const OperatorHubSubscribeForm: FC<OperatorHubSubscribeFormProps> = (props) => {
     };
 
     switch (tokenizedAuth) {
-      case 'AWS':
-        subscription.spec.config = {
-          env: [
-            {
-              name: 'ROLEARN',
-              value: roleARNText,
-            },
-          ],
-        };
+      case 'AWS': {
+        const env = [{ name: 'ROLEARN', value: roleARNText }].filter((e) => e.value);
+        if (env.length > 0) {
+          subscription.spec.config = { env };
+        }
         break;
-      case 'Azure':
-        subscription.spec.config = {
-          env: [
-            {
-              name: 'CLIENTID',
-              value: azureClientId,
-            },
-            {
-              name: 'TENANTID',
-              value: azureTenantId,
-            },
-            {
-              name: 'SUBSCRIPTIONID',
-              value: azureSubscriptionId,
-            },
-            {
-              name: 'RESOURCEGROUP',
-              value: azureResourceGroup,
-            },
-          ],
-        };
+      }
+      case 'Azure': {
+        const env = [
+          { name: 'CLIENTID', value: azureClientId },
+          { name: 'TENANTID', value: azureTenantId },
+          { name: 'SUBSCRIPTIONID', value: azureSubscriptionId },
+          { name: 'RESOURCEGROUP', value: azureResourceGroup },
+        ].filter((e) => e.value);
+        if (env.length > 0) {
+          subscription.spec.config = { env };
+        }
         break;
-      case 'GCP':
-        subscription.spec.config = {
-          env: [
-            {
-              name: 'PROJECT_NUMBER',
-              value: gcpProjectNumber,
-            },
-            {
-              name: 'POOL_ID',
-              value: gcpPoolId,
-            },
-            {
-              name: 'PROVIDER_ID',
-              value: gcpProviderId,
-            },
-            {
-              name: 'SERVICE_ACCOUNT_EMAIL',
-              value: gcpServiceAcctEmail,
-            },
-          ],
-        };
+      }
+      case 'GCP': {
+        const env = [
+          { name: 'PROJECT_NUMBER', value: gcpProjectNumber },
+          { name: 'POOL_ID', value: gcpPoolId },
+          { name: 'PROVIDER_ID', value: gcpProviderId },
+          { name: 'SERVICE_ACCOUNT_EMAIL', value: gcpServiceAcctEmail },
+        ].filter((e) => e.value);
+        if (env.length > 0) {
+          subscription.spec.config = { env };
+        }
         break;
+      }
       default:
         break;
     }
@@ -587,14 +563,7 @@ const OperatorHubSubscribeForm: FC<OperatorHubSubscribeFormProps> = (props) => {
     subscriptionExists(selectedTargetNamespace) ||
     !namespaceSupports(selectedTargetNamespace)(selectedInstallMode) ||
     (selectedTargetNamespace && cannotResolve) ||
-    !_.isEmpty(conflictingProvidedAPIs(selectedTargetNamespace)) ||
-    (tokenizedAuth === 'AWS' && _.isEmpty(roleARNText)) ||
-    (tokenizedAuth === 'Azure' &&
-      [azureClientId, azureTenantId, azureSubscriptionId, azureResourceGroup].some((v) =>
-        _.isEmpty(v),
-      )) ||
-    (tokenizedAuth === 'GCP' &&
-      [gcpProjectNumber, gcpPoolId, gcpProviderId, gcpServiceAcctEmail].some((v) => _.isEmpty(v)));
+    !_.isEmpty(conflictingProvidedAPIs(selectedTargetNamespace));
 
   const formError = () =>
     (error && (


### PR DESCRIPTION
## Summary

On Workload Identity / Federated Identity clusters (AWS STS, Azure WI, GCP WI), the Console UI incorrectly forces users to provide cloud-specific credentials (role ARN, Client ID, etc.) before installing operators that have `token-auth-*` CSV annotations. These annotations indicate the operator's *capability* to support cloud authentication, not a mandatory requirement.

This fix makes the cloud provider configuration fields **optional** so users can install operators first and configure cloud credentials as a Day-2 task.

## Changes

- Removed `required` attribute and `co-required` CSS class from the token-auth input fields
- Removed the token-auth validation checks from `formValid()` that blocked the install button when fields were empty

The fields and warning banners still appear when applicable -- they just no longer block installation.

## Test plan

- [ ] Install an operator with `token-auth-aws` annotation on an AWS STS cluster without filling in the role ARN -- should succeed
- [ ] Install an operator with `token-auth-gcp` annotation on a GCP WI cluster without filling in GCP fields -- should succeed
- [ ] Install an operator with `token-auth-azure` annotation on an Azure WI cluster without filling in Azure fields -- should succeed
- [ ] Verify the warning banners and input fields still render correctly
- [ ] Verify filling in the fields still works and values are passed to the subscription

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subscription form validation so optional AWS, Azure, and GCP authentication fields no longer incorrectly block submission.
  * Authentication settings now include only values that have been entered, preventing empty configuration fields from being submitted.
  * Removed misleading required-field indicators from authentication inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->