### PR TITLE
[release-4.15] OCPBUGS-105792: Disable operator-hub e2e tests to unblock CI

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
@@ -1,7 +1,7 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 import { nav } from '../../../integration-tests-cypress/views/nav';
 
-describe('Interacting with OperatorHub', () => {
+xdescribe('Interacting with OperatorHub', () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
@@ -15,7 +15,7 @@ const testOperand: TestOperandProps = {
   exampleName: 'example-infinispan',
 };
 
-describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
+xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     operator.install(testOperator.name, testOperator.operatorHubCardTestID);


### PR DESCRIPTION
**Analysis / Root cause**:
operator-hub e2e tests are failing consistently, blocking CI and PR merges

**Solution description**:
Temporarily disable failing tests to unblock CI. Investigate and re-enable them in https://redhat.atlassian.net/browse/OCPBUGS-105795

