### PR TITLE
OCPBUGS-105517: Fix flaky search.spec.ts Playwright e2e tests

### DIFF
--- a/frontend/e2e/pages/base-page.ts
+++ b/frontend/e2e/pages/base-page.ts
@@ -70,6 +70,12 @@ export async function ensureDeveloperPerspective(
     await expect(async () => {
       await page.reload();
       await expect(toggle).not.toHaveAttribute('id', 'only-one-perspective');
+      await toggle.click();
+      const devOption = page
+        .getByTestId('perspective-switcher-menu-option')
+        .filter({ hasText: 'Developer' });
+      await expect(devOption).toBeVisible();
+      await page.keyboard.press('Escape');
     }).toPass({ timeout: 60_000 });
   }
 }

--- a/frontend/e2e/pages/dev-console/search-page.ts
+++ b/frontend/e2e/pages/dev-console/search-page.ts
@@ -1,4 +1,5 @@
 import type { Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import BasePage from '../base-page';
 
@@ -24,6 +25,7 @@ export class SearchPage extends BasePage {
 
   async openResourcesFilter(): Promise<void> {
     await this.resourceFilterInput.click();
+    await expect(this.resourceDropdownList).toBeVisible();
   }
 
   async clearHistory(): Promise<void> {


### PR DESCRIPTION
**Analysis / Root cause**:

The `dev-console/search.spec.ts` "Search page - Recently used" Playwright e2e tests flake in CI due to two race conditions:

1. **Dropdown not awaited after click:** `SearchPage.openResourcesFilter()` clicks the resource filter combobox but returns immediately without waiting for the dropdown listbox (`#resource-dropdown-listbox`) to render. On slower CI runs, `toBeVisible()` assertions against dropdown contents fail because the element doesn't exist yet.

2. **Developer perspective not fully loaded:** `ensureDeveloperPerspective()` patches the cluster config to enable the Developer perspective, then reloads until the perspective switcher toggle is no longer a static single-perspective div. However, the toggle becoming a `<Select>` dropdown does not guarantee the "Developer" menu option is listed — the console may still be loading perspective extensions. `switchPerspective("Developer")` opens the dropdown, finds no Developer option, and throws `Perspective "Developer" not found in switcher menu`.

**Solution description**:

1. Added `await expect(this.resourceDropdownList).toBeVisible()` after the click in `openResourcesFilter()` so Playwright auto-retries until the dropdown is fully open before any test assertions run against its contents.

2. Extended the `ensureDeveloperPerspective()` retry loop to open the perspective switcher dropdown and verify the "Developer" menu option is visible before considering the perspective ready. The dropdown is dismissed with `Escape` after each check.

**Screenshots / screen recording**:
<!-- N/A — test infrastructure change, no visual changes -->

**Test setup:**
Run the search.spec.ts Playwright e2e tests against a cluster where the Developer perspective is not enabled by default (single perspective mode).

**Test cases:**
- [ ] `shows recently searched resource in dropdown` passes consistently
- [ ] `shows up to 5 recently searched items` passes consistently
- [ ] `clears recently searched history` passes consistently
- [ ] Tests pass on clusters where Developer perspective is already enabled (no-op path)
- [ ] Tests pass on clusters where Developer perspective needs to be enabled (patch path)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-105517

**Reviewers and assignees:**
<!-- Tag reviewers as appropriate -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup by verifying the Developer perspective is available before proceeding.
  * Added a wait for the resource filter dropdown to become visible, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->