### PR TITLE
OCPBUGS-98765: Bump linkify-it to 5.0.2 to fix CVE-2026-48801

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -329,6 +329,7 @@
     "@types/jest": "21.x",
     "hosted-git-info": "^3.0.8",
     "jquery": "3.5.1",
+    "linkify-it": "^5.0.1",
     "lodash-es": "^4.18.1",
     "minimist": "1.2.5",
     "ua-parser-js": "^0.7.24",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15945,12 +15945,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^2.0.3":
-  version: 2.1.0
-  resolution: "linkify-it@npm:2.1.0"
+"linkify-it@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
-    uc.micro: "npm:^1.0.1"
-  checksum: 10c0/2fc45f06740a3c58c3393eecb634f91b62afc8b571ec82dd4fb250acded2d15ab1c83730c0fc0c353b8577d594384c7ca9e7f075be4342e9238d41089d0001bf
+    uc.micro: "npm:^2.0.0"
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 
@@ -23228,10 +23228,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uc.micro@npm:^1.0.1":
-  version: 1.0.6
-  resolution: "uc.micro@npm:1.0.6"
-  checksum: 10c0/9bde2afc6f2e24b899db6caea47dae778b88862ca76688d844ef6e6121dec0679c152893a74a6cfbd2e6fde34654e6bd8424fee8e0166cdfa6c9ae5d42b8a17b
+"uc.micro@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10c0/8862eddb412dda76f15db8ad1c640ccc2f47cdf8252a4a30be908d535602c8d33f9855dfcccb8b8837855c1ce1eaa563f7fa7ebe3c98fd0794351aab9b9c55fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## CVE-2026-48801: linkify-it ReDoS vulnerability

Bumps the transitive dependency `linkify-it` from 2.1.0 to 5.0.2 via yarn resolutions to address [CVE-2026-48801](https://access.redhat.com/security/cve/CVE-2026-48801) (CVSS 7.5 Moderate).

### Vulnerability

`linkify-it` < 5.0.1 has O(N²) algorithmic complexity in `LinkifyIt.prototype.match`, enabling ReDoS (Regular Expression Denial of Service) via crafted input with many fuzzy links or emails (CWE-1333).

### Changes

- Added `"linkify-it": "^5.0.1"` to `frontend/package.json` `resolutions` block to override the transitive dependency pinned by `react-linkify@0.2.2`
- `linkify-it`: 2.1.0 → 5.0.2
- `uc.micro` (child dep): 1.0.6 → 2.1.0

### Validation

- Jest unit tests: 9/9 passed
- Webpack production build: succeeded (127s, zero linkify-related warnings)
- Runtime compatibility verified: react-linkify@0.2.2 works correctly with linkify-it 5.x API

### Jira

- [OCPBUGS-98765](https://redhat.atlassian.net/browse/OCPBUGS-98765)