### PR TITLE
OCPBUGS-105523: Fix flaky perspective query parameter e2e tests

### DIFF
--- a/frontend/e2e/pages/base-page.ts
+++ b/frontend/e2e/pages/base-page.ts
@@ -48,7 +48,7 @@ export async function dismissQuickStartDrawer(page: Page): Promise<void> {
 export async function ensureDeveloperPerspective(
   page: Page,
   k8sClient: KubernetesClient,
-): Promise<void> {
+): Promise<boolean> {
   const toggle = page.getByTestId('perspective-switcher-toggle');
   await expect(toggle).toBeVisible();
   const isSinglePerspective =
@@ -71,7 +71,9 @@ export async function ensureDeveloperPerspective(
       await page.reload();
       await expect(toggle).not.toHaveAttribute('id', 'only-one-perspective');
     }).toPass({ timeout: 60_000 });
+    return true;
   }
+  return false;
 }
 
 export default abstract class BasePage {

--- a/frontend/e2e/tests/console/crud/other-routes.spec.ts
+++ b/frontend/e2e/tests/console/crud/other-routes.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from '../../../fixtures';
+import { ensureDeveloperPerspective, warmupSPA } from '../../../pages/base-page';
 import { testA11y } from '../../../utils/a11y';
 
 type RouteConfig = {
@@ -173,33 +174,9 @@ test.describe('Perspective query parameters', { tag: ['@admin'] }, () => {
     k8sClient,
   }) => {
     await test.step('Ensure Developer perspective is available', async () => {
-      await page.goto('/k8s/cluster/projects');
-
-      const toggle = page.getByTestId('perspective-switcher-toggle');
-      await expect(toggle).toBeVisible();
-
-      const isSinglePerspective =
-        (await toggle.getAttribute('id')) === 'only-one-perspective';
-      if (isSinglePerspective) {
-        await k8sClient.customObjectsApi.patchClusterCustomObject({
-          group: 'operator.openshift.io',
-          version: 'v1',
-          plural: 'consoles',
-          name: 'cluster',
-          body: [
-            {
-              op: 'add',
-              path: '/spec/customization/perspectives',
-              value: [{ id: 'dev', visibility: { state: 'Enabled' } }],
-            },
-          ],
-        });
-        patchedPerspectives = true;
-      }
-      await expect(async () => {
-        await page.reload();
-        await expect(toggle).not.toHaveAttribute('id', 'only-one-perspective');
-      }).toPass({ timeout: 60_000 });
+      await warmupSPA(page);
+      await ensureDeveloperPerspective(page, k8sClient);
+      patchedPerspectives = true;
     });
 
     await test.step('Navigate with perspective=dev and verify', async () => {
@@ -212,19 +189,16 @@ test.describe('Perspective query parameters', { tag: ['@admin'] }, () => {
 
   test('Administrator query parameter switches to Administrator perspective', async ({
     page,
+    k8sClient,
   }) => {
     await test.step('Switch to Developer perspective first', async () => {
-      await page.goto('/k8s/cluster/projects');
+      await warmupSPA(page);
+      await ensureDeveloperPerspective(page, k8sClient);
 
-      const toggle = page.getByTestId('perspective-switcher-toggle');
-      await toggle.click();
-
-      const devOption = page
-        .getByTestId('perspective-switcher-menu-option')
-        .filter({ hasText: 'Developer' });
-      await devOption.click();
-
-      await expect(toggle).toContainText('Developer');
+      await page.goto('/topology/all-namespaces?view=graph&perspective=dev');
+      await expect(page.getByTestId('perspective-switcher-toggle')).toContainText('Developer', {
+        timeout: 30_000,
+      });
     });
 
     await test.step('Navigate with perspective=admin and verify', async () => {

--- a/frontend/e2e/tests/console/crud/other-routes.spec.ts
+++ b/frontend/e2e/tests/console/crud/other-routes.spec.ts
@@ -175,8 +175,9 @@ test.describe('Perspective query parameters', { tag: ['@admin'] }, () => {
   }) => {
     await test.step('Ensure Developer perspective is available', async () => {
       await warmupSPA(page);
-      await ensureDeveloperPerspective(page, k8sClient);
-      patchedPerspectives = true;
+      if (await ensureDeveloperPerspective(page, k8sClient)) {
+        patchedPerspectives = true;
+      }
     });
 
     await test.step('Navigate with perspective=dev and verify', async () => {
@@ -193,7 +194,9 @@ test.describe('Perspective query parameters', { tag: ['@admin'] }, () => {
   }) => {
     await test.step('Switch to Developer perspective first', async () => {
       await warmupSPA(page);
-      await ensureDeveloperPerspective(page, k8sClient);
+      if (await ensureDeveloperPerspective(page, k8sClient)) {
+        patchedPerspectives = true;
+      }
 
       await page.goto('/topology/all-namespaces?view=graph&perspective=dev');
       await expect(page.getByTestId('perspective-switcher-toggle')).toContainText('Developer', {


### PR DESCRIPTION
**Analysis / Root cause**:

The `console/crud/other-routes.spec.ts` "Perspective query parameters" Playwright e2e tests intermittently fail with a 120s test timeout. The error shows `element was detached from the DOM, retrying` when clicking the Developer perspective menu option.

Three contributing issues:

1. **Missing `warmupSPA`:** Tests navigate to deep URLs without first establishing the SPA session, which can land on the OAuth login page.

2. **No guard for Developer option availability:** The second test clicks the perspective switcher toggle and immediately tries to click the Developer option without verifying it exists and is stable. The option may not be in the DOM yet or gets detached during a re-render.

3. **Assumes serial execution without configuration:** The second test assumes the first test enabled the Developer perspective, but the describe block is not configured as serial and each test gets a fresh browser context.

**Solution description**:

- Added `warmupSPA` calls before deep navigation in both tests
- Replaced inline perspective enablement logic with the shared `ensureDeveloperPerspective` helper (which verifies the Developer menu option is actually visible before proceeding)
- Made the second test independently ensure the Developer perspective is available
- Used `perspective=dev` query parameter to switch to Developer perspective instead of manually clicking unstable menu options

**Screenshots / screen recording**:
<!-- N/A — test infrastructure change, no visual changes -->

**Test setup:**
Run the `other-routes.spec.ts` Playwright e2e tests against a cluster.

**Test cases:**
- [ ] "Developer query parameter switches to Developer perspective" passes consistently
- [ ] "Administrator query parameter switches to Administrator perspective" passes consistently
- [ ] Tests pass on clusters where Developer perspective is already enabled
- [ ] Tests pass on clusters where Developer perspective needs to be enabled

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-105523

**Reviewers and assignees:**
<!-- Tag reviewers as appropriate -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for perspective selection through URL parameters.
  * Added more reliable validation that the Developer perspective is available before testing Administrator perspective behavior.
  * Streamlined test setup to reduce failures caused by inconsistent navigation or application state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->