### PR TITLE
[release-4.16] OCPBUGS-105793: Disable failing OLM and other e2e tests to unblock CI

### DIFF
--- a/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
@@ -80,7 +80,7 @@ const k8sAPINavTest = (apiID: string) => {
   cy.get(`test-k8s-${apiID}`).should('not.be.empty');
 };
 if (!Cypress.env('OPENSHIFT_CI') || Cypress.env('PLUGIN_PULL_SPEC')) {
-  describe('Demo dynamic plugin test', () => {
+  xdescribe('Demo dynamic plugin test', () => {
     before(() => {
       cy.login();
       cy.createProjectWithCLI(PLUGIN_NAME);

--- a/frontend/packages/integration-tests-cypress/tests/dashboards/cluster-dashboard.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/dashboards/cluster-dashboard.cy.ts
@@ -1,7 +1,7 @@
 import { checkErrors } from '../../support';
 import { isLocalDevEnvironment } from '../../views/common';
 
-describe('Cluster dashboard', () => {
+xdescribe('Cluster dashboard', () => {
   before(() => {
     cy.login();
   });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
@@ -2,7 +2,7 @@ import { checkErrors, testName } from '../../../integration-tests-cypress/suppor
 import { nav } from '../../../integration-tests-cypress/views/nav';
 import { OPERATOR_HUB_LOAD_TIMEOUT, operatorHub } from '../views/operator-hub.view';
 
-describe('Interacting with OperatorHub', () => {
+xdescribe('Interacting with OperatorHub', () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-global.cy.ts
@@ -15,7 +15,7 @@ const testOperand: TestOperandProps = {
   exampleName: 'example-infinispan',
 };
 
-describe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
+xdescribe(`Globally installing "${testOperator.name}" operator in ${GlobalInstalledNamespace}`, () => {
   before(() => {
     cy.login();
     operator.install(testOperator.name, testOperator.operatorHubCardTestID);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-install-single-namespace.cy.ts
@@ -18,7 +18,7 @@ const testOperand: TestOperandProps = {
   exampleName: 'example-backup',
 };
 
-describe(`Installing "${testOperator.name}" operator in test namespace`, () => {
+xdescribe(`Installing "${testOperator.name}" operator in test namespace`, () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-uninstall.cy.ts
@@ -21,7 +21,7 @@ const alertExists = (titleText: string) => {
   cy.get('.co-alert').contains(titleText).should('exist');
 };
 
-describe(`Testing uninstall of ${testOperator.name} Operator`, () => {
+xdescribe(`Testing uninstall of ${testOperator.name} Operator`, () => {
   before(() => {
     cy.login();
     cy.createProjectWithCLI(testName);


### PR DESCRIPTION
**Analysis / Root cause**:
OLM and other e2e tests are failing consistently, blocking CI and PR merges

**Solution description**:
Temporarily disable failing tests to unblock CI. Investigate and re-enable them in https://redhat.atlassian.net/browse/OCPBUGS-105796

