### PR TITLE
CONSOLE-5438: Expose `ResourceYAMLEditor` `onCancel` to the SDK

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -10,6 +10,10 @@ For current development version of Console, use `4.x.0-prerelease.n` packages.
 For older 1.x plugin SDK packages, refer to "OpenShift Console Versions vs SDK Versions" compatibility
 table in [Console dynamic plugins README](./README.md).
 
+## 4.23.0-prerelease.6 - TBD
+
+- Add an `onCancel` prop to `ResourceYAMLEditor` to allow overriding the default cancel behavior ([CONSOLE-5438], [#16941])
+
 ## 4.23.0-prerelease.5 - 2026-08-04
 
 - **Deprecated**: The use of multiple predicates in the `useResolvedExtensions` hook is deprecated ([#16115], [CONSOLE-5065])
@@ -254,6 +258,7 @@ table in [Console dynamic plugins README](./README.md).
 [CONSOLE-5361]: https://issues.redhat.com/browse/CONSOLE-5361
 [CONSOLE-5415]: https://issues.redhat.com/browse/CONSOLE-5415
 [CONSOLE-5424]: https://issues.redhat.com/browse/CONSOLE-5424
+[CONSOLE-5438]: https://issues.redhat.com/browse/CONSOLE-5438
 [OCPBUGS-19048]: https://issues.redhat.com/browse/OCPBUGS-19048
 [OCPBUGS-30077]: https://issues.redhat.com/browse/OCPBUGS-30077
 [OCPBUGS-31355]: https://issues.redhat.com/browse/OCPBUGS-31355
@@ -349,3 +354,4 @@ table in [Console dynamic plugins README](./README.md).
 [#16726]: https://github.com/openshift/console/pull/16726
 [#16750]: https://github.com/openshift/console/pull/16750
 [#16762]: https://github.com/openshift/console/pull/16762
+[#16941]: https://github.com/openshift/console/pull/16941

--- a/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/docs/api.md
@@ -2200,6 +2200,7 @@ A lazy loaded YAML editor for Kubernetes resources with hover help and completio
 | `initialResource` | YAML/Object representing a resource to be shown by the editor. This prop is used only during the inital render. |
 | `header` | Add a header on top of the YAML editor. |
 | `onSave` | Callback for the Save button. Passing it will override the default update performed on the resource by the editor. |
+| `onCancel` | Callback function to be called on cancel. Passing it will override the default behavior of the cancel button. |
 | `readOnly` | Sets the YAML editor to read-only mode. |
 | `create` | Editor will be on creation mode. Create button will replace the Save and Cancel buttons. If no onSave method defined, the 'Create' button will trigger the creation of the defined resource. Default: false |
 | `onChange` | Callback triggered at any editor change. |

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/core-api.ts
@@ -676,6 +676,7 @@ export const CodeEditor: ForwardRefExoticComponent<
  * @param {ResourceYAMLEditorProps['initialResource']} initialResource - YAML/Object representing a resource to be shown by the editor. This prop is used only during the inital render.
  * @param {ResourceYAMLEditorProps['header']} header - Add a header on top of the YAML editor.
  * @param {ResourceYAMLEditorProps['onSave']} onSave - Callback for the Save button. Passing it will override the default update performed on the resource by the editor.
+ * @param {ResourceYAMLEditorProps['onCancel']} onCancel - Callback function to be called on cancel. Passing it will override the default behavior of the cancel button.
  * @param {ResourceYAMLEditorProps['readOnly']} readOnly - Sets the YAML editor to read-only mode.
  * @param {ResourceYAMLEditorProps['create']} create - Editor will be on creation mode. Create button will replace the Save and Cancel buttons. If no onSave method defined, the 'Create' button will trigger the creation of the defined resource. Default: false
  * @param {ResourceYAMLEditorProps['onChange']} onChange - Callback triggered at any editor change.

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -884,6 +884,7 @@ export type ResourceYAMLEditorProps = {
   initialResource: K8sResourceKind;
   header?: string;
   onSave?: (content: string) => void;
+  onCancel?: () => void;
   readOnly?: boolean;
   create?: boolean;
   onChange?: (content: string) => void;

--- a/frontend/public/components/droppable-edit-yaml.tsx
+++ b/frontend/public/components/droppable-edit-yaml.tsx
@@ -162,6 +162,7 @@ export const ResourceYAMLEditor: FC<ResourceYAMLEditorProps> = ({
   initialResource,
   header,
   onSave,
+  onCancel,
   readOnly,
   create,
   onChange,
@@ -171,6 +172,7 @@ export const ResourceYAMLEditor: FC<ResourceYAMLEditorProps> = ({
     initialResource={initialResource}
     header={header}
     onSave={onSave}
+    onCancel={onCancel}
     readOnly={readOnly}
     create={create}
     onChange={onChange}


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

We were not allowing consumers to pass `onCancel` until now, but now others want to use the prop. It's been stable for a while so it seems reasonable to allow people to use it now

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Adds passthrough for the `onCancel` prop to `ResourceYAMLEditor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional cancel callback to the resource YAML editor, allowing custom behavior when users cancel editing.
  * Custom cancel handling overrides the editor’s default cancel-button behavior.

* **Documentation**
  * Documented the new cancel callback and its behavior in the SDK API reference.

* **Bug Fixes**
  * Improved localization key extraction to correctly handle singular and plural translation suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->