### PR TITLE
Fix for OCPBUGS-101825: CVE-2026-69152

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -81,7 +81,8 @@
     "minimatch@^3.0.2": "^3.1.3",
     "minimatch@^3.0.4": "^3.1.3",
     "minimatch@^3.1.1": "^3.1.3",
-    "nanoid@^3.3.4": "^3.3.12"
+    "nanoid@^3.3.4": "^3.3.12",
+    "brace-expansion@^1.1.7": "1.1.18"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -343,7 +343,10 @@
     "nanoid@^3.3.6": "^3.3.12",
     "form-data@^2.3.3": "^2.5.6",
     "form-data@~2.3.2": "^2.5.6",
-    "form-data@~4.0.0": "^4.0.6"
+    "form-data@~4.0.0": "^4.0.6",
+    "brace-expansion@^1.1.7": "1.1.18",
+    "brace-expansion@^2.0.2": "2.1.4",
+    "brace-expansion@^5.0.2": "5.0.9"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6629,31 +6629,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+"brace-expansion@npm:1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "brace-expansion@npm:2.0.3"
+"brace-expansion@npm:2.1.4":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "brace-expansion@npm:5.0.3"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/e474d300e581ec56851b3863ff1cf18573170c6d06deb199ccbd03b2119c36975f6ce2abc7b770f5bebddc1ab022661a9fea9b4d56f33315d7bef54d8793869e
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes CVE-2026-69152 — Denial of Service via unbounded intermediate array allocation in `brace-expansion`'s `expand()` function.

### Resolutions added

**frontend/package.json:**
- `brace-expansion@^1.1.7` → `1.1.18`
- `brace-expansion@^2.0.2` → `2.1.4`
- `brace-expansion@^5.0.2` → `5.0.9`

**dynamic-demo-plugin/package.json:**
- `brace-expansion@^1.1.7` → `1.1.18`