### PR TITLE
OCPBUGS-87009: Handle truncated Operator CR names in list-operands

### DIFF
--- a/vendor/github.com/operator-framework/kubectl-operator/pkg/action/operator_list_operands.go
+++ b/vendor/github.com/operator-framework/kubectl-operator/pkg/action/operator_list_operands.go
@@ -36,21 +36,40 @@ func (o *OperatorListOperands) Run(ctx context.Context, packageName string) (*un
 	return result, nil
 }
 
+// dns1123LabelMaxLength is the maximum length of a DNS-1123 label.
+const dns1123LabelMaxLength = 63
+
 // FindOperator finds an operator object on-cluster provided a package and namespace.
 func (o *OperatorListOperands) findOperator(ctx context.Context, packageName string) (*v1.Operator, error) {
-	opKey := types.NamespacedName{
-		Name: fmt.Sprintf("%s.%s", packageName, o.config.Namespace),
-	}
+	name := fmt.Sprintf("%s.%s", packageName, o.config.Namespace)
+	opKey := types.NamespacedName{Name: name}
 
 	operator := v1.Operator{}
 	err := o.config.Client.Get(ctx, opKey, &operator)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("package %q not found in namespace %q", packageName, o.config.Namespace)
-		}
-		return nil, err
+	if err == nil {
+		return &operator, nil
 	}
-	return &operator, nil
+
+	// OLM truncates Operator CR names to 63 characters (DNS-1123 label limit)
+	// when the package.namespace combination is too long. Retry with the
+	// truncated name if the full name was not found.
+	if apierrors.IsNotFound(err) && len(name) > dns1123LabelMaxLength {
+		truncated := name[:dns1123LabelMaxLength]
+		for len(truncated) > 0 && !isAlphanumeric(truncated[len(truncated)-1]) {
+			truncated = truncated[:len(truncated)-1]
+		}
+		if truncated != "" && truncated != name {
+			opKey.Name = truncated
+			if retryErr := o.config.Client.Get(ctx, opKey, &operator); retryErr == nil {
+				return &operator, nil
+			}
+		}
+	}
+
+	if apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("package %q not found in namespace %q", packageName, o.config.Namespace)
+	}
+	return nil, err
 }
 
 // Unzip finds the CSV referenced by the provided operator and then inspects the spec.customresourcedefinitions.owned
@@ -192,4 +211,8 @@ func inNamespace(ns string, namespaces []string) bool {
 		}
 	}
 	return false
+}
+
+func isAlphanumeric(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }


### PR DESCRIPTION
## Summary
- Fixes "Cannot load Operands" error during uninstall preview for operators whose `package.namespace` name exceeds 63 characters (e.g. Cluster Observability Operator)
- OLM truncates Operator CR names to conform to DNS-1123 label rules (max 63 chars), but the `findOperator` lookup was using the full untruncated name
- Adds a fallback: if the initial Get returns NotFound and the name exceeds 63 chars, retry with the truncated name (stripped of trailing non-alphanumeric chars)

## Test plan
- [ ] Install Cluster Observability Operator in namespace `openshift-cluster-observability-operator`
- [ ] Verify uninstall preview no longer shows "Cannot load Operands" warning
- [ ] Verify operators with short names (< 63 chars) continue to work as before