### PR TITLE
OCPBUGS-105611: [release-4.22] Fix leading whitespace in Quick Start execute code snippets

### DIFF
--- a/frontend/packages/console-shared/src/components/markdown-extensions/inline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/inline-execute-extension.ts
@@ -46,9 +46,7 @@ const useInlineExecuteCommandExtension = () => {
           </div>
         </div>
         <div class="pf-v6-c-code-block__content">
-          <pre class="pf-v6-c-code-block__pre pfext-code-block__pre">
-            <code class="pf-v6-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupType}">${group.trim()}</code>
-          </pre>
+          <pre class="pf-v6-c-code-block__pre pfext-code-block__pre"><code class="pf-v6-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupType}">${group.trim()}</code></pre>
         </div>
       </div>`;
       },

--- a/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
+++ b/frontend/packages/console-shared/src/components/markdown-extensions/multiline-execute-extension.ts
@@ -47,10 +47,7 @@ const useMultilineExecuteCommandExtension = () => {
                 </div>
               </div>
               <div class="pf-v6-c-code-block__content">
-                <pre class="pf-v6-c-code-block__pre pfext-code-block__pre">
-                  <code class="pf-v6-c-code-block__code"
-                    ${MARKDOWN_SNIPPET_ID}="${groupId}">${group.trim()}</code>
-                </pre>
+                <pre class="pf-v6-c-code-block__pre pfext-code-block__pre"><code class="pf-v6-c-code-block__code" ${MARKDOWN_SNIPPET_ID}="${groupId}">${group.trim()}</code></pre>
               </div>
             </div>`;
       },


### PR DESCRIPTION
**Analysis / Root cause**:

The `<pre>` and `<code>` tags in the Quick Start {{execute}} code snippet HTML templates are on separate
lines with indentation between them. Since `<pre>` preserves all whitespace literally, the newline and
spaces between `<pre>` and `<code>` render as a visible leading blank line in the code block.

This was fixed on main incidentally by commit 552dc84e ([CONSOLE-5434](https://redhat.atlassian.net/browse/CONSOLE-5434)) but never backported to release
branches.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->
Collapse `<pre>` and `<code>` onto a single line in both inline-execute-extension.ts and
multiline-execute-extension.ts, removing the whitespace that `<pre>` was preserving. This matches what is
already on main.


**Screenshots / screen recording**:
Before:
<img width="884" height="188" alt="OCPBUGS-98159-before" src="https://github.com/user-attachments/assets/8b05779d-1114-428f-a8cd-f47d64f266de" />
After:
<img width="456" height="272" alt="OCPBUGS-98159-after" src="https://github.com/user-attachments/assets/18051576-60bc-4aa2-aa0e-16acbc76ca41" />

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
1. Cluster running OCP 4.20+ (tested on 4.20.17 via cluster-bot)
2. Run console locally against the cluster using contrib/oc-environment.sh and ./bin/bridge

**Test cases:**
<!-- List possible test cases to validate the changes. -->
1. Navigate to Help > Quick Starts > Enable Developer Perspective > Step 4 of 4
2. Verify the oc patch code snippet has no leading blank line
4. Verify the copy button still works
5. Verify other Quick Start steps render correctly

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)
