### PR TITLE
[release-4.17] OCPBUGS-105790: Disable shipwright e2e tests to unblock CI

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -81,7 +81,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
   yarn run test-cypress-pipelines-nightly
-  yarn run test-cypress-shipwright-nightly
+  # yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
   # yarn run test-cypress-webterminal-nightly
@@ -97,7 +97,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
   yarn run test-cypress-pipelines-headless
-  yarn run test-cypress-shipwright-headless
+  # yarn run test-cypress-shipwright-headless
   # yarn run test-cypress-webterminal-headless
   exit;
 fi


### PR DESCRIPTION
manual backport of https://github.com/openshift/console/pull/16818