### PR TITLE
OCPBUGS-95593: show OCP version in About modal for non-admin users

### DIFF
--- a/frontend/public/components/about-modal.tsx
+++ b/frontend/public/components/about-modal.tsx
@@ -75,7 +75,8 @@ const AboutModalItems: FC<AboutModalItemsProps> = ({ closeAboutModal }) => {
 
   const clusterID = getClusterID(clusterVersion);
   const channel: string = clusterVersion?.spec?.channel;
-  const openshiftVersion = getOpenShiftVersion(clusterVersion);
+  const openshiftVersion =
+    getOpenShiftVersion(clusterVersion) || window.SERVER_FLAGS.releaseVersion;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes [OCPBUGS-95593](https://redhat.atlassian.net/browse/OCPBUGS-95593): Non-admin users see only the Kubernetes version in the About modal ("?" > "About"), but not the OpenShift version.

The About modal uses `useClusterVersion()` which watches the `ClusterVersion` resource via the K8s API. Non-admin users lack RBAC access to this resource, so the hook returns null and the OpenShift version is hidden.

The fix falls back to `window.SERVER_FLAGS.releaseVersion`, which is set by the console backend at startup and is available to all users regardless of RBAC. This pattern is already used elsewhere in the codebase (e.g. `useTelemetry.ts`).

## Test plan

- [x] Admin users: version continues to come from `ClusterVersion` resource (with "Updating to..." state awareness)
- [x] Non-admin users: version falls back to `SERVER_FLAGS.releaseVersion`
- [ ] Verify About modal shows OCP version for a non-admin user on a running cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The About modal now displays the OpenShift version using a fallback value when the cluster-derived version is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->