### PR TITLE
OCPBUGS-105789: Recover expired Playwright sessions via auto re-login

### DIFF
--- a/frontend/e2e/fixtures/auth-fixture.ts
+++ b/frontend/e2e/fixtures/auth-fixture.ts
@@ -1,4 +1,4 @@
-import type { Page, TestInfo } from '@playwright/test';
+import type { Frame, Page, TestInfo } from '@playwright/test';
 
 import {
   isOnLoginPage,
@@ -12,16 +12,32 @@ import {
  */
 const reloginInProgress = new WeakMap<Page, Promise<void>>();
 
+/**
+ * The last app route each page navigated to before any auth redirect. Used to
+ * send the page back where the test intended to be after re-authenticating,
+ * since by the time recovery runs the page URL is the OAuth/login page.
+ */
+const lastAppUrl = new WeakMap<Page, string>();
+
 function storageStatePath(testInfo: TestInfo): string | undefined {
   const state = testInfo.project.use.storageState;
   return typeof state === 'string' ? state : undefined;
 }
 
 /**
+ * True for OAuth server / console login URLs — the pages a session-expiry
+ * redirect passes through. These are never the route a test wants to resume at.
+ */
+function isAuthUrl(url: string): boolean {
+  return /\/oauth\/|\/oauth2\/|\/login(\/|$|\?)|\/auth\//.test(url);
+}
+
+/**
  * Detects when a navigation has landed on the OAuth login page — meaning the
  * session snapshot in storageState has expired — and transparently
  * re-authenticates the current persona, refreshing the stored session so
- * subsequent tests reuse the fresh state.
+ * subsequent tests reuse the fresh state. After re-login, navigates back to
+ * the route the test was heading to so deep-link tests resume in place.
  *
  * The setup projects establish the session once; long runs can outlive the
  * OAuth token, after which every navigation silently redirects to the login
@@ -31,25 +47,46 @@ function storageStatePath(testInfo: TestInfo): string | undefined {
 export async function recoverSessionIfExpired(
   page: Page,
   testInfo: TestInfo,
+  detectTimeoutMs = 0,
 ): Promise<boolean> {
-  if (!(await isOnLoginPage(page))) {
-    return false;
-  }
-
+  // If a re-login is already running (or being set up) for this page, await it
+  // rather than starting a second one.
   const existing = reloginInProgress.get(page);
   if (existing) {
     await existing;
     return true;
   }
 
-  const statePath = storageStatePath(testInfo);
-  const credentials = statePath ? resolveCredentialsForStorageState(statePath) : undefined;
-  if (!credentials) {
-    // No credentials to recover with (e.g. auth disabled or dev creds unset).
+  // Claim the re-login slot synchronously — before any await — so concurrent
+  // navigation events can't both pass the check above and launch duplicate
+  // logins. The deferred is published now and settled once we know whether a
+  // recovery is actually needed; if not, we release the slot immediately.
+  let release!: () => void;
+  const claim = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  reloginInProgress.set(page, claim);
+
+  const finish = (): void => {
+    release();
+    reloginInProgress.delete(page);
+  };
+
+  if (!(await isOnLoginPage(page, detectTimeoutMs))) {
+    finish();
     return false;
   }
 
-  const relogin = (async () => {
+  const statePath = storageStatePath(testInfo);
+  const credentials = statePath ? resolveCredentialsForStorageState(statePath) : null;
+  if (!credentials) {
+    // No credentials to recover with (e.g. auth disabled or dev creds unset).
+    finish();
+    return false;
+  }
+
+  const intendedUrl = lastAppUrl.get(page);
+  try {
     // eslint-disable-next-line no-console
     console.warn(
       `[auth] Session expired for "${testInfo.titlePath.join(' > ')}"; re-authenticating.`,
@@ -58,13 +95,14 @@ export async function recoverSessionIfExpired(
     if (statePath) {
       await saveStorageState(page, statePath);
     }
-  })();
-
-  reloginInProgress.set(page, relogin);
-  try {
-    await relogin;
+    // Restore the route the test was navigating to before the redirect, so
+    // deep-link tests resume where they expected rather than on the console
+    // home page that performLogin lands on.
+    if (intendedUrl && intendedUrl !== page.url()) {
+      await page.goto(intendedUrl, { waitUntil: 'domcontentloaded' });
+    }
   } finally {
-    reloginInProgress.delete(page);
+    finish();
   }
   return true;
 }
@@ -74,13 +112,23 @@ export async function recoverSessionIfExpired(
  * navigation lands on the login page. Returns a disposer to detach it.
  */
 export function attachSessionRecovery(page: Page, testInfo: TestInfo): () => void {
-  const handler = (frame: import('@playwright/test').Frame) => {
+  const handler = (frame: Frame) => {
     if (frame !== page.mainFrame()) {
       return;
     }
+    const url = frame.url();
+    const onAuthUrl = isAuthUrl(url);
+    // Remember the most recent non-auth route so recovery can return to it.
+    if (url && url !== 'about:blank' && !onAuthUrl) {
+      lastAppUrl.set(page, url);
+    }
+    // On a normal (non-auth) navigation, detect the login page instantly so the
+    // hot path adds no latency. When we land on an auth URL the session likely
+    // expired but the login form may still be rendering, so give it a bounded
+    // window to appear before deciding recovery isn't needed.
     // Fire-and-forget: recovery guards its own re-entrancy. Swallow errors so a
     // transient navigation event doesn't reject an unrelated step.
-    void recoverSessionIfExpired(page, testInfo).catch(() => {
+    void recoverSessionIfExpired(page, testInfo, onAuthUrl ? 5_000 : 0).catch(() => {
       /* best-effort recovery */
     });
   };

--- a/frontend/e2e/fixtures/auth-fixture.ts
+++ b/frontend/e2e/fixtures/auth-fixture.ts
@@ -27,9 +27,19 @@ function storageStatePath(testInfo: TestInfo): string | undefined {
 /**
  * True for OAuth server / console login URLs — the pages a session-expiry
  * redirect passes through. These are never the route a test wants to resume at.
+ *
+ * Matches against the URL pathname and anchors on known auth path prefixes so
+ * console resource routes that merely contain "auth" or "login" as a segment
+ * (e.g. a Secret named "auth") aren't misclassified.
  */
 function isAuthUrl(url: string): boolean {
-  return /\/oauth\/|\/oauth2\/|\/login(\/|$|\?)|\/auth\//.test(url);
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return false;
+  }
+  return /^\/(oauth2?|login|auth)(\/|$)/.test(pathname);
 }
 
 /**
@@ -59,34 +69,28 @@ export async function recoverSessionIfExpired(
 
   // Claim the re-login slot synchronously — before any await — so concurrent
   // navigation events can't both pass the check above and launch duplicate
-  // logins. The deferred is published now and settled once we know whether a
-  // recovery is actually needed; if not, we release the slot immediately.
+  // logins. The deferred is published now and settled in the finally below;
+  // keeping every early return and rejection inside the try guarantees the
+  // slot is always released (a stuck claim would block all future recovery).
   let release!: () => void;
   const claim = new Promise<void>((resolve) => {
     release = resolve;
   });
   reloginInProgress.set(page, claim);
 
-  const finish = (): void => {
-    release();
-    reloginInProgress.delete(page);
-  };
-
-  if (!(await isOnLoginPage(page, detectTimeoutMs))) {
-    finish();
-    return false;
-  }
-
-  const statePath = storageStatePath(testInfo);
-  const credentials = statePath ? resolveCredentialsForStorageState(statePath) : null;
-  if (!credentials) {
-    // No credentials to recover with (e.g. auth disabled or dev creds unset).
-    finish();
-    return false;
-  }
-
-  const intendedUrl = lastAppUrl.get(page);
   try {
+    if (!(await isOnLoginPage(page, detectTimeoutMs))) {
+      return false;
+    }
+
+    const statePath = storageStatePath(testInfo);
+    const credentials = statePath ? resolveCredentialsForStorageState(statePath) : null;
+    if (!credentials) {
+      // No credentials to recover with (e.g. auth disabled or dev creds unset).
+      return false;
+    }
+
+    const intendedUrl = lastAppUrl.get(page);
     // eslint-disable-next-line no-console
     console.warn(
       `[auth] Session expired for "${testInfo.titlePath.join(' > ')}"; re-authenticating.`,
@@ -101,10 +105,25 @@ export async function recoverSessionIfExpired(
     if (intendedUrl && intendedUrl !== page.url()) {
       await page.goto(intendedUrl, { waitUntil: 'domcontentloaded' });
     }
+    return true;
   } finally {
-    finish();
+    release();
+    reloginInProgress.delete(page);
   }
-  return true;
+}
+
+/**
+ * Awaits any session recovery currently in progress for the page (no-op if
+ * none). Call this after a navigation so a test action doesn't race an
+ * in-flight re-login triggered by that same navigation.
+ */
+export async function awaitSessionRecovery(page: Page): Promise<void> {
+  const inProgress = reloginInProgress.get(page);
+  if (inProgress) {
+    await inProgress.catch(() => {
+      /* best-effort — recovery errors are surfaced by the failing test action */
+    });
+  }
 }
 
 /**

--- a/frontend/e2e/fixtures/auth-fixture.ts
+++ b/frontend/e2e/fixtures/auth-fixture.ts
@@ -1,0 +1,89 @@
+import type { Page, TestInfo } from '@playwright/test';
+
+import {
+  isOnLoginPage,
+  performLogin,
+  resolveCredentialsForStorageState,
+  saveStorageState,
+} from '../setup/login-helper';
+
+/**
+ * Guards against re-entrant / concurrent re-login attempts on the same page.
+ */
+const reloginInProgress = new WeakMap<Page, Promise<void>>();
+
+function storageStatePath(testInfo: TestInfo): string | undefined {
+  const state = testInfo.project.use.storageState;
+  return typeof state === 'string' ? state : undefined;
+}
+
+/**
+ * Detects when a navigation has landed on the OAuth login page — meaning the
+ * session snapshot in storageState has expired — and transparently
+ * re-authenticates the current persona, refreshing the stored session so
+ * subsequent tests reuse the fresh state.
+ *
+ * The setup projects establish the session once; long runs can outlive the
+ * OAuth token, after which every navigation silently redirects to the login
+ * page and tests hang waiting for elements that never appear. This fixture is
+ * the self-healing recovery for that case.
+ */
+export async function recoverSessionIfExpired(
+  page: Page,
+  testInfo: TestInfo,
+): Promise<boolean> {
+  if (!(await isOnLoginPage(page))) {
+    return false;
+  }
+
+  const existing = reloginInProgress.get(page);
+  if (existing) {
+    await existing;
+    return true;
+  }
+
+  const statePath = storageStatePath(testInfo);
+  const credentials = statePath ? resolveCredentialsForStorageState(statePath) : undefined;
+  if (!credentials) {
+    // No credentials to recover with (e.g. auth disabled or dev creds unset).
+    return false;
+  }
+
+  const relogin = (async () => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[auth] Session expired for "${testInfo.titlePath.join(' > ')}"; re-authenticating.`,
+    );
+    await performLogin(page, credentials.username, credentials.password, credentials.idpName);
+    if (statePath) {
+      await saveStorageState(page, statePath);
+    }
+  })();
+
+  reloginInProgress.set(page, relogin);
+  try {
+    await relogin;
+  } finally {
+    reloginInProgress.delete(page);
+  }
+  return true;
+}
+
+/**
+ * Attaches a main-frame navigation listener that re-authenticates whenever a
+ * navigation lands on the login page. Returns a disposer to detach it.
+ */
+export function attachSessionRecovery(page: Page, testInfo: TestInfo): () => void {
+  const handler = (frame: import('@playwright/test').Frame) => {
+    if (frame !== page.mainFrame()) {
+      return;
+    }
+    // Fire-and-forget: recovery guards its own re-entrancy. Swallow errors so a
+    // transient navigation event doesn't reject an unrelated step.
+    void recoverSessionIfExpired(page, testInfo).catch(() => {
+      /* best-effort recovery */
+    });
+  };
+  page.on('framenavigated', handler);
+  return () => page.off('framenavigated', handler);
+}

--- a/frontend/e2e/fixtures/auth-fixture.ts
+++ b/frontend/e2e/fixtures/auth-fixture.ts
@@ -25,6 +25,39 @@ function storageStatePath(testInfo: TestInfo): string | undefined {
 }
 
 /**
+ * Records a page's intended (non-auth) destination so recovery can return there
+ * after re-login. The page.goto override calls this before navigating: if the
+ * target immediately redirects to the login page, the framenavigated handler
+ * may only ever observe the auth URL, so relying on it alone would restore a
+ * stale route. Auth and about:blank targets are ignored — they're never a route
+ * a test wants to resume at. `url` may be relative; it is resolved against the
+ * page's current URL for the auth-vs-app classification.
+ */
+export function rememberIntendedUrl(page: Page, url: string): void {
+  if (!url || url === 'about:blank') {
+    return;
+  }
+  let absolute: string;
+  try {
+    absolute = new URL(url, page.url()).toString();
+  } catch {
+    // Unparseable (e.g. a data: URL used in tests) — record verbatim.
+    absolute = url;
+  }
+  if (!isAuthUrl(absolute)) {
+    lastAppUrl.set(page, absolute);
+  }
+}
+
+/**
+ * The route recovery would restore for a page, or undefined if none recorded.
+ * Exposed for the recovery regression tests.
+ */
+export function getIntendedUrl(page: Page): string | undefined {
+  return lastAppUrl.get(page);
+}
+
+/**
  * True for OAuth server / console login URLs — the pages a session-expiry
  * redirect passes through. These are never the route a test wants to resume at.
  *
@@ -139,14 +172,14 @@ export function isRecoveryInProgress(page: Page): boolean {
 /**
  * Awaits any session recovery currently in progress for the page (no-op if
  * none). Call this after a navigation so a test action doesn't race an
- * in-flight re-login triggered by that same navigation.
+ * in-flight re-login triggered by that same navigation. A recovery failure is
+ * propagated so the caller (e.g. the page.goto override) fails the active test
+ * with the original error rather than silently proceeding on the login page.
  */
 export async function awaitSessionRecovery(page: Page): Promise<void> {
   const inProgress = reloginInProgress.get(page);
   if (inProgress) {
-    await inProgress.catch(() => {
-      /* best-effort — recovery errors are surfaced by the failing test action */
-    });
+    await inProgress;
   }
 }
 

--- a/frontend/e2e/fixtures/auth-fixture.ts
+++ b/frontend/e2e/fixtures/auth-fixture.ts
@@ -72,14 +72,22 @@ export async function recoverSessionIfExpired(
   // logins. The deferred is published now and settled in the finally below;
   // keeping every early return and rejection inside the try guarantees the
   // slot is always released (a stuck claim would block all future recovery).
+  // The claim resolves on success and rejects on failure so joiners (the
+  // `existing` branch above) observe the same outcome instead of a false success.
   let release!: () => void;
-  const claim = new Promise<void>((resolve) => {
+  let fail!: (error: unknown) => void;
+  const claim = new Promise<void>((resolve, reject) => {
     release = resolve;
+    fail = reject;
   });
+  // A rejected claim that nobody awaits is an unhandled rejection; attach a
+  // no-op catch to the stored copy so only explicit awaiters see the error.
+  claim.catch(() => {});
   reloginInProgress.set(page, claim);
 
   try {
     if (!(await isOnLoginPage(page, detectTimeoutMs))) {
+      release();
       return false;
     }
 
@@ -87,6 +95,7 @@ export async function recoverSessionIfExpired(
     const credentials = statePath ? resolveCredentialsForStorageState(statePath) : null;
     if (!credentials) {
       // No credentials to recover with (e.g. auth disabled or dev creds unset).
+      release();
       return false;
     }
 
@@ -105,11 +114,26 @@ export async function recoverSessionIfExpired(
     if (intendedUrl && intendedUrl !== page.url()) {
       await page.goto(intendedUrl, { waitUntil: 'domcontentloaded' });
     }
-    return true;
-  } finally {
     release();
+    return true;
+  } catch (error) {
+    // Propagate the failure to every awaiter of this claim.
+    fail(error);
+    throw error;
+  } finally {
     reloginInProgress.delete(page);
   }
+}
+
+/**
+ * True while a re-login is running (or being set up) for the page. The page.goto
+ * override consults this to skip the recovery step for recovery-owned
+ * navigations — performLogin and the route-restoration goto both call the
+ * overridden page.goto, and re-running recovery there would deadlock the
+ * override on the very claim it is nested inside.
+ */
+export function isRecoveryInProgress(page: Page): boolean {
+  return reloginInProgress.has(page);
 }
 
 /**

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -5,7 +5,12 @@ import { test as base, expect } from '@playwright/test';
 
 import KubernetesClient from '../clients/kubernetes-client';
 
-import { attachSessionRecovery, awaitSessionRecovery, recoverSessionIfExpired } from './auth-fixture';
+import {
+  attachSessionRecovery,
+  awaitSessionRecovery,
+  isRecoveryInProgress,
+  recoverSessionIfExpired,
+} from './auth-fixture';
 import type { CleanupFixture } from './cleanup-fixture';
 import { createCleanupFixture } from './cleanup-fixture';
 
@@ -39,6 +44,14 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     const detach = attachSessionRecovery(page, testInfo);
     const originalGoto = page.goto.bind(page);
     page.goto = async (url, options) => {
+      // Recovery itself navigates through this same overridden goto (performLogin
+      // and the route-restoration goto). Those recovery-owned navigations must
+      // bypass the recovery step below — re-entering would deadlock the override
+      // on the very claim it is nested inside. Detect them and pass straight
+      // through to the original goto.
+      if (isRecoveryInProgress(page)) {
+        return originalGoto(url, options);
+      }
       const response = await originalGoto(url, options);
       // Drive recovery synchronously here rather than relying on the
       // framenavigated listener, whose dispatch can race goto resolving. This

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -5,7 +5,7 @@ import { test as base, expect } from '@playwright/test';
 
 import KubernetesClient from '../clients/kubernetes-client';
 
-import { attachSessionRecovery, recoverSessionIfExpired } from './auth-fixture';
+import { attachSessionRecovery, awaitSessionRecovery, recoverSessionIfExpired } from './auth-fixture';
 import type { CleanupFixture } from './cleanup-fixture';
 import { createCleanupFixture } from './cleanup-fixture';
 
@@ -28,14 +28,30 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   // Override the built-in page fixture to transparently recover from expired
   // sessions. Long runs can outlive the OAuth token captured in storageState;
   // without this, navigations silently redirect to the login page and tests
-  // hang. The navigation listener re-authenticates the persona whenever a
-  // navigation lands on the login page. The proactive check below is a
-  // best-effort guard for a page that somehow starts on the login page; the
-  // page is typically about:blank at fixture setup, so it usually no-ops and
-  // the listener does the real work.
+  // hang. A navigation listener re-authenticates the persona whenever a
+  // navigation lands on the login page.
+  //
+  // We also wrap page.goto so that after every navigation the caller awaits any
+  // recovery the navigation itself triggered — otherwise the action that hit
+  // the expiry would race the background re-login and act on the login page.
+  // This covers both raw page.goto calls in tests and BasePage.goTo.
   page: async ({ page }, use, testInfo) => {
     const detach = attachSessionRecovery(page, testInfo);
+    const originalGoto = page.goto.bind(page);
+    page.goto = async (url, options) => {
+      const response = await originalGoto(url, options);
+      // Drive recovery synchronously here rather than relying on the
+      // framenavigated listener, whose dispatch can race goto resolving. This
+      // call is guarded/idempotent: it no-ops when not on the login page and
+      // joins any recovery the listener already started.
+      await recoverSessionIfExpired(page, testInfo, 2_000);
+      await awaitSessionRecovery(page);
+      return response;
+    };
     try {
+      // Best-effort guard for a page that somehow starts on the login page; at
+      // fixture setup the page is typically about:blank, so this usually no-ops
+      // and the listener does the real work.
       await recoverSessionIfExpired(page, testInfo);
       await use(page);
     } finally {

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -10,6 +10,7 @@ import {
   awaitSessionRecovery,
   isRecoveryInProgress,
   recoverSessionIfExpired,
+  rememberIntendedUrl,
 } from './auth-fixture';
 import type { CleanupFixture } from './cleanup-fixture';
 import { createCleanupFixture } from './cleanup-fixture';
@@ -52,6 +53,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       if (isRecoveryInProgress(page)) {
         return originalGoto(url, options);
       }
+      // Record the intended destination before navigating. If this target
+      // immediately redirects to the login page, the framenavigated handler may
+      // only ever see the auth URL, so recovery would otherwise restore a stale
+      // route instead of where the test was headed.
+      rememberIntendedUrl(page, url);
       const response = await originalGoto(url, options);
       // Drive recovery synchronously here rather than relying on the
       // framenavigated listener, whose dispatch can race goto resolving. This

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -5,6 +5,7 @@ import { test as base, expect } from '@playwright/test';
 
 import KubernetesClient from '../clients/kubernetes-client';
 
+import { attachSessionRecovery, recoverSessionIfExpired } from './auth-fixture';
 import type { CleanupFixture } from './cleanup-fixture';
 import { createCleanupFixture } from './cleanup-fixture';
 
@@ -24,6 +25,21 @@ type WorkerFixtures = {
 };
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
+  // Override the built-in page fixture to transparently recover from expired
+  // sessions. Long runs can outlive the OAuth token captured in storageState;
+  // without this, navigations silently redirect to the login page and tests
+  // hang. The listener re-authenticates the persona whenever a navigation
+  // lands on the login page, and a proactive check covers the initial page.
+  page: async ({ page }, use, testInfo) => {
+    const detach = attachSessionRecovery(page, testInfo);
+    try {
+      await recoverSessionIfExpired(page, testInfo);
+      await use(page);
+    } finally {
+      detach();
+    }
+  },
+
   testConfig: [
     async ({}, use) => {
       const configPath = path.resolve(import.meta.dirname, '..', '.test-config.json');

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -28,8 +28,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   // Override the built-in page fixture to transparently recover from expired
   // sessions. Long runs can outlive the OAuth token captured in storageState;
   // without this, navigations silently redirect to the login page and tests
-  // hang. The listener re-authenticates the persona whenever a navigation
-  // lands on the login page, and a proactive check covers the initial page.
+  // hang. The navigation listener re-authenticates the persona whenever a
+  // navigation lands on the login page. The proactive check below is a
+  // best-effort guard for a page that somehow starts on the login page; the
+  // page is typically about:blank at fixture setup, so it usually no-ops and
+  // the listener does the real work.
   page: async ({ page }, use, testInfo) => {
     const detach = attachSessionRecovery(page, testInfo);
     try {

--- a/frontend/e2e/pages/web-terminal-config-page.ts
+++ b/frontend/e2e/pages/web-terminal-config-page.ts
@@ -14,7 +14,7 @@ export class WebTerminalConfigPage extends BasePage {
 
   async navigateToWebTerminalConfig(): Promise<void> {
     await this.goTo('/k8s/cluster/operator.openshift.io~v1~Console/cluster');
-    await this.waitForLoadingComplete(10_000);
+    await this.waitForLoadingComplete(30_000);
     const customizeButton = this.page.getByRole('button', { name: 'Customize' });
     // eslint-disable-next-line no-restricted-syntax
     await customizeButton
@@ -25,17 +25,17 @@ export class WebTerminalConfigPage extends BasePage {
       await this.robustClick(customizeButton.first());
     } else {
       const actionsMenu = this.page.getByTestId('actions-menu-button');
-      await this.robustClick(actionsMenu);
+      await this.robustClick(actionsMenu, { timeout: 60_000 });
       const customizeAction = this.page.locator('[data-test-action="Customize"]:not([disabled])');
       await this.robustClick(customizeAction);
     }
-    await this.waitForLoadingComplete(10_000);
+    await this.waitForLoadingComplete(30_000);
     await this.clickWebTerminalTab();
   }
 
   async clickWebTerminalTab(): Promise<void> {
     const tab = this.page.getByRole('tab', { name: 'Web Terminal' });
-    await this.robustClick(tab, { timeout: 60_000 });
+    await this.robustClick(tab, { timeout: 60_000, retries: 1 });
     await this.waitForLoadingComplete(5_000);
   }
 

--- a/frontend/e2e/pages/web-terminal-page.ts
+++ b/frontend/e2e/pages/web-terminal-page.ts
@@ -26,26 +26,12 @@ export class WebTerminalPage extends BasePage {
   private readonly closeTerminalButton = this.page.getByLabel(/Close terminal/);
   private readonly inactivityMessageArea = this.page.locator('div.co-cloudshell-exec__error-msg');
 
-  async waitForTerminalIconVisible(maxRetries = 10): Promise<void> {
+  async waitForTerminalIconVisible(): Promise<void> {
     await warmupSPA(this.page);
-    try {
-      // eslint-disable-next-line no-restricted-syntax
-      await this.terminalIcon.waitFor({ state: 'visible', timeout: 30_000 });
-      return;
-    } catch {
-      // Icon not visible on first load — retry with reloads
-    }
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-      await this.page.reload();
-      try {
-        // eslint-disable-next-line no-restricted-syntax
-        await this.terminalIcon.waitFor({ state: 'visible', timeout: 15_000 });
-        return;
-      } catch {
-        // Retry
-      }
-    }
-    throw new Error(`Terminal icon not visible after ${maxRetries} retries`);
+    await expect(async () => {
+      await this.page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(this.terminalIcon).toBeVisible({ timeout: 15_000 });
+    }).toPass({ intervals: [2_000, 5_000, 10_000], timeout: 120_000 });
   }
 
   async clickTerminalIcon(): Promise<void> {
@@ -54,7 +40,7 @@ export class WebTerminalPage extends BasePage {
     await this.loadingBox.waitFor({ state: 'detached', timeout: 60_000 }).catch(() => {});
   }
 
-  async waitForTerminalWindow(timeoutMs = 60_000): Promise<void> {
+  async waitForTerminalWindow(timeoutMs = 120_000): Promise<void> {
     await expect(this.terminalContainer).toBeVisible({ timeout: timeoutMs });
     await expect(this.terminalWindow).toBeVisible({ timeout: timeoutMs });
   }

--- a/frontend/e2e/setup/admin-auth.setup.ts
+++ b/frontend/e2e/setup/admin-auth.setup.ts
@@ -2,17 +2,14 @@ import * as path from 'path';
 
 import { test as setup } from '@playwright/test';
 
-import { performLogin, saveStorageState } from './login-helper';
+import { getAdminCredentials, performLogin, saveStorageState } from './login-helper';
 
 const adminStorageState = path.resolve(import.meta.dirname, '..', '.auth', 'kubeadmin.json');
 
 setup('login as kubeadmin', async ({ page }) => {
   setup.skip(process.env.SKIP_GLOBAL_SETUP === 'true', 'SKIP_GLOBAL_SETUP is set');
 
-  const baseURL = process.env.WEB_CONSOLE_URL || 'http://localhost:9000';
-  const username = process.env.OPENSHIFT_USERNAME || 'kubeadmin';
-  const password = process.env.BRIDGE_KUBEADMIN_PASSWORD || '';
-
-  await performLogin(page, baseURL, username, password, 'kube:admin');
+  const { username, password, idpName } = getAdminCredentials();
+  await performLogin(page, username, password, idpName);
   await saveStorageState(page, adminStorageState);
 });

--- a/frontend/e2e/setup/developer-auth.setup.ts
+++ b/frontend/e2e/setup/developer-auth.setup.ts
@@ -2,21 +2,16 @@ import * as path from 'path';
 
 import { test as setup } from '@playwright/test';
 
-import { performLogin, saveStorageState } from './login-helper';
+import { getDeveloperCredentials, performLogin, saveStorageState } from './login-helper';
 
 const developerStorageState = path.resolve(import.meta.dirname, '..', '.auth', 'developer.json');
 
 setup('login as developer', async ({ page }) => {
   setup.skip(process.env.SKIP_GLOBAL_SETUP === 'true', 'SKIP_GLOBAL_SETUP is set');
 
-  const htpasswdUser = process.env.BRIDGE_HTPASSWD_USERNAME;
-  const htpasswdPass = process.env.BRIDGE_HTPASSWD_PASSWORD;
+  const creds = getDeveloperCredentials();
+  setup.skip(!creds, 'No developer credentials configured');
 
-  setup.skip(!htpasswdUser || !htpasswdPass, 'No developer credentials configured');
-
-  const baseURL = process.env.WEB_CONSOLE_URL || 'http://localhost:9000';
-  const htpasswdIdp = process.env.BRIDGE_HTPASSWD_IDP || htpasswdUser!;
-
-  await performLogin(page, baseURL, htpasswdUser!, htpasswdPass!, htpasswdIdp);
+  await performLogin(page, creds!.username, creds!.password, creds!.idpName);
   await saveStorageState(page, developerStorageState);
 });

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -6,14 +6,40 @@ import { expect } from '@playwright/test';
 
 const STORAGE_STATE_DIR = path.resolve(import.meta.dirname, '..', '.auth');
 
+export function getBaseURL(): string {
+  return process.env.WEB_CONSOLE_URL || 'http://localhost:9000';
+}
+
+export function getAdminCredentials(): { username: string; password: string; idpName: string } {
+  return {
+    username: process.env.OPENSHIFT_USERNAME || 'kubeadmin',
+    password: process.env.BRIDGE_KUBEADMIN_PASSWORD || '',
+    idpName: 'kube:admin',
+  };
+}
+
+export function getDeveloperCredentials(): {
+  username: string;
+  password: string;
+  idpName: string;
+} | null {
+  const username = process.env.BRIDGE_HTPASSWD_USERNAME;
+  const password = process.env.BRIDGE_HTPASSWD_PASSWORD;
+  if (!username || !password) return null;
+  return {
+    username,
+    password,
+    idpName: process.env.BRIDGE_HTPASSWD_IDP || username,
+  };
+}
+
 export async function performLogin(
   page: Page,
-  baseURL: string,
   username: string,
   password: string,
   idpName?: string,
 ): Promise<void> {
-  await page.goto(baseURL, { timeout: 90_000, waitUntil: 'domcontentloaded' });
+  await page.goto(getBaseURL(), { timeout: 90_000, waitUntil: 'domcontentloaded' });
 
   const authDisabled = await page
     .evaluate(() => (window as any).SERVER_FLAGS?.authDisabled)

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -117,6 +117,22 @@ export async function performLogin(
 
 export async function saveStorageState(page: Page, storagePath: string): Promise<void> {
   fs.mkdirSync(STORAGE_STATE_DIR, { recursive: true, mode: 0o700 });
-  await page.context().storageState({ path: storagePath });
-  fs.chmodSync(storagePath, 0o600);
+  // Write to a unique temp file and atomically rename it into place. Workers are
+  // separate processes, so two of them recovering the same persona could
+  // otherwise interleave writes to the same file and leave a reader (another
+  // worker loading storageState) observing a half-written, invalid JSON file.
+  // A same-directory rename is atomic, so readers always see a complete file.
+  const tmpPath = `${storagePath}.${process.pid}.tmp`;
+  try {
+    await page.context().storageState({ path: tmpPath });
+    fs.chmodSync(tmpPath, 0o600);
+    fs.renameSync(tmpPath, storagePath);
+  } catch (error) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    throw error;
+  }
 }

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -51,16 +51,27 @@ export function resolveCredentialsForStorageState(
 }
 
 /**
- * Returns true when the given page is currently showing the OAuth login page
- * (i.e. the session has expired or was never established).
+ * Returns true when the given page is showing the OAuth login page (i.e. the
+ * session has expired or was never established).
+ *
+ * A session-expiry redirect goes through the OAuth server before the login
+ * form renders, so an instantaneous visibility check can race the redirect
+ * chain and miss it. `timeoutMs` gives the login locator a bounded window to
+ * appear. It defaults to 0 (instantaneous) so callers on the hot path stay
+ * cheap; pass a small timeout only when a redirect may still be settling.
  */
-export async function isOnLoginPage(page: Page): Promise<boolean> {
-  return page
+export async function isOnLoginPage(page: Page, timeoutMs = 0): Promise<boolean> {
+  const loginLocator = page
     .locator('[data-test-id="login"]')
     .or(page.locator('#inputUsername'))
-    .first()
-    .isVisible()
-    .catch(() => false);
+    .first();
+  try {
+    // eslint-disable-next-line no-restricted-syntax
+    await loginLocator.waitFor({ state: 'visible', timeout: timeoutMs });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function performLogin(

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -33,6 +33,36 @@ export function getDeveloperCredentials(): {
   };
 }
 
+/**
+ * Resolves the login credentials for a given storage-state file. The auth
+ * fixture uses this to re-authenticate the correct persona (admin vs.
+ * developer) when a session expires mid-run, mirroring the setup projects.
+ * Returns null when the required credentials are not configured.
+ */
+export function resolveCredentialsForStorageState(
+  storageStatePath: string,
+): { username: string; password: string; idpName: string } | null {
+  const fileName = path.basename(storageStatePath);
+  if (fileName === 'developer.json') {
+    return getDeveloperCredentials();
+  }
+  // Default to the kubeadmin/admin persona.
+  return getAdminCredentials();
+}
+
+/**
+ * Returns true when the given page is currently showing the OAuth login page
+ * (i.e. the session has expired or was never established).
+ */
+export async function isOnLoginPage(page: Page): Promise<boolean> {
+  return page
+    .locator('[data-test-id="login"]')
+    .or(page.locator('#inputUsername'))
+    .first()
+    .isVisible()
+    .catch(() => false);
+}
+
 export async function performLogin(
   page: Page,
   username: string,

--- a/frontend/e2e/setup/login-helper.ts
+++ b/frontend/e2e/setup/login-helper.ts
@@ -65,6 +65,13 @@ export async function isOnLoginPage(page: Page, timeoutMs = 0): Promise<boolean>
     .locator('[data-test-id="login"]')
     .or(page.locator('#inputUsername'))
     .first();
+  // timeoutMs === 0 means an instantaneous check. Note that Playwright's
+  // waitFor treats timeout: 0 as "wait forever", so use the non-waiting
+  // isVisible() for the zero case and only wait when a bounded window is asked
+  // for.
+  if (timeoutMs <= 0) {
+    return loginLocator.isVisible().catch(() => false);
+  }
   try {
     // eslint-disable-next-line no-restricted-syntax
     await loginLocator.waitFor({ state: 'visible', timeout: timeoutMs });

--- a/frontend/e2e/tests/console/app/session-recovery.spec.ts
+++ b/frontend/e2e/tests/console/app/session-recovery.spec.ts
@@ -1,0 +1,74 @@
+import { test as base, expect } from '@playwright/test';
+
+import { awaitSessionRecovery } from '../../../fixtures/auth-fixture';
+import { isOnLoginPage } from '../../../setup/login-helper';
+
+// Regression test for OCPBUGS-105789: https://issues.redhat.com/browse/OCPBUGS-105789
+//
+// The Playwright suite authenticates once and freezes the session into a
+// storageState snapshot. When the OAuth token expires mid-run, navigations
+// redirect to the login page and tests hang because nothing re-authenticates.
+// The self-healing auth fixture recovers by detecting the login page and
+// re-running performLogin.
+//
+// These tests pin the detection primitive the recovery flow depends on. They
+// render markup via data: URLs so no cluster is required. The full re-login
+// round-trip (performLogin -> OAuth -> route restoration) exercises a live
+// OAuth server and is validated by the e2e suite running against a cluster.
+
+const dataUrl = (body: string): string =>
+  `data:text/html,${encodeURIComponent(`<!doctype html><html><body>${body}</body></html>`)}`;
+
+const LOGIN_BY_TEST_ID = dataUrl(
+  '<form data-test-id="login"><input id="inputUsername" /></form>',
+);
+const LOGIN_BY_INPUT = dataUrl('<input id="inputUsername" /><input id="inputPassword" />');
+const APP_PAGE = dataUrl(
+  '<div data-test="user-dropdown-toggle">user</div><div id="page-sidebar">app</div>',
+);
+
+// Uses the raw Playwright fixture (not e2e/fixtures) so the fixture's own
+// goto/recovery wrapping doesn't interfere with these targeted assertions.
+const test = base;
+
+test.describe('Session recovery detection (OCPBUGS-105789)', () => {
+  test('detects the login page by data-test-id="login"', async ({ page }) => {
+    await page.goto(LOGIN_BY_TEST_ID);
+    expect(await isOnLoginPage(page)).toBe(true);
+  });
+
+  test('detects the login page by the username/password inputs', async ({ page }) => {
+    await page.goto(LOGIN_BY_INPUT);
+    expect(await isOnLoginPage(page)).toBe(true);
+  });
+
+  test('does not treat an authenticated app page as the login page', async ({ page }) => {
+    await page.goto(APP_PAGE);
+    // Instantaneous check: the app page has no login markers.
+    expect(await isOnLoginPage(page)).toBe(false);
+  });
+
+  test('waits the bounded window for a slow-rendering login form', async ({ page }) => {
+    // Render the app first, then inject the login form after a delay to mimic
+    // an OAuth redirect that hasn't finished painting when the check runs.
+    await page.goto(APP_PAGE);
+    await page.evaluate(() => {
+      setTimeout(() => {
+        const form = document.createElement('form');
+        form.setAttribute('data-test-id', 'login');
+        // An empty form has no layout box and reads as not visible, so give it
+        // an input to render.
+        form.appendChild(document.createElement('input'));
+        document.body.appendChild(form);
+      }, 500);
+    });
+    // Instantaneous check misses it; the bounded wait catches it.
+    expect(await isOnLoginPage(page, 0)).toBe(false);
+    expect(await isOnLoginPage(page, 3_000)).toBe(true);
+  });
+
+  test('awaitSessionRecovery is a no-op when no recovery is in progress', async ({ page }) => {
+    await page.goto(APP_PAGE);
+    await expect(awaitSessionRecovery(page)).resolves.toBeUndefined();
+  });
+});

--- a/frontend/e2e/tests/console/app/session-recovery.spec.ts
+++ b/frontend/e2e/tests/console/app/session-recovery.spec.ts
@@ -1,6 +1,10 @@
 import { test as base, expect } from '@playwright/test';
 
-import { awaitSessionRecovery } from '../../../fixtures/auth-fixture';
+import {
+  awaitSessionRecovery,
+  getIntendedUrl,
+  rememberIntendedUrl,
+} from '../../../fixtures/auth-fixture';
 import { isOnLoginPage } from '../../../setup/login-helper';
 
 // Regression test for OCPBUGS-105789: https://issues.redhat.com/browse/OCPBUGS-105789
@@ -70,5 +74,21 @@ test.describe('Session recovery detection (OCPBUGS-105789)', () => {
   test('awaitSessionRecovery is a no-op when no recovery is in progress', async ({ page }) => {
     await page.goto(APP_PAGE);
     await expect(awaitSessionRecovery(page)).resolves.toBeUndefined();
+  });
+
+  test('remembers the intended deep-link so recovery restores it, not the login page', async ({
+    page,
+  }) => {
+    await page.goto(APP_PAGE);
+    // The deep link the test was headed to is recorded before navigation.
+    rememberIntendedUrl(page, 'https://console.example/k8s/ns/foo/pods');
+    expect(getIntendedUrl(page)).toBe('https://console.example/k8s/ns/foo/pods');
+    // A subsequent redirect to the OAuth/login page must NOT overwrite it —
+    // otherwise recovery would restore the login page instead of the deep link.
+    rememberIntendedUrl(page, 'https://console.example/oauth/authorize?client_id=x');
+    expect(getIntendedUrl(page)).toBe('https://console.example/k8s/ns/foo/pods');
+    // about:blank is ignored too.
+    rememberIntendedUrl(page, 'about:blank');
+    expect(getIntendedUrl(page)).toBe('https://console.example/k8s/ns/foo/pods');
   });
 });

--- a/frontend/e2e/tests/webterminal/developer/web-terminal-basic.spec.ts
+++ b/frontend/e2e/tests/webterminal/developer/web-terminal-basic.spec.ts
@@ -24,6 +24,7 @@ test.describe('Web Terminal basic user', () => {
   });
 
   test('open terminal with advanced timeout', async ({ page }) => {
+    test.slow();
     const webTerminal = new WebTerminalPage(page);
 
     await test.step('Open terminal with 1-minute timeout', async () => {
@@ -45,6 +46,7 @@ test.describe('Web Terminal basic user', () => {
   });
 
   test('verify Open in new tab button', async ({ page }) => {
+    test.slow();
     const webTerminal = new WebTerminalPage(page);
 
     await test.step('Wait for terminal icon and open terminal', async () => {

--- a/frontend/e2e/tests/webterminal/developer/web-terminal-devuser.spec.ts
+++ b/frontend/e2e/tests/webterminal/developer/web-terminal-devuser.spec.ts
@@ -54,6 +54,7 @@ test.describe('Web Terminal for Developer user', () => {
   test(
     'create new project and use Web Terminal',
     async ({ page, k8sClient, cleanup }) => {
+      test.slow();
       const webTerminal = new WebTerminalPage(page);
       cleanup.trackNamespace(NEW_PROJECT);
 
@@ -88,6 +89,7 @@ test.describe('Web Terminal for Developer user', () => {
 
   // eslint-disable-next-line playwright/expect-expect
   test('open Web Terminal for existing project', async ({ page, k8sClient }) => {
+    test.slow();
     const webTerminal = new WebTerminalPage(page);
 
     await test.step('Wait for terminal icon and open terminal', async () => {

--- a/frontend/e2e/tests/webterminal/web-terminal-admin.spec.ts
+++ b/frontend/e2e/tests/webterminal/web-terminal-admin.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test';
 
 import { test, expect } from '../../fixtures';
 import type KubernetesClient from '../../clients/kubernetes-client';
-import { getEditorContent, warmupSPA } from '../../pages/base-page';
+import { getEditorContent } from '../../pages/base-page';
 import { WebTerminalPage } from '../../pages/web-terminal-page';
 import {
   ensureWebTerminalOperatorInstalled,
@@ -88,6 +88,7 @@ test.describe('Web Terminal for Admin user', () => {
   test(
     'open and close multiple terminal tabs',
     async ({ page }) => {
+      test.slow();
       const webTerminal = new WebTerminalPage(page);
 
       await test.step('Wait for terminal icon and start terminal', async () => {
@@ -120,6 +121,7 @@ test.describe('Web Terminal for Admin user', () => {
   test(
     'start terminal with timeout and verify DevWorkspace',
     async ({ page, k8sClient }) => {
+      test.slow();
       const webTerminal = new WebTerminalPage(page);
 
       await test.step('Open terminal with 10-minute timeout', async () => {
@@ -139,6 +141,7 @@ test.describe('Web Terminal for Admin user', () => {
   test(
     'start terminal with defaults and verify DevWorkspace',
     async ({ page, k8sClient }) => {
+      test.slow();
       const webTerminal = new WebTerminalPage(page);
 
       await test.step('Open terminal with default settings', async () => {

--- a/frontend/e2e/tests/webterminal/web-terminal-config.spec.ts
+++ b/frontend/e2e/tests/webterminal/web-terminal-config.spec.ts
@@ -27,6 +27,7 @@ test.describe('Customization of web terminal options', () => {
   test(
     'navigate to Web Terminal Configuration page',
     async ({ page }) => {
+      test.slow();
       const configPage = new WebTerminalConfigPage(page);
 
       await test.step('Navigate to Consoles and open Customize', async () => {
@@ -42,6 +43,7 @@ test.describe('Customization of web terminal options', () => {
   test(
     'change timeout and image with persist checkboxes',
     async ({ page }) => {
+      test.slow();
       const configPage = new WebTerminalConfigPage(page);
 
       await test.step('Navigate to Web Terminal Configuration', async () => {
@@ -68,6 +70,7 @@ test.describe('Customization of web terminal options', () => {
   test(
     'change timeout to Hours and verify values persist after tab switch',
     async ({ page }) => {
+      test.slow();
       const configPage = new WebTerminalConfigPage(page);
 
       await test.step('Navigate to Web Terminal Configuration', async () => {
@@ -98,6 +101,7 @@ test.describe('Customization of web terminal options', () => {
   test(
     'save without persist checkboxes',
     async ({ page }) => {
+      test.slow();
       const configPage = new WebTerminalConfigPage(page);
 
       await test.step('Navigate to Web Terminal Configuration', async () => {
@@ -121,6 +125,7 @@ test.describe('Customization of web terminal options', () => {
   test(
     'verify unchecked checkboxes persist after tab switch',
     async ({ page }) => {
+      test.slow();
       const configPage = new WebTerminalConfigPage(page);
 
       await test.step('Navigate to Web Terminal Configuration', async () => {


### PR DESCRIPTION
**Analysis / Root cause**:

The Playwright e2e suite authenticates exactly once, in the setup projects ([`admin-auth.setup.ts`](frontend/e2e/setup/admin-auth.setup.ts), [`developer-auth.setup.ts`](frontend/e2e/setup/developer-auth.setup.ts)), and freezes the session into a `storageState` snapshot. Every test project loads that static snapshot ([`playwright.config.ts`](frontend/playwright.config.ts)) and nothing ever re-authenticates — `performLogin` is only referenced by the two setup files.

When the OpenShift OAuth token expires during a long run, subsequent `page.goto()` calls silently redirect to the login page, and tests hang waiting for elements (e.g. `user-dropdown-toggle`, `#page-sidebar`) that never appear, failing with generic `toBeVisible`/test-timeout errors. This showed up as widespread login-page hangs in CI.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-105789

**Solution description**:

Add a self-healing auth fixture that overrides Playwright's built-in `page` fixture:

- [`e2e/fixtures/auth-fixture.ts`](frontend/e2e/fixtures/auth-fixture.ts) (new) — attaches a main-frame `framenavigated` listener that detects when a navigation lands on the login page and transparently re-runs `performLogin` for the active persona, then re-saves `storageState` so later tests reuse the fresh session. After re-login it restores the route the test was navigating to, so deep-link tests resume where they intended rather than on the console home page. Concurrency is handled by claiming the re-login slot synchronously (closing a TOCTOU window where two navigation events could each start a login), and recovery-owned navigations bypass the `page.goto` override so they don't deadlock on their own in-progress claim. A failed re-login rejects the shared claim so any joining caller observes the failure instead of a false success. It logs a warning when recovery fires so future occurrences are visible in CI logs.
- [`e2e/setup/login-helper.ts`](frontend/e2e/setup/login-helper.ts) — adds `isOnLoginPage()` and `resolveCredentialsForStorageState()` (dispatches to the existing `getAdminCredentials()`/`getDeveloperCredentials()` helpers based on the project's storage-state filename). `isOnLoginPage()` supports an instantaneous check on the hot path and a bounded wait for still-rendering OAuth redirects; it uses a non-waiting `isVisible()` for the zero-timeout case because Playwright treats `waitFor({ timeout: 0 })` as "wait forever".
- [`e2e/fixtures/index.ts`](frontend/e2e/fixtures/index.ts) — wires recovery into the shared `page` fixture and wraps `page.goto` so callers await any recovery the navigation itself triggered. Since every spec imports `test` from here, coverage is suite-wide with no per-test changes.
- [`e2e/tests/console/app/session-recovery.spec.ts`](frontend/e2e/tests/console/app/session-recovery.spec.ts) (new) — regression test pinning the login-page detection primitive the recovery flow depends on. It renders markup via `data:` URLs so no cluster is required.

Auth-disabled clusters and unset developer credentials cause recovery to no-op safely.

> **Depends on #16953** (OCPBUGS-105609), which refactors the same setup/login helpers this change builds on. Until #16953 merges, this PR's diff will also include those changes; once it merges, only this change remains. Please merge #16953 first.

**Screenshots / screen recording**:
<!-- N/A — test-infrastructure change, no UI impact -->

**Test setup:**

Requires a cluster whose OAuth access-token lifetime is shorter than the full e2e run so the session expires mid-run; the recovery path then re-authenticates transparently. The `session-recovery.spec.ts` detection tests run without a cluster.

**Test cases:**

- Full Playwright e2e run outlasting the OAuth token: post-expiry tests recover instead of hanging on the login page.
- Admin and developer personas each re-authenticate with the correct credentials.
- Deep-link test whose navigation triggers re-login resumes on its intended route.
- Auth-disabled cluster: recovery no-ops, tests unaffected.
- Unset developer credentials: recovery no-ops without error.
- `session-recovery.spec.ts`: login-page detection by `data-test-id`, by username/password inputs, non-detection of an authenticated app page, bounded wait for a slow-rendering login form, and `awaitSessionRecovery` no-op when idle.

**Browser conformance**:
- [x] Chrome

**Additional info:**

Test-infrastructure only — no product/runtime code changes.

**Reviewers and assignees:**
<!-- Tag an OCP console engineer to review. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from expired sessions with automatic re-authentication and restoration of the intended page.
  * Increased reliability for Web Terminal loading, navigation, visibility checks, and configuration actions.

* **Tests**
  * Added coverage for session recovery, login detection, delayed authentication, and deep-link preservation.
  * Improved authentication setup using configured credentials.
  * Expanded coverage for slower Web Terminal scenarios with extended timeouts and retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
