### PR TITLE
Fix for OCPBUGS-105899: CVE-2026-73086

### DIFF
--- a/dynamic-demo-plugin/package.json
+++ b/dynamic-demo-plugin/package.json
@@ -80,7 +80,8 @@
   "resolutions": {
     "minimatch@^3.0.2": "^3.1.3",
     "minimatch@^3.0.4": "^3.1.3",
-    "minimatch@^3.1.1": "^3.1.3"
+    "minimatch@^3.1.1": "^3.1.3",
+    "nanoid": "^3.3.12"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -3492,12 +3492,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "nanoid@npm:3.3.4"
+"nanoid@npm:^3.3.12":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/a0747d5c6021828fe8d38334e5afb05d3268d7d4b06024058ec894ccc47070e4e81d268a6b75488d2ff3485fa79a75c251d4b7c6f31051bb54bb662b6fd2a27d
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -4241,7 +4241,7 @@ __metadata:
   version: 8.4.21
   resolution: "postcss@npm:8.4.21"
   dependencies:
-    nanoid: "npm:^3.3.4"
+    nanoid: "npm:^3.3.12"
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 10c0/a26e7cc86a1807d624d9965914c26c20faa3f237184cbd69db537387f6a4f62df97347549144284d47e9e8e27e7c60e797cb3b92ad36cb2f4c3c9cb3b73f9758

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -369,7 +369,8 @@
     "minimatch@3.0.4": "^3.1.3",
     "minimatch@^3.1.1": "^3.1.3",
     "shell-quote": "^1.8.4",
-    "immutable": "3.8.3"
+    "immutable": "3.8.3",
+    "nanoid": "^3.3.12"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,gql,graphql}": "eslint --color --fix"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -17902,19 +17902,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^2.1.0":
-  version: 2.1.11
-  resolution: "nanoid@npm:2.1.11"
-  checksum: 10c0/8640d17698633ff78b2549ec8d5dffd8f56909bad1cf0da08bf3a4012f98553b1b9f2327a2d7fb3613084f33189a8ab4b889eb4c7939f3f9e242d9fd8ff059d5
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.6":
-  version: 3.3.6
-  resolution: "nanoid@npm:3.3.6"
+"nanoid@npm:^3.3.12":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/606b355960d0fcbe3d27924c4c52ef7d47d3b57208808ece73279420d91469b01ec1dce10fae512b6d4a8c5a5432b352b228336a8b2202a6ea68e67fa348e2ee
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes CVE-2026-73086 — Integer overflow in `nanoid`'s `nanoid(size)` function that corrupts the process-wide CSPRNG, causing all subsequent IDs to become deterministic.

### Resolutions added

**frontend/package.json:**
- `nanoid` → `^3.3.12`

**dynamic-demo-plugin/package.json:**
- `nanoid` → `^3.3.12`

Lockfiles regenerated.