### PR TITLE
OCPBUGS-52186: Show CPU/Memory metrics for non-admin users on Projects page

### DIFF
--- a/frontend/public/components/namespace.jsx
+++ b/frontend/public/components/namespace.jsx
@@ -80,7 +80,7 @@ import { DetailsPage, ListPage, sorts } from './factory';
 import { sortResourceByValue } from './factory/Table/sort';
 import { Area } from './graphs/area';
 import { Bar } from './graphs/bar';
-import { PROMETHEUS_BASE_PATH } from './graphs/consts';
+import { PROMETHEUS_BASE_PATH, PROMETHEUS_TENANCY_BASE_PATH } from './graphs/consts';
 import { LazyConfigureNamespacePullSecretModalOverlay } from './modals';
 import { OverviewListPage } from './overview';
 import { RoleBindingsPage } from './RBAC';
@@ -156,6 +156,50 @@ const fetchNamespaceMetrics = () => {
       // eslint-disable-next-line no-console
       .catch(console.error)
   );
+};
+
+const DNS_LABEL_RE = /^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+const fetchNamespaceTenancyMetrics = async (namespaces) => {
+  if (!PROMETHEUS_TENANCY_BASE_PATH || namespaces.length === 0) {
+    return {};
+  }
+  const sanitizedNamespaces = namespaces.filter((ns) => DNS_LABEL_RE.test(ns));
+  if (sanitizedNamespaces.length === 0) {
+    return {};
+  }
+  const results = await Promise.all(
+    sanitizedNamespaces.map(async (ns) => {
+      const metrics = [
+        {
+          key: 'memory',
+          query: `sum(container_memory_working_set_bytes{namespace='${ns}',container='',pod!=''}) BY (namespace)`,
+        },
+        {
+          key: 'cpu',
+          query: `namespace:container_cpu_usage:sum{namespace='${ns}'}`,
+        },
+      ];
+      const metricResults = await Promise.all(
+        metrics.map(async ({ key, query }) => {
+          const url = `${PROMETHEUS_TENANCY_BASE_PATH}/api/v1/query?namespace=${ns}&query=${encodeURIComponent(query)}`;
+          try {
+            const {
+              data: { result },
+            } = await coFetchJSON(url);
+            if (result.length === 0) {
+              return {};
+            }
+            return { [key]: { [ns]: Number(result[0].value[1]) } };
+          } catch {
+            return {};
+          }
+        }),
+      );
+      return _.merge({}, ...metricResults);
+    }),
+  );
+  return _.merge({}, ...results);
 };
 
 const namespaceColumnInfo = [
@@ -739,21 +783,48 @@ const ProjectList = (props) => {
     true,
   );
   const isPrometheusAvailable = usePrometheusGate();
-  const showMetrics = isPrometheusAvailable && canGetNS;
+  const showMetrics = isPrometheusAvailable;
   const showActions = true;
   const { columns, resetAllColumnWidths } = useProjectsColumns({ showMetrics, showActions });
   const namespaceMetrics = useConsoleSelector(({ UI }) => UI.getIn(['metrics', 'namespace']));
 
+  const namespaces = useMemo(
+    () => (props.data || []).map((project) => project.metadata?.name).filter(Boolean),
+    [props.data],
+  );
+
   // TODO Utilize usePoll hook
   useEffect(() => {
-    if (showMetrics) {
-      const updateMetrics = () =>
-        fetchNamespaceMetrics().then((result) => dispatch(UIActions.setNamespaceMetrics(result)));
-      updateMetrics();
-      const id = setInterval(updateMetrics, 30 * 1000);
-      return () => clearInterval(id);
+    if (!showMetrics || flagPending(canGetNS)) {
+      return;
     }
-  }, [dispatch, showMetrics]);
+    let active = true;
+    const updateMetrics = async () => {
+      try {
+        const result = canGetNS
+          ? await fetchNamespaceMetrics()
+          : await fetchNamespaceTenancyMetrics(namespaces);
+        if (active) {
+          dispatch(UIActions.setNamespaceMetrics(result));
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    };
+    let id;
+    const poll = async () => {
+      await updateMetrics();
+      if (active) {
+        id = setTimeout(poll, 30 * 1000);
+      }
+    };
+    poll();
+    return () => {
+      active = false;
+      clearTimeout(id);
+    };
+  }, [dispatch, showMetrics, canGetNS, namespaces]);
 
   const columnLayout = useMemo(
     () => ({


### PR DESCRIPTION
**Analysis / Root cause**:
The Projects list page (Home > Projects) gated metrics column visibility on `CAN_GET_NS`, a cluster-scoped namespace GET permission that non-admin users lack. Additionally, `fetchNamespaceMetrics()` used the cluster-scoped Prometheus endpoint (`/api/prometheus`), which returns 403 for non-admin users. As a result, non-admin users either saw no CPU/Memory columns at all, or saw hyphens for all projects.

**Solution description**:
- Show the CPU/Memory columns for all users when Prometheus is available (removed `canGetNS` gate from `showMetrics`)
- Added `fetchNamespaceTenancyMetrics()` that queries the per-namespace Prometheus tenancy endpoint (`/api/prometheus-tenancy`) for non-admin users, following the same pattern used by `fetchOverviewMetrics` in `metricUtils.ts` and the pod list page
- Admin users (`canGetNS === true`) continue using the efficient single cluster-wide query via `fetchNamespaceMetrics()`

**Screenshots / screen recording**:
<!-- TODO: Add before/after screenshots -->

**Test setup:**
1. Create a non-admin user (e.g. htpasswd identity provider)
2. Grant the user `edit` access to a namespace with running pods consuming CPU/memory

**Test cases:**
- Log in as a non-admin user, navigate to Home > Projects, verify CPU and Memory columns are visible with actual values
- Log in as cluster-admin, verify CPU and Memory columns still work as before
- Verify no console errors related to metrics fetching

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
Jira: https://redhat.atlassian.net/browse/OCPBUGS-52186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CPU and memory metrics for projects within the current tenancy.
  * Project metrics now appear whenever monitoring data is available.
  * Metrics automatically use the broadest permitted view, with tenancy-scoped results when required.

* **Bug Fixes**
  * Improved handling of unavailable, invalid, empty, or failed metric queries.
  * Metric polling stays aligned with selected projects and pauses during access checks.
  * Prevented metric updates after leaving the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->