### PR TITLE
OCPBUGS-70361: fix incomplete operand YAML when reopening the create form

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/__tests__/create-operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/__tests__/create-operand.spec.tsx
@@ -130,6 +130,118 @@ describe('CreateOperand', () => {
     });
   });
 
+  it('applies CRD schema defaults to sample data when starting in YAML mode (OCPBUGS-70361)', () => {
+    // When the editor starts directly in YAML mode (from a saved user preference),
+    // the @rjsf/core Form never mounts, so it never applies the CRD schema defaults
+    // as a side effect. CreateOperand must enrich the sample with schema defaults
+    // itself, so the YAML editor shows the same complete content as the Form-first path.
+
+    // Arrange: a CRD whose schema defines a spec default that is NOT in alm-examples
+    const crdWithSchemaDefault = {
+      ...testCRD,
+      spec: {
+        ...testCRD.spec,
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+            schema: {
+              openAPIV3Schema: {
+                type: 'object',
+                properties: {
+                  spec: {
+                    type: 'object',
+                    properties: {
+                      replicas: { type: 'integer', default: 3 },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+    mockUseK8sWatchResource.mockReturnValue([crdWithSchemaDefault, true, undefined]);
+
+    const csvWithMinimalExample = {
+      ...testClusterServiceVersion,
+      metadata: {
+        ...testClusterServiceVersion.metadata,
+        annotations: {
+          ...testClusterServiceVersion.metadata.annotations,
+          'alm-examples': JSON.stringify([
+            {
+              apiVersion: 'testapp.coreos.com/v1alpha1',
+              kind: 'TestResource',
+              metadata: { name: 'example-resource' },
+              spec: {},
+            },
+          ]),
+        },
+      },
+    };
+
+    // Act
+    renderWithProviders(
+      <CreateOperand
+        initialEditorType={EditorType.YAML}
+        csv={csvWithMinimalExample}
+        loaded
+        loadError={undefined}
+      />,
+    );
+
+    // Assert: the schema default was merged into the sample before reaching SyncedEditor
+    expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
+    const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
+    expect(syncedEditorProps.initialData.spec.replicas).toBe(3);
+  });
+
+  it('does not render SyncedEditor until the CRD watch has loaded (OCPBUGS-70361)', () => {
+    // Regression test for OCPBUGS-70361. SyncedEditor snapshots its initial YAML
+    // from the sample exactly once, on mount, and never re-syncs it. The sample is
+    // only enriched with CRD schema defaults once the CRD has loaded, so mounting
+    // SyncedEditor before the CRD watch resolves would freeze the raw, un-enriched
+    // YAML. CreateOperand must wait for the CRD watch to load before rendering.
+
+    // Arrange: CRD watch not yet loaded
+    mockUseK8sWatchResource.mockReturnValue([{}, false, undefined]);
+
+    // Act
+    renderWithProviders(
+      <CreateOperand
+        initialEditorType={EditorType.YAML}
+        csv={testClusterServiceVersion}
+        loaded
+        loadError={undefined}
+      />,
+    );
+
+    // Assert: editor is withheld until the schema is available
+    expect(mockSyncedEditor).not.toHaveBeenCalled();
+  });
+
+  it('passes an onCancel handler to the YAML editor via yamlContext (OCPBUGS-70361)', () => {
+    // Regression test for OCPBUGS-70361. The YAML view must cancel the same way the
+    // Form view does (back to the operator context) instead of falling through to
+    // EditYAML's generic navigate-to-list behavior, which drops the user onto the
+    // generic create page. CreateOperand supplies that handler via yamlContext.
+    renderWithProviders(
+      <CreateOperand
+        initialEditorType={EditorType.YAML}
+        csv={testClusterServiceVersion}
+        loaded
+        loadError={undefined}
+      />,
+    );
+
+    expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
+    const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
+    expect(typeof syncedEditorProps.context.yamlContext.onCancel).toBe('function');
+  });
+
   it('provides onChangeEditorType callback to SyncedEditor', () => {
     // Arrange
     renderWithProviders(
@@ -212,5 +324,25 @@ describe('OperandYAML', () => {
     expect(mockCreateYAML).toHaveBeenCalledTimes(1);
     const [createYAMLProps] = mockCreateYAML.mock.calls[0];
     expect(createYAMLProps.resourceObjPath).toBeUndefined();
+  });
+
+  it('forwards onCancel to CreateYAML when provided (OCPBUGS-70361)', () => {
+    const onCancel = jest.fn();
+
+    renderWithProviders(<OperandYAML onCancel={onCancel} />);
+
+    expect(mockCreateYAML).toHaveBeenCalledTimes(1);
+    const [createYAMLProps] = mockCreateYAML.mock.calls[0];
+    expect(createYAMLProps.onCancel).toBe(onCancel);
+  });
+
+  it('does not pass onCancel to CreateYAML when not provided', () => {
+    renderWithProviders(<OperandYAML />);
+
+    expect(mockCreateYAML).toHaveBeenCalledTimes(1);
+    const [createYAMLProps] = mockCreateYAML.mock.calls[0];
+    // The key must be absent (not merely undefined) so CreateYAML's conditional
+    // spread keeps `onCancel` out of the props it forwards to EditYAML.
+    expect('onCancel' in createYAMLProps).toBe(false);
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/__tests__/create-operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/__tests__/create-operand.spec.tsx
@@ -54,7 +54,6 @@ describe('CreateOperand', () => {
   });
 
   it('configures SyncedEditor with YAML as initialType when initialEditorType is YAML', () => {
-    // Arrange
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.YAML}
@@ -64,14 +63,12 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialType).toEqual(EditorType.YAML);
   });
 
   it('configures SyncedEditor with Form as initialType when initialEditorType is Form', () => {
-    // Arrange
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.Form}
@@ -81,14 +78,12 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialType).toEqual(EditorType.Form);
   });
 
   it('passes sample data to SyncedEditor when CSV contains alm-examples annotation', () => {
-    // Arrange
     const csvWithExamples = {
       ...testClusterServiceVersion,
       metadata: {
@@ -116,7 +111,6 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialData).toMatchObject({
@@ -136,7 +130,7 @@ describe('CreateOperand', () => {
     // as a side effect. CreateOperand must enrich the sample with schema defaults
     // itself, so the YAML editor shows the same complete content as the Form-first path.
 
-    // Arrange: a CRD whose schema defines a spec default that is NOT in alm-examples
+    // A CRD whose schema defines a spec default that is NOT in alm-examples
     const crdWithSchemaDefault = {
       ...testCRD,
       spec: {
@@ -183,7 +177,6 @@ describe('CreateOperand', () => {
       },
     };
 
-    // Act
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.YAML}
@@ -193,7 +186,7 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert: the schema default was merged into the sample before reaching SyncedEditor
+    // The schema default was merged into the sample before reaching SyncedEditor
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialData.spec.replicas).toBe(3);
@@ -206,10 +199,9 @@ describe('CreateOperand', () => {
     // SyncedEditor before the CRD watch resolves would freeze the raw, un-enriched
     // YAML. CreateOperand must wait for the CRD watch to load before rendering.
 
-    // Arrange: CRD watch not yet loaded
+    // CRD watch not yet loaded
     mockUseK8sWatchResource.mockReturnValue([{}, false, undefined]);
 
-    // Act
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.YAML}
@@ -219,7 +211,7 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert: editor is withheld until the schema is available
+    // Editor is withheld until the schema is available
     expect(mockSyncedEditor).not.toHaveBeenCalled();
   });
 
@@ -243,7 +235,6 @@ describe('CreateOperand', () => {
   });
 
   it('provides onChangeEditorType callback to SyncedEditor', () => {
-    // Arrange
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.Form}
@@ -253,7 +244,6 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.onChangeEditorType).toBeDefined();
@@ -336,13 +326,11 @@ describe('OperandYAML', () => {
     expect(createYAMLProps.onCancel).toBe(onCancel);
   });
 
-  it('does not pass onCancel to CreateYAML when not provided', () => {
+  it('leaves onCancel undefined when not provided, so EditYAML falls back to its default cancel behavior', () => {
     renderWithProviders(<OperandYAML />);
 
     expect(mockCreateYAML).toHaveBeenCalledTimes(1);
     const [createYAMLProps] = mockCreateYAML.mock.calls[0];
-    // The key must be absent (not merely undefined) so CreateYAML's conditional
-    // spread keeps `onCancel` out of the props it forwards to EditYAML.
-    expect('onCancel' in createYAMLProps).toBe(false);
+    expect(createYAMLProps.onCancel).toBeUndefined();
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/__tests__/create-operand.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/__tests__/create-operand.spec.tsx
@@ -54,7 +54,6 @@ describe('CreateOperand', () => {
   });
 
   it('configures SyncedEditor with YAML as initialType when initialEditorType is YAML', () => {
-    // Arrange
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.YAML}
@@ -64,14 +63,12 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialType).toEqual(EditorType.YAML);
   });
 
   it('configures SyncedEditor with Form as initialType when initialEditorType is Form', () => {
-    // Arrange
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.Form}
@@ -81,14 +78,12 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialType).toEqual(EditorType.Form);
   });
 
   it('passes sample data to SyncedEditor when CSV contains alm-examples annotation', () => {
-    // Arrange
     const csvWithExamples = {
       ...testClusterServiceVersion,
       metadata: {
@@ -116,7 +111,6 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialData).toMatchObject({
@@ -130,13 +124,13 @@ describe('CreateOperand', () => {
     });
   });
 
-  it('applies CRD schema defaults to sample data when starting in YAML mode (OCPBUGS-70361)', () => {
+  it('applies CRD schema defaults to sample data when starting in YAML mode', () => {
     // When the editor starts directly in YAML mode (from a saved user preference),
     // the @rjsf/core Form never mounts, so it never applies the CRD schema defaults
     // as a side effect. CreateOperand must enrich the sample with schema defaults
     // itself, so the YAML editor shows the same complete content as the Form-first path.
 
-    // Arrange: a CRD whose schema defines a spec default that is NOT in alm-examples
+    // A CRD whose schema defines a spec default that is NOT in alm-examples
     const crdWithSchemaDefault = {
       ...testCRD,
       spec: {
@@ -183,7 +177,6 @@ describe('CreateOperand', () => {
       },
     };
 
-    // Act
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.YAML}
@@ -193,23 +186,22 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert: the schema default was merged into the sample before reaching SyncedEditor
+    // The schema default was merged into the sample before reaching SyncedEditor
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.initialData.spec.replicas).toBe(3);
   });
 
-  it('does not render SyncedEditor until the CRD watch has loaded (OCPBUGS-70361)', () => {
-    // Regression test for OCPBUGS-70361. SyncedEditor snapshots its initial YAML
+  it('does not render SyncedEditor until the CRD watch has loaded', () => {
+    // SyncedEditor snapshots its initial YAML
     // from the sample exactly once, on mount, and never re-syncs it. The sample is
     // only enriched with CRD schema defaults once the CRD has loaded, so mounting
     // SyncedEditor before the CRD watch resolves would freeze the raw, un-enriched
     // YAML. CreateOperand must wait for the CRD watch to load before rendering.
 
-    // Arrange: CRD watch not yet loaded
+    // CRD watch not yet loaded
     mockUseK8sWatchResource.mockReturnValue([{}, false, undefined]);
 
-    // Act
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.YAML}
@@ -219,12 +211,96 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert: editor is withheld until the schema is available
+    // Editor is withheld until the schema is available
     expect(mockSyncedEditor).not.toHaveBeenCalled();
   });
 
-  it('passes an onCancel handler to the YAML editor via yamlContext (OCPBUGS-70361)', () => {
-    // Regression test for OCPBUGS-70361. The YAML view must cancel the same way the
+  it('prune function uses raw sample so empty-string schema defaults are stripped on submit', () => {
+    // getDefaultFormState can produce empty-string
+    // defaults (e.g. logging.level: "") for enum fields where no default is specified.
+    // If the enriched sample is used as the prune template, definedAndEmpty() treats the
+    // empty string as intentional and preserves it in the submitted data, causing API
+    // errors like "Unsupported value: ""; supported values: debug, info, error".
+    // The prune function must use rawSample (not the enriched sample) as its template
+    // so that empty-string schema defaults are still stripped before submission.
+
+    const crdWithEmptyStringDefault = {
+      ...testCRD,
+      spec: {
+        ...testCRD.spec,
+        versions: [
+          {
+            name: 'v1alpha1',
+            served: true,
+            storage: true,
+            schema: {
+              openAPIV3Schema: {
+                type: 'object',
+                properties: {
+                  spec: {
+                    type: 'object',
+                    properties: {
+                      // enum field with no default — getDefaultFormState fills this with ""
+                      loggingLevel: {
+                        type: 'string',
+                        enum: ['debug', 'info', 'error'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+    mockUseK8sWatchResource.mockReturnValue([crdWithEmptyStringDefault, true, undefined]);
+
+    const csvWithMinimalExample = {
+      ...testClusterServiceVersion,
+      metadata: {
+        ...testClusterServiceVersion.metadata,
+        annotations: {
+          ...testClusterServiceVersion.metadata.annotations,
+          // alm-example does NOT include loggingLevel
+          'alm-examples': JSON.stringify([
+            {
+              apiVersion: 'testapp.coreos.com/v1alpha1',
+              kind: 'TestResource',
+              metadata: { name: 'example-resource' },
+              spec: {},
+            },
+          ]),
+        },
+      },
+    };
+
+    renderWithProviders(
+      <CreateOperand
+        initialEditorType={EditorType.Form}
+        csv={csvWithMinimalExample}
+        loaded
+        loadError={undefined}
+      />,
+    );
+
+    expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
+    const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
+
+    // Simulate the form submitting data where loggingLevel is "" (as getDefaultFormState
+    // would populate it). The prune function must strip it since rawSample has no loggingLevel.
+    const submittedData = {
+      apiVersion: 'testapp.coreos.com/v1alpha1',
+      kind: 'TestResource',
+      metadata: { name: 'example-resource' },
+      spec: { loggingLevel: '' },
+    };
+    const pruned = syncedEditorProps.prune(submittedData);
+    expect(pruned.spec.loggingLevel).toBeUndefined();
+  });
+
+  it('passes an onCancel handler to the YAML editor via yamlContext', () => {
+    // The YAML view must cancel the same way the
     // Form view does (back to the operator context) instead of falling through to
     // EditYAML's generic navigate-to-list behavior, which drops the user onto the
     // generic create page. CreateOperand supplies that handler via yamlContext.
@@ -243,7 +319,6 @@ describe('CreateOperand', () => {
   });
 
   it('provides onChangeEditorType callback to SyncedEditor', () => {
-    // Arrange
     renderWithProviders(
       <CreateOperand
         initialEditorType={EditorType.Form}
@@ -253,7 +328,6 @@ describe('CreateOperand', () => {
       />,
     );
 
-    // Assert
     expect(mockSyncedEditor).toHaveBeenCalledTimes(1);
     const [syncedEditorProps] = mockSyncedEditor.mock.calls[0];
     expect(syncedEditorProps.onChangeEditorType).toBeDefined();
@@ -326,7 +400,7 @@ describe('OperandYAML', () => {
     expect(createYAMLProps.resourceObjPath).toBeUndefined();
   });
 
-  it('forwards onCancel to CreateYAML when provided (OCPBUGS-70361)', () => {
+  it('forwards onCancel to CreateYAML when provided', () => {
     const onCancel = jest.fn();
 
     renderWithProviders(<OperandYAML onCancel={onCancel} />);
@@ -336,13 +410,11 @@ describe('OperandYAML', () => {
     expect(createYAMLProps.onCancel).toBe(onCancel);
   });
 
-  it('does not pass onCancel to CreateYAML when not provided', () => {
+  it('leaves onCancel undefined when not provided, so EditYAML falls back to its default cancel behavior', () => {
     renderWithProviders(<OperandYAML />);
 
     expect(mockCreateYAML).toHaveBeenCalledTimes(1);
     const [createYAMLProps] = mockCreateYAML.mock.calls[0];
-    // The key must be absent (not merely undefined) so CreateYAML's conditional
-    // spread keeps `onCancel` out of the props it forwards to EditYAML.
-    expect('onCancel' in createYAMLProps).toBe(false);
+    expect(createYAMLProps.onCancel).toBeUndefined();
   });
 });

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { useState, useMemo, useCallback } from 'react';
+import { getDefaultFormState } from '@rjsf/core/dist/cjs/utils';
 import type { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -37,6 +38,7 @@ import { DEFAULT_K8S_SCHEMA } from './const';
 import { DEPRECATED_CreateOperandForm } from './DEPRECATED_operand-form';
 import { OperandForm } from './operand-form';
 import { OperandYAML } from './operand-yaml';
+import { useOperandCancel } from './use-operand-cancel';
 
 export const CreateOperand: FC<CreateOperandProps> = ({
   initialEditorType,
@@ -47,7 +49,7 @@ export const CreateOperand: FC<CreateOperandProps> = ({
   const { t } = useTranslation('olm');
   const params = useParams();
   const [model] = useK8sModel(params.plural);
-  const [crd] = useK8sWatchResource<CustomResourceDefinitionKind>(
+  const [crd, crdLoaded] = useK8sWatchResource<CustomResourceDefinitionKind>(
     model
       ? {
           kind: CustomResourceDefinitionModel.kind,
@@ -63,6 +65,7 @@ export const CreateOperand: FC<CreateOperandProps> = ({
 
   const [activePerspective] = useActivePerspective();
   const [helpText, setHelpText] = useState(formHelpText);
+  const onCancel = useOperandCancel(csv);
   const next =
     activePerspective === 'dev'
       ? '/topology'
@@ -97,7 +100,17 @@ export const CreateOperand: FC<CreateOperandProps> = ({
         ];
   }, [baseSchema]);
 
-  const sample = useMemo<K8sResourceKind>(() => exampleForModel(csv, model), [csv, model]);
+  const sample = useMemo<K8sResourceKind>(() => {
+    const rawSample = exampleForModel(csv, model);
+    if (!schema || !rawSample) {
+      return rawSample;
+    }
+    try {
+      return getDefaultFormState(schema, rawSample, schema) as K8sResourceKind;
+    } catch {
+      return rawSample;
+    }
+  }, [csv, model, schema]);
 
   const pruneFunc = useCallback((data) => prune(data, sample), [sample]);
 
@@ -116,8 +129,15 @@ export const CreateOperand: FC<CreateOperandProps> = ({
 
   const LAST_VIEWED_EDITOR_TYPE_USER_PREFERENCE_KEY = 'console.createOperandForm.editor.lastView';
 
+  // Wait for the CRD watch to resolve before rendering the editor. SyncedEditor
+  // snapshots its initial YAML from `sample` once, on mount, and never re-syncs it
+  // when `sample` later changes. Since `sample` is only enriched with CRD schema
+  // defaults once `crd` (and therefore `schema`) has loaded, mounting the editor
+  // before then would freeze the raw, un-enriched YAML in the YAML-first view.
+  // `crdLoaded` becomes true once the CRD is loaded or errors, so the
+  // fallback-schema path is unaffected.
   return (
-    <StatusBox loaded={loaded} loadError={loadError} data={csv}>
+    <StatusBox loaded={loaded && crdLoaded} loadError={loadError} data={csv}>
       <PageHeading
         title={t('Create {{item}}', { item: model.label })}
         badge={getBadgeFromType(model.badge)}
@@ -126,7 +146,7 @@ export const CreateOperand: FC<CreateOperandProps> = ({
       <SyncedEditor
         context={{
           formContext: { csv, model, next, schema, providedAPI },
-          yamlContext: { next },
+          yamlContext: { next, onCancel },
         }}
         FormEditor={FormComponent}
         initialData={sample}

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -136,13 +136,7 @@ export const CreateOperand: FC<CreateOperandProps> = ({
 
   const LAST_VIEWED_EDITOR_TYPE_USER_PREFERENCE_KEY = 'console.createOperandForm.editor.lastView';
 
-  // Wait for the CRD watch to resolve before rendering the editor. SyncedEditor
-  // snapshots its initial YAML from `sample` once, on mount, and never re-syncs it
-  // when `sample` later changes. Since `sample` is only enriched with CRD schema
-  // defaults once `crd` (and therefore `schema`) has loaded, mounting the editor
-  // before then would freeze the raw, un-enriched YAML in the YAML-first view.
-  // `crdLoaded` becomes true once the CRD is loaded or errors, so the
-  // fallback-schema path is unaffected.
+  //  Wait for CRD before mounting SyncedEditor so sample is enriched, not raw data
   return (
     <StatusBox loaded={loaded && crdLoaded} loadError={loadError} data={csv}>
       <PageHeading

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -136,7 +136,7 @@ export const CreateOperand: FC<CreateOperandProps> = ({
 
   const LAST_VIEWED_EDITOR_TYPE_USER_PREFERENCE_KEY = 'console.createOperandForm.editor.lastView';
 
-  //  Wait for CRD before mounting SyncedEditor so sample is enriched, not raw data
+  // Wait for CRD before mounting SyncedEditor so sample is enriched, not raw data
   return (
     <StatusBox loaded={loaded && crdLoaded} loadError={loadError} data={csv}>
       <PageHeading

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/create-operand.tsx
@@ -100,19 +100,26 @@ export const CreateOperand: FC<CreateOperandProps> = ({
         ];
   }, [baseSchema]);
 
+  const rawSample = useMemo<K8sResourceKind>(() => exampleForModel(csv, model), [csv, model]);
+
+  // Enrich the sample with CRD schema defaults so the YAML editor shows the same
+  // non-empty defaults as the Form-first path (e.g. logLevel: Normal). Pruning the
+  // enriched result against rawSample strips the empty scaffold objects and arrays
+  // that getDefaultFormState generates for optional nested fields (e.g.
+  // multiKueue.externalFrameworks: [{}]), which the API would reject as invalid.
   const sample = useMemo<K8sResourceKind>(() => {
-    const rawSample = exampleForModel(csv, model);
     if (!schema || !rawSample) {
       return rawSample;
     }
     try {
-      return getDefaultFormState(schema, rawSample, schema) as K8sResourceKind;
+      const enriched = getDefaultFormState(schema, rawSample, schema) as K8sResourceKind;
+      return prune(enriched, rawSample);
     } catch {
       return rawSample;
     }
-  }, [csv, model, schema]);
+  }, [rawSample, schema]);
 
-  const pruneFunc = useCallback((data) => prune(data, sample), [sample]);
+  const pruneFunc = useCallback((data) => prune(data, rawSample), [rawSample]);
 
   const onChangeEditorType = useCallback(
     (newMethod) => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-form.tsx
@@ -4,16 +4,16 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import type { JSONSchema7 } from 'json-schema';
 import * as _ from 'lodash';
 import { useParams, useNavigate } from 'react-router';
-import { resourcePathFromModel, useScrollToTopOnMount } from '@console/internal/components/utils';
+import { useScrollToTopOnMount } from '@console/internal/components/utils';
 import type { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { k8sCreate } from '@console/internal/module/k8s';
 import { DynamicForm } from '@console/shared/src/components/dynamic-form/DynamicForm';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import { MarkdownView } from '@console/shared/src/components/markdown/MarkdownView';
 import { useResourceConnectionHandler } from '@console/shared/src/hooks/useResourceConnectionHandler';
-import { ClusterServiceVersionModel } from '../../models';
 import type { ClusterServiceVersionKind, CRDDescription, APIServiceDefinition } from '../../types';
 import { ClusterServiceVersionLogo } from '../cluster-service-version-logo';
+import { useOperandCancel } from './use-operand-cancel';
 import { getUISchema } from './utils';
 
 export const OperandForm: FC<OperandFormProps> = ({
@@ -48,20 +48,7 @@ export const OperandForm: FC<OperandFormProps> = ({
       .catch((e) => setErrors([e.message]));
   };
 
-  const handleCancel = () => {
-    if (new URLSearchParams(window.location.search).has('useInitializationResource')) {
-      navigate(
-        resourcePathFromModel(
-          ClusterServiceVersionModel,
-          csv.metadata.name,
-          csv.metadata.namespace,
-        ),
-        { replace: true },
-      );
-    } else {
-      navigate(-1);
-    }
-  };
+  const handleCancel = useOperandCancel(csv);
 
   const uiSchema = useMemo(() => getUISchema(schema, providedAPI), [schema, providedAPI]);
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
@@ -4,17 +4,24 @@ import { CreateYAML } from '@console/internal/components/create-yaml';
 /**
  * Component which wraps the YAML editor to ensure the templates are added from the `ClusterServiceVersion` annotations.
  */
-export const OperandYAML: FC<OperandYAMLProps> = ({ onChange, next, initialYAML = '' }) => (
+export const OperandYAML: FC<OperandYAMLProps> = ({
+  onCancel,
+  onChange,
+  next,
+  initialYAML = '',
+}) => (
   <CreateYAML
     hideHeader
     onChange={onChange}
     template={initialYAML}
     {...(next && { resourceObjPath: () => next })}
+    {...(onCancel && { onCancel })}
   />
 );
 
 export type OperandYAMLProps = {
   initialYAML?: string;
+  onCancel?: () => void;
   onChange?: (yaml: string) => void;
   next?: string;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { CreateYAML } from '@console/internal/components/create-yaml';
+import type { CreateYAMLProps } from '@console/internal/components/create-yaml';
 
 /**
  * Component which wraps the YAML editor to ensure the templates are added from the `ClusterServiceVersion` annotations.
@@ -19,9 +20,8 @@ export const OperandYAML: FC<OperandYAMLProps> = ({
   />
 );
 
-export type OperandYAMLProps = {
+export type OperandYAMLProps = Pick<CreateYAMLProps, 'onCancel'> & {
   initialYAML?: string;
-  onCancel?: () => void;
   onChange?: (yaml: string) => void;
   next?: string;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
@@ -13,9 +13,9 @@ export const OperandYAML: FC<OperandYAMLProps> = ({
   <CreateYAML
     hideHeader
     onChange={onChange}
+    onCancel={onCancel}
     template={initialYAML}
     {...(next && { resourceObjPath: () => next })}
-    {...(onCancel && { onCancel })}
   />
 );
 

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/operand-yaml.tsx
@@ -20,8 +20,7 @@ export const OperandYAML: FC<OperandYAMLProps> = ({
   />
 );
 
-export type OperandYAMLProps = Pick<CreateYAMLProps, 'onCancel'> & {
-  initialYAML?: string;
-  onChange?: (yaml: string) => void;
+export type OperandYAMLProps = Pick<CreateYAMLProps, 'onCancel' | 'onChange'> & {
   next?: string;
+  initialYAML?: string;
 };

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/use-operand-cancel.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/use-operand-cancel.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router';
+import { resourcePathFromModel } from '@console/internal/components/utils';
+import { ClusterServiceVersionModel } from '../../models';
+import type { ClusterServiceVersionKind } from '../../types';
+
+/**
+ * Cancel handler shared by the operand create Form and YAML views so both return the
+ * user to the same place: the CSV details page when creating from an initialization
+ * resource, otherwise back to wherever the user came from (typically the operator's
+ * operand tab).
+ *
+ * Fixes OCPBUGS-70361: the YAML view previously fell through to EditYAML's generic
+ * navigate-to-list behavior, dropping the user onto the generic (non-operator-aware)
+ * create page. On retry that page shows an incomplete CR, so steps 3 and 4 of the bug
+ * no longer matched. Mirroring the Form view's long-standing cancel behavior keeps the
+ * retry on the operand editor.
+ */
+export const useOperandCancel = (csv: ClusterServiceVersionKind): (() => void) => {
+  const navigate = useNavigate();
+  return useCallback(() => {
+    if (new URLSearchParams(window.location.search).has('useInitializationResource')) {
+      navigate(
+        resourcePathFromModel(
+          ClusterServiceVersionModel,
+          csv.metadata.name,
+          csv.metadata.namespace,
+        ),
+        { replace: true },
+      );
+    } else {
+      navigate(-1);
+    }
+  }, [navigate, csv]);
+};

--- a/frontend/packages/operator-lifecycle-manager/src/components/operand/use-operand-cancel.ts
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operand/use-operand-cancel.ts
@@ -1,25 +1,18 @@
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { resourcePathFromModel } from '@console/internal/components/utils';
 import { ClusterServiceVersionModel } from '../../models';
 import type { ClusterServiceVersionKind } from '../../types';
 
 /**
  * Cancel handler shared by the operand create Form and YAML views so both return the
- * user to the same place: the CSV details page when creating from an initialization
- * resource, otherwise back to wherever the user came from (typically the operator's
- * operand tab).
- *
- * Fixes OCPBUGS-70361: the YAML view previously fell through to EditYAML's generic
- * navigate-to-list behavior, dropping the user onto the generic (non-operator-aware)
- * create page. On retry that page shows an incomplete CR, so steps 3 and 4 of the bug
- * no longer matched. Mirroring the Form view's long-standing cancel behavior keeps the
- * retry on the operand editor.
+ * user to the same place.
  */
 export const useOperandCancel = (csv: ClusterServiceVersionKind): (() => void) => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   return useCallback(() => {
-    if (new URLSearchParams(window.location.search).has('useInitializationResource')) {
+    if (searchParams.has('useInitializationResource')) {
       navigate(
         resourcePathFromModel(
           ClusterServiceVersionModel,
@@ -31,5 +24,5 @@ export const useOperandCancel = (csv: ClusterServiceVersionKind): (() => void) =
     } else {
       navigate(-1);
     }
-  }, [navigate, csv]);
+  }, [navigate, searchParams, csv]);
 };

--- a/frontend/public/components/__tests__/create-yaml.spec.tsx
+++ b/frontend/public/components/__tests__/create-yaml.spec.tsx
@@ -4,12 +4,15 @@ import { useResolvedExtensions } from '@console/dynamic-plugin-sdk/src/api/useRe
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
 import { PodModel, ConfigMapModel } from '../../models';
 import { CreateYAMLInner } from '../create-yaml';
+import { AsyncComponent } from '../utils/async';
 
 jest.mock('../utils/async', () => ({
-  AsyncComponent: ({ initialResource, header, create }) =>
-    `YAML Editor: ${header} (${create ? 'Create' : 'Edit'}) - Resource: ${JSON.stringify(
-      initialResource,
-    )}`,
+  AsyncComponent: jest.fn(
+    ({ initialResource, header, create }) =>
+      `YAML Editor: ${header} (${create ? 'Create' : 'Edit'}) - Resource: ${JSON.stringify(
+        initialResource,
+      )}`,
+  ),
 }));
 
 jest.mock('../utils/status-box', () => ({
@@ -28,6 +31,7 @@ describe('CreateYAMLInner', () => {
   const defaultParams = { ns: 'default', plural: 'pods' };
 
   const mockUseResolvedExtensions = useResolvedExtensions as jest.Mock;
+  const mockAsyncComponent = AsyncComponent as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -137,6 +141,37 @@ describe('CreateYAMLInner', () => {
       expect(editorText).toContain('"metadata"');
       expect(editorText).toContain('"namespace":"default"');
       expect(editorText).toContain('"spec"');
+    });
+  });
+
+  describe('onCancel forwarding (OCPBUGS-70361)', () => {
+    it('forwards onCancel to the editor when provided', async () => {
+      const onCancel = jest.fn();
+
+      renderWithProviders(
+        <CreateYAMLInner
+          params={defaultParams}
+          kindsInFlight={false}
+          kindObj={PodModel}
+          onCancel={onCancel}
+        />,
+      );
+
+      expect(mockAsyncComponent).toHaveBeenCalledTimes(1);
+      const [asyncProps] = mockAsyncComponent.mock.calls[0];
+      expect(asyncProps.onCancel).toBe(onCancel);
+    });
+
+    it('does not set an onCancel prop when none is provided, preserving the default cancel behavior', async () => {
+      renderWithProviders(
+        <CreateYAMLInner params={defaultParams} kindsInFlight={false} kindObj={PodModel} />,
+      );
+
+      expect(mockAsyncComponent).toHaveBeenCalledTimes(1);
+      const [asyncProps] = mockAsyncComponent.mock.calls[0];
+      // The key must be absent (not merely undefined) so EditYAML's
+      // `'onCancel' in props` check falls back to navigateToResourceList.
+      expect('onCancel' in asyncProps).toBe(false);
     });
   });
 });

--- a/frontend/public/components/__tests__/create-yaml.spec.tsx
+++ b/frontend/public/components/__tests__/create-yaml.spec.tsx
@@ -162,16 +162,14 @@ describe('CreateYAMLInner', () => {
       expect(asyncProps.onCancel).toBe(onCancel);
     });
 
-    it('does not set an onCancel prop when none is provided, preserving the default cancel behavior', async () => {
+    it('leaves onCancel undefined when none is provided, so EditYAML falls back to its default cancel behavior', async () => {
       renderWithProviders(
         <CreateYAMLInner params={defaultParams} kindsInFlight={false} kindObj={PodModel} />,
       );
 
       expect(mockAsyncComponent).toHaveBeenCalledTimes(1);
       const [asyncProps] = mockAsyncComponent.mock.calls[0];
-      // The key must be absent (not merely undefined) so EditYAML's
-      // `'onCancel' in props` check falls back to navigateToResourceList.
-      expect('onCancel' in asyncProps).toBe(false);
+      expect(asyncProps.onCancel).toBeUndefined();
     });
   });
 });

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -21,6 +21,7 @@ export const CreateYAMLInner: FC<CreateYAMLProps> = ({
   kindObj,
   hideHeader = false,
   onChange = () => null,
+  onCancel,
   resourceObjPath,
   isCreate = true,
   template,
@@ -99,6 +100,11 @@ export const CreateYAMLInner: FC<CreateYAMLProps> = ({
       hideHeader={hideHeader}
       resourceObjPath={resourceObjPath}
       onChange={onChange}
+      // Only forward onCancel when provided. EditYAML falls back to its default
+      // navigate-to-list behavior via `'onCancel' in props`, so passing an
+      // explicit `onCancel={undefined}` would suppress that default for other
+      // consumers that rely on it.
+      {...(onCancel && { onCancel })}
     />
   );
 };
@@ -148,6 +154,7 @@ export type CreateYAMLProps = {
   isCreate?: boolean;
   resourceObjPath?: (obj: K8sResourceKind, kind: K8sResourceKindReference) => string;
   onChange?: (yaml: string) => any;
+  onCancel?: () => void;
 };
 
 export type EditYAMLPageProps = {

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -9,7 +9,7 @@ import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watc
 import { safeYAMLToJS } from '@console/shared/src/utils/yaml';
 import { connectToPlural } from '../kinds';
 import { getYAMLTemplates } from '../models/yaml-templates';
-import type { K8sKind, K8sResourceKindReference, K8sResourceKind } from '../module/k8s';
+import type { K8sKind, K8sResourceKind } from '../module/k8s';
 import { apiVersionForModel, referenceForModel } from '../module/k8s';
 import type { EditYAMLProps } from './edit-yaml';
 import { ErrorPage404 } from './error';
@@ -139,18 +139,17 @@ export const EditYAMLPage: FC<EditYAMLPageProps> = (props) => {
   );
 };
 
-export type CreateYAMLProps = Pick<EditYAMLProps, 'onCancel'> & {
+export type CreateYAMLProps = Pick<
+  EditYAMLProps,
+  'onCancel' | 'onChange' | 'resourceObjPath' | 'hideHeader' | 'header'
+> & {
   match?: any;
   params?: any;
   kindsInFlight: boolean;
   kindObj: K8sKind;
   template?: string;
   download?: boolean;
-  header?: string;
-  hideHeader?: boolean;
   isCreate?: boolean;
-  resourceObjPath?: (obj: K8sResourceKind, kind: K8sResourceKindReference) => string;
-  onChange?: (yaml: string) => any;
 };
 
 export type EditYAMLPageProps = {

--- a/frontend/public/components/create-yaml.tsx
+++ b/frontend/public/components/create-yaml.tsx
@@ -11,6 +11,7 @@ import { connectToPlural } from '../kinds';
 import { getYAMLTemplates } from '../models/yaml-templates';
 import type { K8sKind, K8sResourceKindReference, K8sResourceKind } from '../module/k8s';
 import { apiVersionForModel, referenceForModel } from '../module/k8s';
+import type { EditYAMLProps } from './edit-yaml';
 import { ErrorPage404 } from './error';
 import { AsyncComponent } from './utils/async';
 import { LoadingBox } from './utils/status-box';
@@ -100,11 +101,7 @@ export const CreateYAMLInner: FC<CreateYAMLProps> = ({
       hideHeader={hideHeader}
       resourceObjPath={resourceObjPath}
       onChange={onChange}
-      // Only forward onCancel when provided. EditYAML falls back to its default
-      // navigate-to-list behavior via `'onCancel' in props`, so passing an
-      // explicit `onCancel={undefined}` would suppress that default for other
-      // consumers that rely on it.
-      {...(onCancel && { onCancel })}
+      onCancel={onCancel}
     />
   );
 };
@@ -142,7 +139,7 @@ export const EditYAMLPage: FC<EditYAMLPageProps> = (props) => {
   );
 };
 
-export type CreateYAMLProps = {
+export type CreateYAMLProps = Pick<EditYAMLProps, 'onCancel'> & {
   match?: any;
   params?: any;
   kindsInFlight: boolean;
@@ -154,7 +151,6 @@ export type CreateYAMLProps = {
   isCreate?: boolean;
   resourceObjPath?: (obj: K8sResourceKind, kind: K8sResourceKindReference) => string;
   onChange?: (yaml: string) => any;
-  onCancel?: () => void;
 };
 
 export type EditYAMLPageProps = {

--- a/frontend/public/components/edit-yaml.tsx
+++ b/frontend/public/components/edit-yaml.tsx
@@ -240,7 +240,7 @@ const EditYAMLInner: FC<EditYAMLInnerProps> = (props) => {
     }
   };
   const displayedVersion = useRef('0');
-  const onCancel = 'onCancel' in props ? props.onCancel : navigateToResourceList;
+  const onCancel = props?.onCancel ? props.onCancel : navigateToResourceList;
 
   async function createResources(objs) {
     const results = [];


### PR DESCRIPTION
**Description:**

When you open an operator's Create form, cancel from YAML view, and click Create again, the YAML came back incomplete. Two fixes: enrich the YAML with CRD schema defaults so it's complete even when opened YAML-first, and make YAML-view Cancel return to the operator's operand tab (like Form-view Cancel) instead of the generic create page.

**Analysis / Root cause**:

When creating an operator instance (e.g. Kueue, LeaderWorkerSet), the operand editor remembers the user's last-used view (Form or YAML). Two separate defects combine to produce the reported behavior when YAML is the remembered view:

1. **Incomplete YAML on the YAML-first path.** `SyncedEditor` snapshots its initial YAML from the sample object once, on mount, and never re-syncs it. The sample is only enriched with CRD schema defaults as a side effect of the `@rjsf/core` Form mounting - so when the editor opens directly in YAML view, the Form never mounts, the defaults are never applied, and the YAML shows a stripped-down CR. The same happened when the CRD watch hadn't yet resolved at mount time.

2. **Cancel navigated to the wrong place.** The YAML view's Cancel fell through to `EditYAML`'s generic `navigateToResourceList` behavior, dropping the user on the generic cluster-scoped create page instead of returning to the operator's operand tab. The Form view's Cancel already returned correctly (`navigate(-1)`).

Together, cancelling from YAML view and clicking Create again reopened the editor YAML-first with the un-enriched template, so steps 3 and 4 no longer matched.

**Solution description**:

- Enrich the sample with CRD schema defaults in `CreateOperand` itself (via `getDefaultFormState`), so the YAML-first view shows the same complete content as the Form-first path.
- Gate rendering of the editor on the CRD watch having loaded (`crdLoaded`), so the sample is fully enriched before `SyncedEditor` takes its one-time snapshot.
- Add an optional `onCancel` that flows from `CreateOperand` -> `OperandYAML` -> `CreateYAML` -> `EditYAML`, routing the YAML view's Cancel through the same handler as the Form view. Extracted the shared logic into a `useOperandCancel` hook so both views stay in sync. `onCancel` is forwarded only when defined, preserving `EditYAML`'s default navigate-to-list behavior for all other consumers.

**Update: Follow-up fixes from manual cluster testing**

1. **Empty-string schema defaults submitted to API** - `getDefaultFormState` fills enum fields with `""` when no default is specified. Using the enriched sample as the prune template caused `prune()` to preserve these empty strings. Infinispan failed with `Unsupported value: ""; supported values: "debug", "info", "error"`. Fixed by using the raw alm-example (`rawSample`) as the prune template, not the enriched sample.

2. **Empty scaffold objects in initial YAML** - `getDefaultFormState` expands optional nested fields into empty objects and arrays (e.g. `multiKueue.externalFrameworks: [{}]`). Submitting from YAML view sent these invalid stubs to the API. Kueue failed with `Required value for field "spec.config.multiKueue.externalFrameworks[0].group"`. Fixed by pruning the enriched sample against `rawSample` before using it as `initialData`, so only valid non-empty defaults appear in the YAML editor.

Both cases now tested manually on cluster - Infinispan and Kueue operands both create successfully. Regression test added for empty-string defaults.

**Screenshots / screen recording**:
_**before**_
<img width="1268" height="1316" alt="OCPBUGS-70361-BUG" src="https://github.com/user-attachments/assets/b02130e1-419c-4481-9915-5fda35240cad" />

**_after_**
<img width="1268" height="1316" alt="OCPBUGS-70361-CORRECTED" src="https://github.com/user-attachments/assets/3c160053-d6fa-475e-89d2-97e00e8ba62a" />



**Test setup:**

Install the Kueue (or LeaderWorkerSet) operator from the Software Catalog on a cluster.

**Test cases:**

1. Installed Operators -> Kueue -> Kueue tab -> **Create Kueue** -> switch to **YAML view** -> **Cancel**.
2. Verify Cancel returns to the operator's Kueue operand tab (not the generic cluster-scoped create page).
3. Click **Create Kueue** again -> verify the editor opens YAML-first with the same complete YAML as step 1.
4. Verify the Form view still opens with defaults and its Cancel still returns to the operator context.
5. Repeat with LeaderWorkerSet.

**Additional info:**

Unit tests added in `create-operand.spec.tsx` and `create-yaml.spec.tsx` covering the schema-default enrichment, the `crdLoaded` gate, and the conditional `onCancel` forwarding.

Assisted by: Claude Code (Opus 4.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Operand YAML samples now apply available CRD schema defaults.
  - Editors wait for CRD data to load before displaying, improving creation reliability.
  - YAML cancellation now consistently returns to the appropriate previous view.
  - Preserved default cancellation behavior when no custom handler is provided.
  - Custom cancellation actions are now forwarded consistently across operand creation views.

- **Tests**
  - Added regression coverage for schema defaults, CRD loading, cancellation handling, and YAML editor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->