### PR TITLE
OCPBUGS-14473: Guard against undefined data in dashboard charts

### DIFF
--- a/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
+++ b/frontend/packages/console-shared/src/components/dashboard/utilization-card/UtilizationItem.tsx
@@ -70,23 +70,26 @@ export const MultilineUtilizationItem = memo<MultilineUtilizationItemProps>(
     }, [maxDate, updateEndDate]);
 
     const mapTranslatedData = (originalData: DataPoint[][]) => {
-      if (!originalData || originalData.length === 0 || originalData[0].length === 0)
-        return originalData;
+      if (!originalData || originalData.length === 0) return originalData;
       const translatedData = [];
 
       for (const query of originalData) {
-        const currData = [];
-        const desc = query[0].description;
-        for (const item of query) {
-          if (desc === 'in') {
-            currData.push({ ...item, description: t('in') });
-          } else if (desc === 'out') {
-            currData.push({ ...item, description: t('out') });
-          } else {
-            currData.push(item);
+        if (!query || query.length === 0) {
+          translatedData.push(query);
+        } else {
+          const currData = [];
+          const desc = query[0].description;
+          for (const item of query) {
+            if (desc === 'in') {
+              currData.push({ ...item, description: t('in') });
+            } else if (desc === 'out') {
+              currData.push({ ...item, description: t('out') });
+            } else {
+              currData.push(item);
+            }
           }
+          translatedData.push(currData);
         }
-        translatedData.push(currData);
       }
       return translatedData;
     };

--- a/frontend/public/components/graphs/area.tsx
+++ b/frontend/public/components/graphs/area.tsx
@@ -112,9 +112,9 @@ export const AreaChart: FC<AreaChartProps> = ({
   const container = useMemo(() => {
     if (multiLine) {
       const legendData = processedData.map((d) => ({
-        childName: d[0].description,
-        name: d[0].description,
-        symbol: d[0].symbol,
+        childName: d[0]?.description,
+        name: d[0]?.description,
+        symbol: d[0]?.symbol,
       }));
       return (
         <CursorVoronoiContainer
@@ -127,7 +127,7 @@ export const AreaChart: FC<AreaChartProps> = ({
               stack={showAllTooltip}
               legendData={legendData}
               getLabel={getLabel}
-              formatDate={(d) => formatDate(d[0].x)}
+              formatDate={(d) => formatDate(d[0]?.x)}
               mainDataName={mainDataName}
             />
           }


### PR DESCRIPTION
## Problem

Visiting **Home → Overview** and leaving the page open for an extended period causes a crash:
```
TypeError: Cannot read properties of undefined (reading 'description')
```

This happens when Prometheus polling returns empty results for individual network utilization queries at different times. The `mapTranslatedData` function in `UtilizationItem` only checks if the first sub-array is empty, but subsequent sub-arrays can also be empty, causing `query[0].description` to throw. Similarly, `AreaChart` accesses `d[0].description` without optional chaining in the legend data mapping.

## Root Cause

- `PrometheusMultilineUtilizationItem` builds a stats array where individual queries can return empty: `[[valid_data], []]`
- The guard in `mapTranslatedData` only checks `originalData[0].length === 0`, so it passes when the first query has data but a later one is empty
- In `AreaChart`, `legendData` mapping accesses `d[0].description` without optional chaining, despite `d[0]` potentially being undefined

## Solution

- **UtilizationItem.tsx**: Skip empty/null sub-arrays in the `mapTranslatedData` loop instead of crashing
- **area.tsx**: Add optional chaining (`?.`) on `d[0]` accesses in `legendData` mapping and `formatDate` callback, matching the existing safe pattern already used elsewhere in the same file

## Testing

- Verify **Home → Overview** page loads without errors
- Leave the Overview page open for an extended period and confirm no crash occurs
- Verify network utilization charts render correctly when data is available
- Verify charts handle gracefully when individual Prometheus queries return empty results

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-14473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard utilization charts to handle empty or missing query data without errors.
  * Updated area chart legends and tooltips to display safely when the first data point is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->