### PR TITLE
[release-4.14] OCPBUGS-105791: Disable failing OLM and pipelines e2e tests to unblock CI

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.spec.ts
@@ -1,7 +1,7 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 import { nav } from '../../../integration-tests-cypress/views/nav';
 
-describe('Interacting with OperatorHub', () => {
+xdescribe('Interacting with OperatorHub', () => {
   before(() => {
     cy.login();
     cy.visit('/');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.spec.ts
@@ -17,7 +17,7 @@ const testOperand: TestOperandProps = {
   exampleName: 'example-servicebinding',
 };
 
-describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
+xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     cy.visit('/');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.spec.ts
@@ -18,7 +18,7 @@ const testOperand: TestOperandProps = {
   exampleName: `backend1-sample`,
 };
 
-describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
+xdescribe(`Installing "${testOperator.name}" operator in test namespace`, () => {
   before(() => {
     cy.login();
     cy.visit('/');

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -58,7 +58,7 @@ if [ -n "${nightly-}" ] && [ -z "${pkg-}" ]; then
 
   yarn run test-cypress-dev-console-nightly
   yarn run test-cypress-helm-nightly
-  yarn run test-cypress-pipelines-nightly
+  # yarn run test-cypress-pipelines-nightly
   yarn run test-cypress-shipwright-nightly
   yarn run test-cypress-topology-nightly
   yarn run test-cypress-knative-nightly
@@ -74,7 +74,7 @@ if [ -n "${headless-}" ] && [ -z "${pkg-}" ]; then
   yarn run test-cypress-helm-headless
   yarn run test-cypress-knative-headless
   yarn run test-cypress-topology-headless
-  yarn run test-cypress-pipelines-headless
+  # yarn run test-cypress-pipelines-headless
   # yarn run test-cypress-shipwright-headless
   # yarn run test-cypress-webterminal-headless
   exit;


### PR DESCRIPTION
**Analysis / Root cause**:
OLM and pipelines e2e tests are failing consistently, blocking CI and PR merges

**Solution description**:
Temporarily disable failing tests to unblock CI. Investigate and re-enable them in https://redhat.atlassian.net/browse/OCPBUGS-105794

