### PR TITLE
RFE-9104: sort nodes by Scheduling Disabled and blocking taints

### DIFF
--- a/frontend/packages/console-shared/src/sorts/__tests__/nodes.spec.ts
+++ b/frontend/packages/console-shared/src/sorts/__tests__/nodes.spec.ts
@@ -1,0 +1,97 @@
+import type { NodeKind, Taint } from '@console/internal/module/k8s';
+import { nodeReadiness } from '../nodes';
+
+jest.mock('@console/internal/actions/ui', () => ({
+  getNodeMetric: jest.fn(),
+}));
+jest.mock('@console/app/src/components/nodes/csr', () => ({
+  isCSRResource: jest.fn(),
+}));
+jest.mock('@console/internal/components/factory/Table/sort', () => ({
+  sortResourceByValue: jest.fn(),
+}));
+
+const readyCondition = (status: 'True' | 'False' | 'Unknown') => ({
+  type: 'Ready',
+  status,
+});
+
+const createNode = ({
+  readyStatus,
+  unschedulable = false,
+  taints,
+}: {
+  readyStatus?: 'True' | 'False' | 'Unknown';
+  unschedulable?: boolean;
+  taints?: Taint[];
+} = {}): NodeKind =>
+  ({
+    apiVersion: 'v1',
+    kind: 'Node',
+    metadata: { name: 'test-node' },
+    spec: {
+      unschedulable,
+      taints,
+    },
+    status: {
+      conditions: readyStatus ? [readyCondition(readyStatus)] : [],
+    },
+  }) as NodeKind;
+
+describe('nodeReadiness', () => {
+  it.each([
+    ['Ready', { readyStatus: 'True' as const }, 'True|0|0'],
+    ['Not Ready', { readyStatus: 'False' as const }, 'False|0|0'],
+    ['Unknown Ready status', { readyStatus: 'Unknown' as const }, 'Unknown|0|0'],
+    ['missing Ready condition defaults to Unknown', {}, 'Unknown|0|0'],
+    ['Ready + unschedulable', { readyStatus: 'True' as const, unschedulable: true }, 'True|1|0'],
+    [
+      'default control-plane taint does not change the key',
+      {
+        readyStatus: 'True' as const,
+        taints: [{ key: 'node-role.kubernetes.io/control-plane', value: '', effect: 'NoSchedule' }],
+      },
+      'True|0|0',
+    ],
+    [
+      'default master taint does not change the key',
+      {
+        readyStatus: 'True' as const,
+        taints: [{ key: 'node-role.kubernetes.io/master', value: '', effect: 'NoSchedule' }],
+      },
+      'True|0|0',
+    ],
+    [
+      'extra NoSchedule taint changes the key',
+      {
+        readyStatus: 'True' as const,
+        taints: [{ key: 'dedicated', value: 'infra', effect: 'NoSchedule' }],
+      },
+      'True|0|1',
+    ],
+    [
+      'extra NoExecute taint changes the key',
+      {
+        readyStatus: 'True' as const,
+        taints: [{ key: 'dedicated', value: 'infra', effect: 'NoExecute' }],
+      },
+      'True|0|1',
+    ],
+  ])('%s', (_name, nodeOpts, expected) => {
+    expect(nodeReadiness(createNode(nodeOpts))).toBe(expected);
+  });
+
+  it('splits Ready vs Not Ready so they do not share a sort key', () => {
+    const ready = nodeReadiness(createNode({ readyStatus: 'True' }));
+    const notReady = nodeReadiness(createNode({ readyStatus: 'False' }));
+    expect(ready).not.toBe(notReady);
+    expect(ready.startsWith('True|')).toBe(true);
+    expect(notReady.startsWith('False|')).toBe(true);
+  });
+
+  it('sorts Ready + unschedulable after Ready + schedulable', () => {
+    const schedulable = nodeReadiness(createNode({ readyStatus: 'True' }));
+    const unschedulable = nodeReadiness(createNode({ readyStatus: 'True', unschedulable: true }));
+    expect(schedulable < unschedulable).toBe(true);
+  });
+});

--- a/frontend/packages/console-shared/src/sorts/__tests__/nodes.spec.ts
+++ b/frontend/packages/console-shared/src/sorts/__tests__/nodes.spec.ts
@@ -11,20 +11,24 @@ jest.mock('@console/internal/components/factory/Table/sort', () => ({
   sortResourceByValue: jest.fn(),
 }));
 
+type NodeOpts = {
+  readyStatus?: 'True' | 'False' | 'Unknown';
+  unschedulable?: boolean;
+  taints?: Taint[];
+};
+
 const readyCondition = (status: 'True' | 'False' | 'Unknown') => ({
   type: 'Ready',
   status,
 });
 
-const createNode = ({
-  readyStatus,
-  unschedulable = false,
-  taints,
-}: {
-  readyStatus?: 'True' | 'False' | 'Unknown';
-  unschedulable?: boolean;
-  taints?: Taint[];
-} = {}): NodeKind =>
+const taint = (key: string, effect: Taint['effect'], value = ''): Taint => ({
+  key,
+  value,
+  effect,
+});
+
+const createNode = ({ readyStatus, unschedulable = false, taints }: NodeOpts = {}): NodeKind =>
   ({
     apiVersion: 'v1',
     kind: 'Node',
@@ -39,41 +43,41 @@ const createNode = ({
   }) as NodeKind;
 
 describe('nodeReadiness', () => {
-  it.each([
-    ['Ready', { readyStatus: 'True' as const }, 'True|0|0'],
-    ['Not Ready', { readyStatus: 'False' as const }, 'False|0|0'],
-    ['Unknown Ready status', { readyStatus: 'Unknown' as const }, 'Unknown|0|0'],
+  it.each<[string, NodeOpts, string]>([
+    ['Ready', { readyStatus: 'True' }, 'True|0|0'],
+    ['Not Ready', { readyStatus: 'False' }, 'False|0|0'],
+    ['Unknown Ready status', { readyStatus: 'Unknown' }, 'Unknown|0|0'],
     ['missing Ready condition defaults to Unknown', {}, 'Unknown|0|0'],
-    ['Ready + unschedulable', { readyStatus: 'True' as const, unschedulable: true }, 'True|1|0'],
+    ['Ready + unschedulable', { readyStatus: 'True', unschedulable: true }, 'True|1|0'],
     [
       'default control-plane taint does not change the key',
       {
-        readyStatus: 'True' as const,
-        taints: [{ key: 'node-role.kubernetes.io/control-plane', value: '', effect: 'NoSchedule' }],
+        readyStatus: 'True',
+        taints: [taint('node-role.kubernetes.io/control-plane', 'NoSchedule')],
       },
       'True|0|0',
     ],
     [
       'default master taint does not change the key',
       {
-        readyStatus: 'True' as const,
-        taints: [{ key: 'node-role.kubernetes.io/master', value: '', effect: 'NoSchedule' }],
+        readyStatus: 'True',
+        taints: [taint('node-role.kubernetes.io/master', 'NoSchedule')],
       },
       'True|0|0',
     ],
     [
       'extra NoSchedule taint changes the key',
       {
-        readyStatus: 'True' as const,
-        taints: [{ key: 'dedicated', value: 'infra', effect: 'NoSchedule' }],
+        readyStatus: 'True',
+        taints: [taint('dedicated', 'NoSchedule', 'infra')],
       },
       'True|0|1',
     ],
     [
       'extra NoExecute taint changes the key',
       {
-        readyStatus: 'True' as const,
-        taints: [{ key: 'dedicated', value: 'infra', effect: 'NoExecute' }],
+        readyStatus: 'True',
+        taints: [taint('dedicated', 'NoExecute', 'infra')],
       },
       'True|0|1',
     ],

--- a/frontend/packages/console-shared/src/sorts/nodes.ts
+++ b/frontend/packages/console-shared/src/sorts/nodes.ts
@@ -3,7 +3,24 @@ import { isCSRResource } from '@console/app/src/components/nodes/csr';
 import * as UIActions from '@console/internal/actions/ui';
 import { sortResourceByValue } from '@console/internal/components/factory/Table/sort';
 import type { NodeCertificateSigningRequestKind, NodeKind } from '@console/internal/module/k8s';
-import { getNodeUptime, getNodeMachineName, getNodeRoles } from '../selectors/node';
+import {
+  getNodeUptime,
+  getNodeMachineName,
+  getNodeRoles,
+  isNodeUnschedulable,
+} from '../selectors/node';
+
+const DEFAULT_CONTROL_PLANE_TAINT_KEYS = new Set([
+  'node-role.kubernetes.io/control-plane',
+  'node-role.kubernetes.io/master',
+]);
+
+const hasExtraBlockingTaint = (node: NodeKind): boolean =>
+  node?.spec?.taints?.some(
+    (taint) =>
+      (taint.effect === 'NoSchedule' || taint.effect === 'NoExecute') &&
+      !DEFAULT_CONTROL_PLANE_TAINT_KEYS.has(taint.key),
+  ) ?? false;
 
 export const nodeMemory = (node: NodeKind): number => {
   const used = UIActions.getNodeMetric(node, 'usedMemory');
@@ -25,9 +42,12 @@ export const nodeZone = (node: NodeKind): string =>
   node.metadata.labels?.['topology.kubernetes.io/zone'];
 export const nodeUptime = (node: NodeKind): string => getNodeUptime(node);
 
-export const nodeReadiness = (node: NodeKind) => {
-  const readiness = node?.status?.conditions?.find((c) => c.type === 'Ready');
-  return readiness?.status;
+export const nodeReadiness = (node: NodeKind): string => {
+  const readyStatus =
+    node?.status?.conditions?.find((c) => c.type === 'Ready')?.status ?? 'Unknown';
+  const unschedulable = isNodeUnschedulable(node) ? '1' : '0';
+  const extraBlockingTaint = hasExtraBlockingTaint(node) ? '1' : '0';
+  return `${readyStatus}|${unschedulable}|${extraBlockingTaint}`;
 };
 
 export const nodeRoles = (node: NodeKind) => {


### PR DESCRIPTION
**Analysis / Root cause**:
The Nodes page Status column sorts with `sortWithCSRResource(nodeReadiness, 'False')`. `nodeReadiness` only returned the Ready condition (`True` / `False` / `Unknown`), so cordoned nodes (`spec.unschedulable`) stayed mixed with other Ready nodes (often alphabetical by name). Display already shows “Scheduling disabled”; sort ignored it.

Jira: https://redhat.atlassian.net/browse/RFE-9104
Customer case: 04419258

Jeffrey Phillips confirmed this was not covered by the recent nodes-list work.

**Solution description**:
Treat this as incorrect sort behavior (bug fix), not a new UI feature.

Change `nodeReadiness` to a composite string sort key:

`${readyStatus}|${unschedulable}|${extraBlockingTaint}`

- `readyStatus`: Ready condition status, default `Unknown`
- `unschedulable`: `1` if `spec.unschedulable`, else `0` (existing `isNodeUnschedulable`)
- `extraBlockingTaint`: `1` only for `NoSchedule` / `NoExecute` taints that are **not** the default control-plane/master taints (`node-role.kubernetes.io/control-plane`, `node-role.kubernetes.io/master`)

Default control-plane/master taints are ignored so masters are not split out from workers.

**No new filter chips, columns, or UI labels.** `NodesPage.tsx` is unchanged.

**Type of change**:
- [x] Bug fix (incorrect Status sort; non-breaking)
- [ ] New feature

**Screenshots / screen recording**:
Screenshots pending (console not run locally). Expected grouping when sorting by Status: Ready schedulable nodes grouped together; Ready + Scheduling Disabled grouped after them as a separate block. Extra blocking taints also separate from untainted Ready nodes. Default master/control-plane taints do not create a separate group.

**Test setup:**
OpenShift cluster with at least one Ready worker node.

**Test cases:**
1. `oc adm cordon <node>`
2. Console → Compute → Nodes
3. Sort by Status
4. Actual (before): cordoned node stays mixed with Ready nodes (often alphabetical by name)
5. Expected (after): Ready schedulable grouped together; Ready + Scheduling Disabled grouped after (or before, but consistently separate)

Unit: `yarn test packages/console-shared/src/sorts/__tests__/nodes.spec.ts`
- Ready vs Not Ready still split
- Ready + unschedulable sorts after Ready + schedulable
- Default master/control-plane taint does not change the key
- Extra NoSchedule taint does change the key

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
If this should be tracked as OCPBUGS instead of RFE-9104, please clone/convert and I will retarget the PR.

**Reviewers and assignees:**
/cc @amobrem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Node readiness information now includes Ready status, schedulability, and blocking taint state.
  - Missing readiness information is displayed as “Unknown.”

- **Bug Fixes**
  - Improved readiness sorting and handling of unschedulable nodes and custom blocking taints.

- **Tests**
  - Added comprehensive coverage for readiness states, taints, schedulability, missing conditions, and sort ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->