### PR TITLE
OCPBUGS-95606: Replace deprecated Node10 moduleResolution with Bundler for TS6 compatibility

### DIFF
--- a/frontend/packages/console-dynamic-plugin-sdk/src/utils/dynamic-module-parser.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/utils/dynamic-module-parser.ts
@@ -14,7 +14,7 @@ import * as ts from 'typescript';
 const defaultCompilerOptions: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES2020,
   module: ts.ModuleKind.ESNext,
-  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
   allowJs: true,
   strict: false,
   esModuleInterop: true,


### PR DESCRIPTION
**Analysis / Root cause**:
TypeScript 6 treats `moduleResolution: node10` (and its alias `ModuleResolutionKind.NodeJs`) as deprecated, emitting TS5107 as a hard error. This breaks any consumer of the dynamic plugin SDK using TypeScript 6+.

**Solution description**:
Replace `ModuleResolutionKind.NodeJs` with `ModuleResolutionKind.Bundler` in `dynamic-module-parser.ts`. The SDK only resolves relative paths within PatternFly packages' `dist/esm/` and `dist/dynamic/` directories, so Bundler resolution is functionally equivalent.
This also prepares for TypeScript 7, where node10 will stop functioning entirely.

This is a replica of https://github.com/openshift/console/pull/16259.

**Screenshots / screen recording**:
N/A - no visual changes.

**Test setup:**
N/A

**Test cases:**
- Build the console with TypeScript 6+ and verify no TS5107 errors are emitted.

**Browser conformance**:
N/A - no UI changes.

**Additional info:**
Closes https://github.com/openshift/console/issues/16258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript module resolution for dynamic plugin development and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->