### PR TITLE
OCPBUGS-105603: Strip version tag from OCI chart URL to prevent doubl…

### DIFF
--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
@@ -34,7 +34,7 @@ import { WizardStep } from './types';
 // Only OCI refs use tag (chart:version); HTTP/HTTPS chart URLs (.tgz) must not have :version appended
 const getFullChartURL = (chartURL: string, chartVersion: string): string => {
   if (!chartVersion) return chartURL;
-  if (!chartURL.startsWith('oci://')) return chartURL;
+  if (!/^oci:\/\//i.test(chartURL)) return chartURL;
   const tag = `:${chartVersion}`;
   const base = chartURL.endsWith(tag) ? chartURL.slice(0, -tag.length) : chartURL;
   return `${base}:${chartVersion}`;

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
@@ -32,10 +32,11 @@ import type { HelmURLChartFormData, HelmURLInstallFormData } from './types';
 import { WizardStep } from './types';
 
 // Only OCI refs use tag (chart:version); HTTP/HTTPS chart URLs (.tgz) must not have :version appended
-const getFullChartURL = (chartURL: string, chartVersion: string): string =>
-  chartVersion && /^oci:\/\//i.test(chartURL) && !chartURL.endsWith(`:${chartVersion}`)
-    ? `${chartURL}:${chartVersion}`
-    : chartURL;
+const getFullChartURL = (chartURL: string, chartVersion: string): string => {
+  if (!chartVersion || !/^oci:\/\//i.test(chartURL)) return chartURL;
+  const base = chartURL.replace(/:[^/]+$/, '');
+  return `${base}:${chartVersion}`;
+};
 
 const HelmURLChartInstallPage: FunctionComponent = () => {
   const params = useParams();

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
@@ -32,13 +32,10 @@ import type { HelmURLChartFormData, HelmURLInstallFormData } from './types';
 import { WizardStep } from './types';
 
 // Only OCI refs use tag (chart:version); HTTP/HTTPS chart URLs (.tgz) must not have :version appended
-const getFullChartURL = (chartURL: string, chartVersion: string): string => {
-  if (!chartVersion) return chartURL;
-  if (!/^oci:\/\//i.test(chartURL)) return chartURL;
-  const tag = `:${chartVersion}`;
-  const base = chartURL.endsWith(tag) ? chartURL.slice(0, -tag.length) : chartURL;
-  return `${base}:${chartVersion}`;
-};
+const getFullChartURL = (chartURL: string, chartVersion: string): string =>
+  chartVersion && /^oci:\/\//i.test(chartURL) && !chartURL.endsWith(`:${chartVersion}`)
+    ? `${chartURL}:${chartVersion}`
+    : chartURL;
 
 const HelmURLChartInstallPage: FunctionComponent = () => {
   const params = useParams();

--- a/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
+++ b/frontend/packages/helm-plugin/src/components/forms/url-chart/HelmURLChartInstallPage.tsx
@@ -34,8 +34,10 @@ import { WizardStep } from './types';
 // Only OCI refs use tag (chart:version); HTTP/HTTPS chart URLs (.tgz) must not have :version appended
 const getFullChartURL = (chartURL: string, chartVersion: string): string => {
   if (!chartVersion) return chartURL;
-  const isOCI = chartURL.startsWith('oci://');
-  return isOCI ? `${chartURL}:${chartVersion}` : chartURL;
+  if (!chartURL.startsWith('oci://')) return chartURL;
+  const tag = `:${chartVersion}`;
+  const base = chartURL.endsWith(tag) ? chartURL.slice(0, -tag.length) : chartURL;
+  return `${base}:${chartVersion}`;
 };
 
 const HelmURLChartInstallPage: FunctionComponent = () => {


### PR DESCRIPTION

When a user enters an OCI URL with an inline version tag (e.g. oci://registry/chart:1.0.0), strip the :version from chartURL so getFullChartURL does not re-append it when sending to the backend.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm chart URL handling for OCI repositories.
  * Prevented duplicate version tags on OCI chart URLs.
  * Preserved non-OCI URLs and OCI URLs that already include a version tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->