### PR TITLE
HELM-480: Change handler return code

### DIFF
--- a/pkg/helm/handlers/handler_test.go
+++ b/pkg/helm/handlers/handler_test.go
@@ -916,7 +916,7 @@ func TestHelmHandlers_HandleHelmInstallAsync(t *testing.T) {
 			name:             "Error occurred",
 			expectedResponse: `{"error":"Failed to install helm chart: Chart path is invalid"}`,
 			error:            errors.New("Chart path is invalid"),
-			httpStatusCode:   http.StatusBadGateway,
+			httpStatusCode:   http.StatusBadRequest,
 		},
 		{
 			name:             "Successful install returns release info in JSON format",
@@ -1030,7 +1030,7 @@ func TestHelmHandlers_HandleHelmUnInstallAsync(t *testing.T) {
 			name:             "Error occurred",
 			expectedResponse: `{"error":"Failed to install helm chart: Chart path is invalid"}`,
 			error:            errors.New("Chart path is invalid"),
-			httpStatusCode:   http.StatusBadGateway,
+			httpStatusCode:   http.StatusBadRequest,
 		},
 		{
 			name:             "Successful uninstall returns secret info",

--- a/pkg/helm/handlers/handler_test.go
+++ b/pkg/helm/handlers/handler_test.go
@@ -14,6 +14,7 @@ import (
 	releasecommon "helm.sh/helm/v4/pkg/release/common"
 	releasev1 "helm.sh/helm/v4/pkg/release/v1"
 	repo "helm.sh/helm/v4/pkg/repo/v1"
+	"helm.sh/helm/v4/pkg/storage/driver"
 	kv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -358,7 +359,7 @@ func TestHelmHandlers_HandleGetRelease(t *testing.T) {
 			error:            errors.New("unknown error occurred"),
 			httpStatusCode:   http.StatusBadGateway,
 			releaseName:      "Test",
-			expectedResponse: `{"error":"Failed to find helm release: unknown error occurred"}`,
+			expectedResponse: `{"error":"Failed to get helm release: unknown error occurred"}`,
 		},
 		{
 			name:             "Return the requested release serialized in JSON format",
@@ -454,7 +455,7 @@ func TestHelmHandlers_HandleGetReleaseHistory(t *testing.T) {
 			name:                "chart release history should error out when there is error from helm",
 			error:               errors.New("Chart path is invalid"),
 			expectedResponse:    `{"error":"Failed to list helm release history: Chart path is invalid"}`,
-			httpStatusCode:      http.StatusBadGateway,
+			httpStatusCode:      http.StatusBadRequest,
 			expectedContentType: "application/json",
 			releaseName:         "test",
 		},
@@ -513,7 +514,7 @@ func TestHelmHandlers_HandleHelmUninstallRelease(t *testing.T) {
 			name:                "Invalid chart uninstall release test",
 			error:               errors.New("Chart path is invalid"),
 			expectedResponse:    `{"error":"Failed to uninstall helm release: Chart path is invalid"}`,
-			httpStatusCode:      http.StatusBadGateway,
+			httpStatusCode:      http.StatusBadRequest,
 			expectedContentType: "application/json",
 			releaseName:         "test",
 			releaseNamespace:    "test-namespace",
@@ -576,8 +577,8 @@ func TestHelmHandlers_HandleHelmRollbackRelease(t *testing.T) {
 			name:                "Invalid chart rollback release test",
 			error:               errors.New("Chart path is invalid"),
 			body:                `{"name": "test", "namespace":"test", "version":1}`,
-			expectedResponse:    `{"error":"Failed to rollback helm releases: Chart path is invalid"}`,
-			httpStatusCode:      http.StatusBadGateway,
+			expectedResponse:    `{"error":"Failed to rollback helm release: Chart path is invalid"}`,
+			httpStatusCode:      http.StatusBadRequest,
 			expectedContentType: "application/json",
 			releaseName:         "test",
 			releaseNamespace:    "test",
@@ -605,7 +606,7 @@ func TestHelmHandlers_HandleHelmRollbackRelease(t *testing.T) {
 			body:                `{"name": "test", "namespace":"test", "version":"abc"}`,
 			expectedContentType: "application/json",
 			error:               errors.New(`{"error":"Failed to parse request: json: cannot unmarshal string into Go struct field HelmRequest.version of type int"}`),
-			httpStatusCode:      http.StatusBadGateway,
+			httpStatusCode:      http.StatusBadRequest,
 			releaseName:         "test",
 			releaseNamespace:    "test",
 		},
@@ -613,7 +614,7 @@ func TestHelmHandlers_HandleHelmRollbackRelease(t *testing.T) {
 			name:                "Non exist release rollback should return revision not found error",
 			error:               actions.ErrReleaseRevisionNotFound,
 			body:                `{"name": "test", "namespace":"test", "version":1}`,
-			expectedResponse:    `{"error":"Failed to rollback helm releases: revision not found for provided release"}`,
+			expectedResponse:    `{"error":"Failed to rollback helm release: revision not found for provided release"}`,
 			httpStatusCode:      http.StatusNotFound,
 			expectedContentType: "application/json",
 			releaseName:         "test",
@@ -661,7 +662,7 @@ func TestHelmHandlers_HandleHelmUpgradeRelease(t *testing.T) {
 			name:                "Invalid chart path upgrade release test",
 			error:               errors.New("Chart path is invalid"),
 			expectedResponse:    `{"error":"Failed to upgrade helm release: Chart path is invalid"}`,
-			httpStatusCode:      http.StatusBadGateway,
+			httpStatusCode:      http.StatusBadRequest,
 			expectedContentType: "application/json",
 			requestBody:         `{"name":"test", "namespace": "test-namespace", "version": 1}`,
 			releaseName:         "test",
@@ -680,7 +681,7 @@ func TestHelmHandlers_HandleHelmUpgradeRelease(t *testing.T) {
 		},
 		{
 			name:                "Upgrade of non exist release should return no revision found error",
-			expectedResponse:    `{"error":"Failed to rollback helm releases: revision not found for provided release"}`,
+			expectedResponse:    `{"error":"Failed to upgrade helm release: revision not found for provided release"}`,
 			release:             &fakeRelease,
 			expectedContentType: "application/json",
 			error:               actions.ErrReleaseRevisionNotFound,
@@ -962,7 +963,7 @@ func TestHelmHandlers_HandleHelmUpgradeReleaseAsync(t *testing.T) {
 			name:                "Invalid chart path upgrade release test",
 			error:               errors.New("Chart path is invalid"),
 			expectedResponse:    `{"error":"Failed to upgrade helm release: Chart path is invalid"}`,
-			httpStatusCode:      http.StatusBadGateway,
+			httpStatusCode:      http.StatusBadRequest,
 			expectedContentType: "application/json",
 			requestBody:         `{"name":"test", "namespace": "test-namespace", "version": 1}`,
 			releaseName:         "test",
@@ -981,7 +982,7 @@ func TestHelmHandlers_HandleHelmUpgradeReleaseAsync(t *testing.T) {
 		},
 		{
 			name:                "Upgrade of non exist release should return no revision found error",
-			expectedResponse:    `{"error":"Failed to rollback helm releases: revision not found for provided release"}`,
+			expectedResponse:    `{"error":"Failed to upgrade helm release: revision not found for provided release"}`,
 			secret:              &fakeSecret,
 			expectedContentType: "application/json",
 			error:               actions.ErrReleaseRevisionNotFound,
@@ -1073,7 +1074,7 @@ func TestHelmHandlers_HandleHelmInstallAsyncNoRepo(t *testing.T) {
 			name:             "Invalid JSON request",
 			requestBody:      `{invalid}`,
 			expectedResponse: `{"error":"Failed to parse request: invalid character 'i' looking for beginning of object key string"}`,
-			httpStatusCode:   http.StatusBadGateway,
+			httpStatusCode:   http.StatusBadRequest,
 		},
 		{
 			name:             "Error occurred during chart install from URL",
@@ -1108,6 +1109,32 @@ func TestHelmHandlers_HandleHelmInstallAsyncNoRepo(t *testing.T) {
 			}
 			if response.Body.String() != tt.expectedResponse {
 				t.Errorf("response body not matching expected is %s and received is %s", tt.expectedResponse, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestDetermineErrorStatusCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected int
+	}{
+		{"actions ErrReleaseNotFound", actions.ErrReleaseNotFound, http.StatusNotFound},
+		{"driver ErrReleaseNotFound", driver.ErrReleaseNotFound, http.StatusNotFound},
+		{"actions ErrReleaseRevisionNotFound", actions.ErrReleaseRevisionNotFound, http.StatusNotFound},
+		{"driver ErrNoDeployedReleases", driver.ErrNoDeployedReleases, http.StatusNotFound},
+		{"wrapped driver ErrReleaseNotFound", fmt.Errorf("wrap: %w", driver.ErrReleaseNotFound), http.StatusNotFound},
+		{"invalid chart URL", fmt.Errorf("invalid chart URL: foo"), http.StatusBadRequest},
+		{"Chart path is invalid", errors.New("Chart path is invalid"), http.StatusBadRequest},
+		{"invalid revision", errors.New("Revision no. should be more than 0"), http.StatusBadRequest},
+		{"unknown error", errors.New("something broke"), http.StatusBadGateway},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineErrorStatusCode(tt.err)
+			if got != tt.expected {
+				t.Errorf("determineErrorStatusCode() = %d, want %d", got, tt.expected)
 			}
 		})
 	}

--- a/pkg/helm/handlers/handlers.go
+++ b/pkg/helm/handlers/handlers.go
@@ -192,7 +192,7 @@ func (h *helmHandlers) HandleHelmInstallAsync(user *auth.User, w http.ResponseWr
 
 	resp, err := h.installChartAsync(namespace, req.Name, req.ChartUrl, req.Values, conf, handlerClients.DynamicClient, handlerClients.CoreClient, true, req.IndexEntry)
 	if err != nil {
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to install helm chart: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to install helm chart: %v", err)})
 		return
 	}
 	serverutils.SendResponse(w, http.StatusCreated, resp)

--- a/pkg/helm/handlers/handlers.go
+++ b/pkg/helm/handlers/handlers.go
@@ -2,14 +2,17 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	releasecommon "helm.sh/helm/v4/pkg/release"
 	releasev1 "helm.sh/helm/v4/pkg/release/v1"
+	"helm.sh/helm/v4/pkg/storage/driver"
 	kv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -79,6 +82,24 @@ type helmHandlers struct {
 	newProxy              func(bearerToken string) (chartproxy.Proxy, error)
 }
 
+func determineErrorStatusCode(err error) int {
+	if errors.Is(err, driver.ErrReleaseNotFound) ||
+		errors.Is(err, actions.ErrReleaseNotFound) ||
+		errors.Is(err, actions.ErrReleaseRevisionNotFound) ||
+		errors.Is(err, driver.ErrNoDeployedReleases) {
+		return http.StatusNotFound
+	}
+
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "invalid chart URL") ||
+		strings.Contains(errMsg, "Chart path is invalid") ||
+		strings.Contains(errMsg, "Revision no. should be more than 0") {
+		return http.StatusBadRequest
+	}
+
+	return http.StatusBadGateway
+}
+
 func (h *helmHandlers) restConfig(bearerToken string) *rest.Config {
 	return &rest.Config{
 		Host:        h.ApiServerHost,
@@ -143,7 +164,7 @@ func (h *helmHandlers) HandleHelmInstallAsync(user *auth.User, w http.ResponseWr
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
 		return
 	}
 
@@ -212,7 +233,7 @@ func (h *helmHandlers) HandleGetRelease(user *auth.User, w http.ResponseWriter, 
 	conf := h.getActionConfigurations(h.ApiServerHost, ns, user.Token, &h.Transport)
 	release, err := h.getRelease(chartName, conf)
 	if err != nil {
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to find helm release: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to get helm release: %v", err)})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -281,11 +302,7 @@ func (h *helmHandlers) HandleUpgradeRelease(user *auth.User, w http.ResponseWrit
 	}
 	resp, err := h.upgradeRelease(req.Namespace, req.Name, req.ChartUrl, req.Values, conf, handlerClients.DynamicClient, handlerClients.CoreClient, false, req.IndexEntry)
 	if err != nil {
-		if err.Error() == actions.ErrReleaseRevisionNotFound.Error() {
-			serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: fmt.Sprintf("Failed to rollback helm releases: %v", err)})
-			return
-		}
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to upgrade helm release: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to upgrade helm release: %v", err)})
 		return
 	}
 
@@ -311,11 +328,7 @@ func (h *helmHandlers) HandleUpgradeReleaseAsync(user *auth.User, w http.Respons
 	}
 	resp, err := h.upgradeReleaseAsync(req.Namespace, req.Name, req.ChartUrl, req.Values, conf, handlerClients.DynamicClient, handlerClients.CoreClient, false, req.IndexEntry, req.BasicAuthSecretName)
 	if err != nil {
-		if err.Error() == actions.ErrReleaseRevisionNotFound.Error() {
-			serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: fmt.Sprintf("Failed to rollback helm releases: %v", err)})
-			return
-		}
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to upgrade helm release: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to upgrade helm release: %v", err)})
 		return
 	}
 	serverutils.SendResponse(w, http.StatusCreated, resp)
@@ -329,11 +342,7 @@ func (h *helmHandlers) HandleUninstallRelease(user *auth.User, w http.ResponseWr
 	conf := h.getActionConfigurations(h.ApiServerHost, ns, user.Token, &h.Transport)
 	resp, err := h.uninstallRelease(rel, conf)
 	if err != nil {
-		if err.Error() == actions.ErrReleaseNotFound.Error() {
-			serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: fmt.Sprintf("Failed to uninstall helm release: %v", err)})
-			return
-		}
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to uninstall helm release: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to uninstall helm release: %v", err)})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -346,18 +355,14 @@ func (h *helmHandlers) HandleRollbackRelease(user *auth.User, w http.ResponseWri
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
 		return
 	}
 
 	conf := h.getActionConfigurations(h.ApiServerHost, req.Namespace, user.Token, &h.Transport)
 	rel, err := h.rollbackRelease(req.Name, req.Version, conf)
 	if err != nil {
-		if err.Error() == actions.ErrReleaseRevisionNotFound.Error() {
-			serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: fmt.Sprintf("Failed to rollback helm releases: %v", err)})
-			return
-		}
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to rollback helm releases: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to rollback helm release: %v", err)})
 		return
 	}
 
@@ -373,11 +378,7 @@ func (h *helmHandlers) HandleGetReleaseHistory(user *auth.User, w http.ResponseW
 	conf := h.getActionConfigurations(h.ApiServerHost, ns, user.Token, &h.Transport)
 	rels, err := h.getReleaseHistory(name, conf)
 	if err != nil {
-		if err.Error() == actions.ErrReleaseNotFound.Error() {
-			serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: fmt.Sprintf("Failed to list helm release history: %v", err)})
-			return
-		}
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to list helm release history: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to list helm release history: %v", err)})
 		return
 	}
 	res, _ := json.Marshal(rels)
@@ -440,11 +441,7 @@ func (h *helmHandlers) HandleUninstallReleaseAsync(user *auth.User, w http.Respo
 	}
 	err = h.uninstallReleaseAsync(rel, ns, version, conf, handlerClients.CoreClient)
 	if err != nil {
-		if err.Error() == actions.ErrReleaseNotFound.Error() {
-			serverutils.SendResponse(w, http.StatusNotFound, serverutils.ApiError{Err: fmt.Sprintf("Failed to uninstall helm release: %v", err)})
-			return
-		}
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: fmt.Sprintf("Failed to uninstall helm release: %v", err)})
+		serverutils.SendResponse(w, determineErrorStatusCode(err), serverutils.ApiError{Err: fmt.Sprintf("Failed to uninstall helm release: %v", err)})
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -481,3 +478,4 @@ func (h *helmHandlers) HandleURLChartGet(user *auth.User, w http.ResponseWriter,
 	res, _ := json.Marshal(resp)
 	w.Write(res)
 }
+

--- a/pkg/helm/handlers/handlers.go
+++ b/pkg/helm/handlers/handlers.go
@@ -478,4 +478,3 @@ func (h *helmHandlers) HandleURLChartGet(user *auth.User, w http.ResponseWriter,
 	res, _ := json.Marshal(resp)
 	w.Write(res)
 }
-


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
Openshift console should return the correct HTTP return code
**Test setup:**
Openshift cluster
COOKIE="openshift-session-token-=MTc4NzE0MTMyMnxQ...Z4=; csrf-token=LoOs...;"
CSRF="X-CSRFToken: LoOs..."
BASE="http://localhost:9000"

Then run each test:
- echo "=== 1. GET nonexistent release (expect 404) ===" && curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/release?ns=default&name=nonexistent"
- echo "=== 2. DELETE nonexistent release (expect 404) ===" && curl -s -w "\nStatus: %{http_code}\n" -X DELETE -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/release?ns=default&name=nonexistent&version=1"
- echo "=== 3. GET history nonexistent (expect 404) ===" && curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/release/history?ns=default&name=nonexistent"
- echo "=== 4. GET chart empty URL (expect 400) ===" && curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/chart?url=&namespace=default&noRepo=true"
- echo "=== 5. GET chart invalid URL (expect 400) ===" && curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/chart?url=invalid://bad&namespace=default&noRepo=true"
- echo "=== 6. POST install bad JSON (expect 400) ===" && curl -s -w "\nStatus: %{http_code}\n" -X POST -H "Content-Type: application/json" -H "$CSRF" -b "$COOKIE" -d '{bad}' "$BASE/api/helm/release/async"
- echo "=== 7. PATCH rollback nonexistent (expect 404) ===" && curl -s -w "\nStatus: %{http_code}\n" -X PATCH -H "Content-Type: application/json" -H "$CSRF" -b "$COOKIE" -d '{"name":"nonexistent","namespace":"default","version":99}' "$BASE/api/helm/release"
- echo "=== 8. PUT upgrade bad JSON (expect 400) ===" && curl -s -w "\nStatus: %{http_code}\n" -X PUT -H "Content-Type: application/json" -H "$CSRF" -b "$COOKIE" -d '{bad}' "$BASE/api/helm/release"

**Test results**
| # | Scenario | Endpoint | Method | Expected | Actual | Command |
|---|----------|----------|--------|----------|--------|---------|
| 1 | Get nonexistent release | `/api/helm/release` | GET | 404 | **404** | `curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/release?ns=default&name=nonexistent"` |
| 2 | Delete nonexistent release | `/api/helm/release` | DELETE | 404 | **404** | `curl -s -w "\nStatus: %{http_code}\n" -X DELETE -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/release?ns=default&name=nonexistent&version=1"` |
| 3 | History for nonexistent release | `/api/helm/release/history` | GET | 404 | **404** | `curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/release/history?ns=default&name=nonexistent"` |
| 4 | Chart fetch with empty URL | `/api/helm/chart` | GET | 400 | **400** | `curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/chart?url=&namespace=default&noRepo=true"` |
| 5 | Chart fetch with invalid URL | `/api/helm/chart` | GET | 400 | **400** | `curl -s -w "\nStatus: %{http_code}\n" -b "$COOKIE" -H "$CSRF" "$BASE/api/helm/chart?url=invalid://bad&namespace=default&noRepo=true"` |
| 6 | Async install with malformed JSON | `/api/helm/release/async` | POST | 400 | **400** | `curl -s -w "\nStatus: %{http_code}\n" -X POST -H "Content-Type: application/json" -H "$CSRF" -b "$COOKIE" -d '{bad}' "$BASE/api/helm/release/async"` |
| 7 | Rollback nonexistent release | `/api/helm/release` | PATCH | 404 | **404** | `curl -s -w "\nStatus: %{http_code}\n" -X PATCH -H "Content-Type: application/json" -H "$CSRF" -b "$COOKIE" -d '{"name":"nonexistent","namespace":"default","version":99}' "$BASE/api/helm/release"` |
| 8 | Upgrade with malformed JSON | `/api/helm/release` | PUT | 400 | **400** | `curl -s -w "\nStatus: %{http_code}\n" -X PUT -H "Content-Type: application/json" -H "$CSRF" -b "$COOKIE" -d '{bad}' "$BASE/api/helm/release"` |

All error responses return proper HTTP status codes (400 Bad Request, 404 Not Found) instead of generic 502 Bad Gateway.

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm error responses across release retrieval, upgrades, uninstall, rollback, and history operations.
  * Invalid chart paths, request bodies, and validation data now return clear 400 responses.
  * Missing releases or revisions now return 404 responses.
  * Unexpected upstream failures now return 502 responses with more accurate messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->