### PR TITLE
OCPBUGS-111707: Flush async feature flag updates immediately

### DIFF
--- a/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
+++ b/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
@@ -35,11 +35,15 @@ export const useFeatureFlagController = () => {
   const flushScheduledRef = useRef(false);
 
   const flushPendingUpdates = useCallback(() => {
+    // Detach the current batch first so reentrant setFeatureFlag calls during
+    // dispatch (e.g. Redux subscribers) write into a fresh map and can schedule a
+    // follow-up flush instead of being cleared with this batch.
+    const updates = pendingUpdatesRef.current;
+    pendingUpdatesRef.current = new Map();
     flushScheduledRef.current = false;
-    pendingUpdatesRef.current.forEach((enabled, flag) => {
+    updates.forEach((enabled, flag) => {
       dispatch(setFlag(flag, enabled));
     });
-    pendingUpdatesRef.current.clear();
   }, [dispatch]);
 
   const scheduleFlush = useCallback(() => {

--- a/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
+++ b/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
@@ -46,6 +46,9 @@ export const useFeatureFlagController = () => {
     pendingUpdatesRef.current.forEach((enabled, flag) => {
       if (flagsRef.current.get(flag) !== enabled) {
         dispatch(setFlag(flag, enabled));
+        // Keep the local snapshot in sync so consecutive async updates (e.g. true
+        // then false before Redux re-renders) are not skipped against a stale value.
+        flagsRef.current = flagsRef.current.set(flag, enabled);
       }
     });
     pendingUpdatesRef.current.clear();

--- a/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
+++ b/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
@@ -22,30 +22,49 @@ import { FeatureFlagExtensionHookResolver } from './FeatureFlagExtensionHookReso
 
 /**
  * React hook that returns a stable {@link SetFeatureFlag} callback.
+ *
+ * Sync calls during render are deferred until after layout effects so we avoid
+ * "Cannot update a component while rendering" with react-redux 8.x (handlers may
+ * invoke this while rendering). Async calls (e.g. after a fetch in a
+ * console.flag/hookProvider) flush immediately so flag-gated extensions update
+ * without waiting for an unrelated re-render.
  */
-const useFeatureFlagController = () => {
+export const useFeatureFlagController = () => {
   const dispatch = useConsoleDispatch();
   const flags = useConsoleSelector(({ FLAGS }) => FLAGS);
+  const flagsRef = useRef(flags);
+  flagsRef.current = flags;
 
   // Queue of flag updates to be dispatched after render
   const pendingUpdatesRef = useRef<Map<string, boolean>>(new Map());
+  const isRenderingRef = useRef(true);
 
-  // Process pending flag updates after render completes.
-  // This avoids "Cannot update a component while rendering" errors with react-redux 8.x
-  // because handlers are called during render (they use hooks) but dispatches happen after.
-  useLayoutEffect(() => {
+  // Mark the render phase; cleared in the layout effect below.
+  isRenderingRef.current = true;
+
+  const flushPendingUpdates = useCallback(() => {
     pendingUpdatesRef.current.forEach((enabled, flag) => {
-      if (flags.get(flag) !== enabled) {
+      if (flagsRef.current.get(flag) !== enabled) {
         dispatch(setFlag(flag, enabled));
       }
     });
     pendingUpdatesRef.current.clear();
+  }, [dispatch]);
+
+  useLayoutEffect(() => {
+    isRenderingRef.current = false;
+    flushPendingUpdates();
   });
 
-  return useCallback<SetFeatureFlag>((flag, enabled) => {
-    // Queue the update to be processed after render
-    pendingUpdatesRef.current.set(flag, enabled);
-  }, []);
+  return useCallback<SetFeatureFlag>(
+    (flag, enabled) => {
+      pendingUpdatesRef.current.set(flag, enabled);
+      if (!isRenderingRef.current) {
+        flushPendingUpdates();
+      }
+    },
+    [flushPendingUpdates],
+  );
 };
 
 /**

--- a/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
+++ b/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
@@ -31,9 +31,6 @@ import { FeatureFlagExtensionHookResolver } from './FeatureFlagExtensionHookReso
  */
 export const useFeatureFlagController = () => {
   const dispatch = useConsoleDispatch();
-  const flags = useConsoleSelector(({ FLAGS }) => FLAGS);
-  const flagsRef = useRef(flags);
-  flagsRef.current = flags;
 
   // Queue of flag updates to be dispatched after render
   const pendingUpdatesRef = useRef<Map<string, boolean>>(new Map());
@@ -42,14 +39,13 @@ export const useFeatureFlagController = () => {
   // Mark the render phase; cleared in the layout effect below.
   isRenderingRef.current = true;
 
+  // Always dispatch pending values. Do not keep a local FLAGS snapshot for
+  // change-detection: flags are also updated elsewhere (e.g. detectFeatures /
+  // setFlag consumers read via useFlag), so a shadow copy can go stale.
+  // Immutable Map.set is a no-op when the value is unchanged.
   const flushPendingUpdates = useCallback(() => {
     pendingUpdatesRef.current.forEach((enabled, flag) => {
-      if (flagsRef.current.get(flag) !== enabled) {
-        dispatch(setFlag(flag, enabled));
-        // Keep the local snapshot in sync so consecutive async updates (e.g. true
-        // then false before Redux re-renders) are not skipped against a stale value.
-        flagsRef.current = flagsRef.current.set(flag, enabled);
-      }
+      dispatch(setFlag(flag, enabled));
     });
     pendingUpdatesRef.current.clear();
   }, [dispatch]);

--- a/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
+++ b/frontend/packages/console-app/src/components/flags/FeatureFlagExtensionLoader.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useCallback, useRef, useEffect, useLayoutEffect } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 import type {
   FeatureFlagHookProvider,
   ModelFeatureFlag,
@@ -23,46 +23,41 @@ import { FeatureFlagExtensionHookResolver } from './FeatureFlagExtensionHookReso
 /**
  * React hook that returns a stable {@link SetFeatureFlag} callback.
  *
- * Sync calls during render are deferred until after layout effects so we avoid
- * "Cannot update a component while rendering" with react-redux 8.x (handlers may
- * invoke this while rendering). Async calls (e.g. after a fetch in a
- * console.flag/hookProvider) flush immediately so flag-gated extensions update
- * without waiting for an unrelated re-render.
+ * Updates are always flushed on a microtask so handlers invoked during render
+ * (including child FeatureFlagExtensionHookResolver re-renders) never dispatch
+ * synchronously, while async callers (e.g. after a fetch in a
+ * console.flag/hookProvider) still update without waiting for an unrelated re-render.
  */
 export const useFeatureFlagController = () => {
   const dispatch = useConsoleDispatch();
 
-  // Queue of flag updates to be dispatched after render
   const pendingUpdatesRef = useRef<Map<string, boolean>>(new Map());
-  const isRenderingRef = useRef(true);
+  const flushScheduledRef = useRef(false);
 
-  // Mark the render phase; cleared in the layout effect below.
-  isRenderingRef.current = true;
-
-  // Always dispatch pending values. Do not keep a local FLAGS snapshot for
-  // change-detection: flags are also updated elsewhere (e.g. detectFeatures /
-  // setFlag consumers read via useFlag), so a shadow copy can go stale.
-  // Immutable Map.set is a no-op when the value is unchanged.
   const flushPendingUpdates = useCallback(() => {
+    flushScheduledRef.current = false;
     pendingUpdatesRef.current.forEach((enabled, flag) => {
       dispatch(setFlag(flag, enabled));
     });
     pendingUpdatesRef.current.clear();
   }, [dispatch]);
 
-  useLayoutEffect(() => {
-    isRenderingRef.current = false;
-    flushPendingUpdates();
-  });
+  const scheduleFlush = useCallback(() => {
+    if (flushScheduledRef.current) {
+      return;
+    }
+    flushScheduledRef.current = true;
+    queueMicrotask(() => {
+      flushPendingUpdates();
+    });
+  }, [flushPendingUpdates]);
 
   return useCallback<SetFeatureFlag>(
     (flag, enabled) => {
       pendingUpdatesRef.current.set(flag, enabled);
-      if (!isRenderingRef.current) {
-        flushPendingUpdates();
-      }
+      scheduleFlush();
     },
-    [flushPendingUpdates],
+    [scheduleFlush],
   );
 };
 

--- a/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
+++ b/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
@@ -1,8 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
-import { Map as ImmutableMap } from 'immutable';
 import { setFlag } from '@console/internal/actions/flags';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
-import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { useFeatureFlagController } from '../FeatureFlagExtensionLoader';
 
 jest.mock('@console/shared/src/hooks/useConsoleSelector', () => ({
@@ -22,7 +20,6 @@ jest.mock('@console/internal/actions/flags', () => ({
 }));
 
 const mockDispatch = jest.fn();
-const mockUseSelector = useConsoleSelector as jest.Mock;
 const mockUseDispatch = useConsoleDispatch as jest.Mock;
 const mockSetFlag = setFlag as jest.MockedFunction<typeof setFlag>;
 
@@ -30,7 +27,6 @@ describe('useFeatureFlagController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
-    mockUseSelector.mockReturnValue(ImmutableMap());
   });
 
   it('defers flag updates made during render until after layout effects', () => {
@@ -63,8 +59,7 @@ describe('useFeatureFlagController', () => {
     expect(mockSetFlag).toHaveBeenCalledWith('ASYNC_FLAG', true);
   });
 
-  it('dispatches consecutive async updates before the selector re-renders', () => {
-    mockUseSelector.mockReturnValue(ImmutableMap({ TOGGLE_FLAG: false }));
+  it('dispatches consecutive async updates before Redux re-renders', () => {
     const { result } = renderHook(() => useFeatureFlagController());
 
     mockDispatch.mockClear();
@@ -78,18 +73,5 @@ describe('useFeatureFlagController', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(2);
     expect(mockSetFlag).toHaveBeenNthCalledWith(1, 'TOGGLE_FLAG', true);
     expect(mockSetFlag).toHaveBeenNthCalledWith(2, 'TOGGLE_FLAG', false);
-  });
-
-  it('does not redispatch when the flag already has the requested value', () => {
-    mockUseSelector.mockReturnValue(ImmutableMap({ EXISTING_FLAG: true }));
-    const { result } = renderHook(() => useFeatureFlagController());
-
-    mockDispatch.mockClear();
-
-    act(() => {
-      result.current('EXISTING_FLAG', true);
-    });
-
-    expect(mockDispatch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
+++ b/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
@@ -34,13 +34,16 @@ describe('useFeatureFlagController', () => {
   });
 
   it('defers flag updates made during render until after layout effects', () => {
+    let dispatchCountDuringRender = 0;
     const { result } = renderHook(() => {
       const setFeatureFlag = useFeatureFlagController();
       // Simulate console.flag/hookProvider handlers that set flags during render.
       setFeatureFlag('SYNC_FLAG', true);
+      dispatchCountDuringRender = mockDispatch.mock.calls.length;
       return setFeatureFlag;
     });
 
+    expect(dispatchCountDuringRender).toBe(0);
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockSetFlag).toHaveBeenCalledWith('SYNC_FLAG', true);
     expect(result.current).toEqual(expect.any(Function));
@@ -58,6 +61,23 @@ describe('useFeatureFlagController', () => {
 
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockSetFlag).toHaveBeenCalledWith('ASYNC_FLAG', true);
+  });
+
+  it('dispatches consecutive async updates before the selector re-renders', () => {
+    mockUseSelector.mockReturnValue(ImmutableMap({ TOGGLE_FLAG: false }));
+    const { result } = renderHook(() => useFeatureFlagController());
+
+    mockDispatch.mockClear();
+    mockSetFlag.mockClear();
+
+    act(() => {
+      result.current('TOGGLE_FLAG', true);
+      result.current('TOGGLE_FLAG', false);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(mockSetFlag).toHaveBeenNthCalledWith(1, 'TOGGLE_FLAG', true);
+    expect(mockSetFlag).toHaveBeenNthCalledWith(2, 'TOGGLE_FLAG', false);
   });
 
   it('does not redispatch when the flag already has the requested value', () => {

--- a/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
+++ b/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
@@ -5,18 +5,6 @@ import { renderHookWithProviders } from '@console/shared/src/test-utils/unit-tes
 import { createTestPluginStore } from '../../console-operator/__tests__/pluginTestUtils';
 import { useFeatureFlagController } from '../FeatureFlagExtensionLoader';
 
-// unit-test-utils / the FLAGS reducer import @console/internal/plugins at module load.
-// Provide a TestPluginStore via the shared helper so that import succeeds in Jest.
-jest.mock('@console/internal/plugins', () => {
-  const { createTestPluginStore: createStore } = jest.requireActual(
-    '../../console-operator/__tests__/pluginTestUtils',
-  );
-  return {
-    pluginStore: createStore(),
-    featureFlagMiddleware: () => (next) => (action) => next(action),
-  };
-});
-
 const renderController = () =>
   renderHookWithProviders(() => useFeatureFlagController(), {
     pluginStore: createTestPluginStore(),

--- a/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
+++ b/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
@@ -2,37 +2,40 @@ import { act } from '@testing-library/react';
 import { useStore } from 'react-redux';
 import type { RootState } from '@console/internal/redux';
 import { renderHookWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { createTestPluginStore } from '../../console-operator/__tests__/pluginTestUtils';
 import { useFeatureFlagController } from '../FeatureFlagExtensionLoader';
 
+// unit-test-utils / the FLAGS reducer import @console/internal/plugins at module load.
+// Provide a TestPluginStore via the shared helper so that import succeeds in Jest.
 jest.mock('@console/internal/plugins', () => {
-  // Avoid loading real local plugins / schema validation in unit tests.
-  const { TestPluginStore } = jest.requireActual('@openshift/dynamic-plugin-sdk');
+  const { createTestPluginStore: createStore } = jest.requireActual(
+    '../../console-operator/__tests__/pluginTestUtils',
+  );
   return {
-    pluginStore: new TestPluginStore({
-      autoEnableLoadedPlugins: true,
-      loader: {
-        loadPluginManifest: async () => {
-          throw new Error('unused');
-        },
-        transformPluginManifest: (manifest) => manifest,
-        loadPlugin: async () => ({ success: true as const, loadedExtensions: [] }),
-      },
-    }),
+    pluginStore: createStore(),
     featureFlagMiddleware: () => (next) => (action) => next(action),
   };
 });
 
+const renderController = () =>
+  renderHookWithProviders(() => useFeatureFlagController(), {
+    pluginStore: createTestPluginStore(),
+  });
+
 describe('useFeatureFlagController', () => {
   it('defers flag updates made during render until after the render completes', async () => {
     let flagDuringRender: boolean | undefined;
-    const { store, result } = renderHookWithProviders(() => {
-      const reduxStore = useStore<RootState>();
-      const setFeatureFlag = useFeatureFlagController();
-      // Simulate console.flag/hookProvider handlers that set flags during render.
-      setFeatureFlag('SYNC_FLAG', true);
-      flagDuringRender = reduxStore.getState().FLAGS.get('SYNC_FLAG');
-      return setFeatureFlag;
-    });
+    const { store, result } = renderHookWithProviders(
+      () => {
+        const reduxStore = useStore<RootState>();
+        const setFeatureFlag = useFeatureFlagController();
+        // Simulate console.flag/hookProvider handlers that set flags during render.
+        setFeatureFlag('SYNC_FLAG', true);
+        flagDuringRender = reduxStore.getState().FLAGS.get('SYNC_FLAG');
+        return setFeatureFlag;
+      },
+      { pluginStore: createTestPluginStore() },
+    );
 
     expect(flagDuringRender).toBeUndefined();
     expect(result.current).toEqual(expect.any(Function));
@@ -45,7 +48,7 @@ describe('useFeatureFlagController', () => {
   });
 
   it('applies async flag updates without waiting for another render', async () => {
-    const { store, result } = renderHookWithProviders(() => useFeatureFlagController());
+    const { store, result } = renderController();
 
     await act(async () => {
       result.current('ASYNC_FLAG', true);
@@ -56,7 +59,7 @@ describe('useFeatureFlagController', () => {
   });
 
   it('coalesces consecutive async updates to the latest value', async () => {
-    const { store, result } = renderHookWithProviders(() => useFeatureFlagController());
+    const { store, result } = renderController();
 
     await act(async () => {
       result.current('TOGGLE_FLAG', true);
@@ -65,5 +68,23 @@ describe('useFeatureFlagController', () => {
     });
 
     expect(store.getState().FLAGS.get('TOGGLE_FLAG')).toBe(false);
+  });
+
+  it('preserves flag updates made reentrantly during flush', async () => {
+    const { store, result } = renderController();
+
+    await act(async () => {
+      const unsubscribe = store.subscribe(() => {
+        if (store.getState().FLAGS.get('REENTRANT_FLAG') === true) {
+          result.current('REENTRANT_FLAG', false);
+          unsubscribe();
+        }
+      });
+      result.current('REENTRANT_FLAG', true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(store.getState().FLAGS.get('REENTRANT_FLAG')).toBe(false);
   });
 });

--- a/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
+++ b/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
@@ -1,77 +1,69 @@
-import { act, renderHook } from '@testing-library/react';
-import { setFlag } from '@console/internal/actions/flags';
-import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
+import { act } from '@testing-library/react';
+import { useStore } from 'react-redux';
+import type { RootState } from '@console/internal/redux';
+import { renderHookWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import { useFeatureFlagController } from '../FeatureFlagExtensionLoader';
 
-jest.mock('@console/shared/src/hooks/useConsoleSelector', () => ({
-  useConsoleSelector: jest.fn(),
-}));
-
-jest.mock('@console/shared/src/hooks/useConsoleDispatch', () => ({
-  useConsoleDispatch: jest.fn(),
-}));
-
-jest.mock('@console/internal/actions/flags', () => ({
-  ...jest.requireActual('@console/internal/actions/flags'),
-  setFlag: jest.fn((flag: string, value: boolean) => ({
-    type: 'setFlag',
-    payload: { flag, value },
-  })),
-}));
-
-const mockDispatch = jest.fn();
-const mockUseDispatch = useConsoleDispatch as jest.Mock;
-const mockSetFlag = setFlag as jest.MockedFunction<typeof setFlag>;
+jest.mock('@console/internal/plugins', () => {
+  // Avoid loading real local plugins / schema validation in unit tests.
+  const { TestPluginStore } = jest.requireActual('@openshift/dynamic-plugin-sdk');
+  return {
+    pluginStore: new TestPluginStore({
+      autoEnableLoadedPlugins: true,
+      loader: {
+        loadPluginManifest: async () => {
+          throw new Error('unused');
+        },
+        transformPluginManifest: (manifest) => manifest,
+        loadPlugin: async () => ({ success: true as const, loadedExtensions: [] }),
+      },
+    }),
+    featureFlagMiddleware: () => (next) => (action) => next(action),
+  };
+});
 
 describe('useFeatureFlagController', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseDispatch.mockReturnValue(mockDispatch);
-  });
-
-  it('defers flag updates made during render until after layout effects', () => {
-    let dispatchCountDuringRender = 0;
-    const { result } = renderHook(() => {
+  it('defers flag updates made during render until after the render completes', async () => {
+    let flagDuringRender: boolean | undefined;
+    const { store, result } = renderHookWithProviders(() => {
+      const reduxStore = useStore<RootState>();
       const setFeatureFlag = useFeatureFlagController();
       // Simulate console.flag/hookProvider handlers that set flags during render.
       setFeatureFlag('SYNC_FLAG', true);
-      dispatchCountDuringRender = mockDispatch.mock.calls.length;
+      flagDuringRender = reduxStore.getState().FLAGS.get('SYNC_FLAG');
       return setFeatureFlag;
     });
 
-    expect(dispatchCountDuringRender).toBe(0);
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
-    expect(mockSetFlag).toHaveBeenCalledWith('SYNC_FLAG', true);
+    expect(flagDuringRender).toBeUndefined();
     expect(result.current).toEqual(expect.any(Function));
-  });
 
-  it('dispatches async flag updates immediately without waiting for another render', () => {
-    const { result } = renderHook(() => useFeatureFlagController());
-
-    mockDispatch.mockClear();
-    mockSetFlag.mockClear();
-
-    act(() => {
-      result.current('ASYNC_FLAG', true);
+    await act(async () => {
+      await Promise.resolve();
     });
 
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
-    expect(mockSetFlag).toHaveBeenCalledWith('ASYNC_FLAG', true);
+    expect(store.getState().FLAGS.get('SYNC_FLAG')).toBe(true);
   });
 
-  it('dispatches consecutive async updates before Redux re-renders', () => {
-    const { result } = renderHook(() => useFeatureFlagController());
+  it('applies async flag updates without waiting for another render', async () => {
+    const { store, result } = renderHookWithProviders(() => useFeatureFlagController());
 
-    mockDispatch.mockClear();
-    mockSetFlag.mockClear();
+    await act(async () => {
+      result.current('ASYNC_FLAG', true);
+      await Promise.resolve();
+    });
 
-    act(() => {
+    expect(store.getState().FLAGS.get('ASYNC_FLAG')).toBe(true);
+  });
+
+  it('coalesces consecutive async updates to the latest value', async () => {
+    const { store, result } = renderHookWithProviders(() => useFeatureFlagController());
+
+    await act(async () => {
       result.current('TOGGLE_FLAG', true);
       result.current('TOGGLE_FLAG', false);
+      await Promise.resolve();
     });
 
-    expect(mockDispatch).toHaveBeenCalledTimes(2);
-    expect(mockSetFlag).toHaveBeenNthCalledWith(1, 'TOGGLE_FLAG', true);
-    expect(mockSetFlag).toHaveBeenNthCalledWith(2, 'TOGGLE_FLAG', false);
+    expect(store.getState().FLAGS.get('TOGGLE_FLAG')).toBe(false);
   });
 });

--- a/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
+++ b/frontend/packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from '@testing-library/react';
+import { Map as ImmutableMap } from 'immutable';
+import { setFlag } from '@console/internal/actions/flags';
+import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
+import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
+import { useFeatureFlagController } from '../FeatureFlagExtensionLoader';
+
+jest.mock('@console/shared/src/hooks/useConsoleSelector', () => ({
+  useConsoleSelector: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks/useConsoleDispatch', () => ({
+  useConsoleDispatch: jest.fn(),
+}));
+
+jest.mock('@console/internal/actions/flags', () => ({
+  ...jest.requireActual('@console/internal/actions/flags'),
+  setFlag: jest.fn((flag: string, value: boolean) => ({
+    type: 'setFlag',
+    payload: { flag, value },
+  })),
+}));
+
+const mockDispatch = jest.fn();
+const mockUseSelector = useConsoleSelector as jest.Mock;
+const mockUseDispatch = useConsoleDispatch as jest.Mock;
+const mockSetFlag = setFlag as jest.MockedFunction<typeof setFlag>;
+
+describe('useFeatureFlagController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockUseSelector.mockReturnValue(ImmutableMap());
+  });
+
+  it('defers flag updates made during render until after layout effects', () => {
+    const { result } = renderHook(() => {
+      const setFeatureFlag = useFeatureFlagController();
+      // Simulate console.flag/hookProvider handlers that set flags during render.
+      setFeatureFlag('SYNC_FLAG', true);
+      return setFeatureFlag;
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockSetFlag).toHaveBeenCalledWith('SYNC_FLAG', true);
+    expect(result.current).toEqual(expect.any(Function));
+  });
+
+  it('dispatches async flag updates immediately without waiting for another render', () => {
+    const { result } = renderHook(() => useFeatureFlagController());
+
+    mockDispatch.mockClear();
+    mockSetFlag.mockClear();
+
+    act(() => {
+      result.current('ASYNC_FLAG', true);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockSetFlag).toHaveBeenCalledWith('ASYNC_FLAG', true);
+  });
+
+  it('does not redispatch when the flag already has the requested value', () => {
+    mockUseSelector.mockReturnValue(ImmutableMap({ EXISTING_FLAG: true }));
+    const { result } = renderHook(() => useFeatureFlagController());
+
+    mockDispatch.mockClear();
+
+    act(() => {
+      result.current('EXISTING_FLAG', true);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes [#16922](https://github.com/openshift/console/issues/16922): flag-gated plugin routes/nav items stayed 404/missing for ~10–15s after an async `console.flag` / `console.flag/hookProvider` resolved.
- Root cause: `useFeatureFlagController` only queued `setFeatureFlag` into a ref and flushed on the next render, so async updates (e.g. after a backend probe) waited on an unrelated re-render.
- Keep render-time updates deferred (react-redux safety), but flush immediately when called outside render. Adds unit coverage for sync deferral and async immediate dispatch.

## Test plan
- [ ] Unit: `jest packages/console-app/src/components/flags/__tests__/FeatureFlagExtensionLoader.spec.tsx`
- [ ] Install a dynamic plugin with an async `console.flag/hookProvider` that gates a `console.page/route` and nav item
- [ ] Confirm the flag probe completes quickly and the route/nav appear without a ~10s wait
- [ ] Confirm sync flag handlers that set flags during render still work (no "Cannot update a component while rendering" errors)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature flag updates so changes apply at the appropriate time, including immediately after rendering.
  * Ensured consecutive and reentrant updates are processed correctly without losing requested changes.
  * Reduced the chance of stale feature flag values appearing temporarily.

* **Tests**
  * Added coverage for deferred, asynchronous, coalesced, and reentrant feature flag updates.
  * Expanded test setup to validate updates through provider-backed plugin stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->