### PR TITLE
OCPBUGS-109521: Remove unscoped CSV watch from ClusterNotUpgradeableAlert

### DIFF
--- a/frontend/public/components/cluster-settings/__tests__/cluster-not-upgradeable-alert.spec.tsx
+++ b/frontend/public/components/cluster-settings/__tests__/cluster-not-upgradeable-alert.spec.tsx
@@ -1,0 +1,94 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
+import { ClusterNotUpgradeableAlert } from '../cluster-settings';
+import { ClusterVersionKind, K8sResourceConditionStatus } from '../../../module/k8s';
+
+jest.mock('react-i18next', () => ({
+  ...jest.requireActual('react-i18next'),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const text = key.replace('public~', '');
+      if (opts) {
+        return Object.entries(opts).reduce(
+          (acc, [k, v]) => acc.replace(`{{${k}}}`, String(v)),
+          text,
+        );
+      }
+      return text;
+    },
+  }),
+}));
+
+jest.mock('@console/internal/components/markdown-view', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react');
+  return {
+    SyncMarkdownView: ({ content }: { content: string }) =>
+      React.createElement('span', null, content),
+  };
+});
+
+jest.mock('../../utils/resource-link', () => ({
+  resourceListPathFromModel: jest.fn(() => '/k8s/all-namespaces/clusterserviceversions'),
+  resourcePathFromModel: jest.fn(() => '/k8s/cluster/clusterautoscalers'),
+  ResourceLink: jest.fn(() => null),
+}));
+
+const clusterVersionUpgradeableFalse: ClusterVersionKind = {
+  apiVersion: 'config.openshift.io/v1',
+  kind: 'ClusterVersion',
+  metadata: { name: 'version', resourceVersion: '1', uid: 'test-uid' },
+  spec: { channel: 'stable-4.22', clusterID: 'test-id' },
+  status: {
+    availableUpdates: [],
+    observedGeneration: 1,
+    versionHash: 'test-hash',
+    conditions: [
+      {
+        type: 'Upgradeable',
+        status: K8sResourceConditionStatus.False,
+        reason: 'Test',
+        message:
+          'Cluster operator testing cannot be upgraded between minor versions: The whatsits are broken.',
+        lastTransitionTime: '2026-01-01T00:00:00Z',
+      },
+    ],
+    desired: { version: '4.22.0', image: 'test-image' },
+    history: [
+      {
+        version: '4.22.0',
+        image: 'test-image',
+        state: 'Completed',
+        verified: true,
+        startedTime: '2026-01-01T00:00:00Z',
+        completionTime: '2026-01-01T01:00:00Z',
+      },
+    ],
+  },
+};
+
+describe('ClusterNotUpgradeableAlert', () => {
+  it('renders the alert body text from the ClusterVersion condition message', () => {
+    renderWithProviders(<ClusterNotUpgradeableAlert cv={clusterVersionUpgradeableFalse} />);
+
+    expect(
+      screen.getByText(
+        'Cluster operator testing cannot be upgraded between minor versions: The whatsits are broken.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('always renders the View ClusterOperators link', () => {
+    renderWithProviders(<ClusterNotUpgradeableAlert cv={clusterVersionUpgradeableFalse} />);
+
+    expect(screen.getByRole('link', { name: /View ClusterOperators/i })).toBeInTheDocument();
+  });
+
+  it('always renders the View installed Operators link with the correct all-namespaces URL', () => {
+    renderWithProviders(<ClusterNotUpgradeableAlert cv={clusterVersionUpgradeableFalse} />);
+
+    const link = screen.getByRole('link', { name: /View installed Operators/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/k8s/all-namespaces/clusterserviceversions');
+  });
+});

--- a/frontend/public/components/cluster-settings/cluster-settings.tsx
+++ b/frontend/public/components/cluster-settings/cluster-settings.tsx
@@ -28,10 +28,7 @@ import { AddCircleOIcon, PauseCircleIcon, PencilAltIcon } from '@patternfly/reac
 
 import { removeQueryArgument } from '@console/internal/components/utils/router';
 import { SyncMarkdownView } from '@console/internal/components/markdown-view';
-import {
-  ClusterServiceVersionKind,
-  ClusterServiceVersionModel,
-} from '@console/operator-lifecycle-manager';
+import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager';
 import { WatchK8sResource } from '@console/dynamic-plugin-sdk';
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import PaneBodyGroup from '@console/shared/src/components/layout/PaneBodyGroup';
@@ -63,7 +60,6 @@ import {
   getMCPsToPausePromises,
   getNewerClusterVersionChannel,
   getNewerMinorVersionUpdate,
-  getNotUpgradeableResources,
   getOCMLink,
   getReleaseNotesLink,
   getSimilarClusterVersionChannels,
@@ -92,7 +88,11 @@ import { Firehose } from '../utils/firehose';
 import type { FirehoseResource } from '../utils/types';
 import { HorizontalNav } from '../utils/horizontal-nav';
 import { ReleaseNotesLink } from '../utils/release-notes-link';
-import { ResourceLink, resourcePathFromModel } from '../utils/resource-link';
+import {
+  ResourceLink,
+  resourceListPathFromModel,
+  resourcePathFromModel,
+} from '../utils/resource-link';
 import { SectionHeading } from '../utils/headings';
 import { togglePaused } from '../utils/workload-pause';
 import { UpstreamConfigDetailsItem } from '../utils/details-page';
@@ -742,24 +742,11 @@ export const UpdateInProgress: React.FC<UpdateInProgressProps> = ({
   );
 };
 
-const ClusterServiceVersionResource: WatchK8sResource = {
-  isList: true,
-  kind: referenceForModel(ClusterServiceVersionModel),
-};
-
 export const ClusterNotUpgradeableAlert: React.FC<ClusterNotUpgradeableAlertProps> = ({
   cv,
   onCancel,
 }) => {
-  const [clusterOperators] = useK8sWatchResource<ClusterOperator[]>(ClusterOperatorsResource);
-  const [clusterServiceVersions] = useK8sWatchResource<ClusterServiceVersionKind[]>(
-    ClusterServiceVersionResource,
-  );
   const { t } = useTranslation();
-  const notUpgradeableClusterOperators = getNotUpgradeableResources(clusterOperators);
-  const notUpgradeableClusterOperatorsPresent = notUpgradeableClusterOperators.length > 0;
-  const notUpgradeableClusterServiceVersions = getNotUpgradeableResources(clusterServiceVersions);
-  const notUpgradeableCSVsPresent = notUpgradeableClusterServiceVersions.length > 0;
   const clusterUpgradeableFalseCondition = getConditionUpgradeableFalse(cv);
   const currentVersion = getLastCompletedUpdate(cv);
   const currentVersionParsed = semver.parse(currentVersion);
@@ -783,28 +770,19 @@ export const ClusterNotUpgradeableAlert: React.FC<ClusterNotUpgradeableAlertProp
       }
       className="co-alert"
       actionLinks={
-        (notUpgradeableClusterOperatorsPresent || notUpgradeableCSVsPresent) && (
-          <Flex>
-            {notUpgradeableClusterOperatorsPresent && (
-              <FlexItem>
-                <ClusterOperatorsLink onCancel={onCancel} queryString="?status=Cannot+update">
-                  {t('public~View ClusterOperators')}
-                </ClusterOperatorsLink>
-              </FlexItem>
-            )}
-            {notUpgradeableCSVsPresent && (
-              // TODO:  update link to include filter once installed Operators filters are updated
-              <FlexItem>
-                <Link
-                  onClick={onCancel}
-                  to={`/k8s/ns/all-namespaces/${ClusterServiceVersionModel.plural}`}
-                >
-                  {t('public~View installed Operators')}
-                </Link>
-              </FlexItem>
-            )}
-          </Flex>
-        )
+        <Flex>
+          <FlexItem>
+            <ClusterOperatorsLink onCancel={onCancel} queryString="?status=Cannot+update">
+              {t('public~View ClusterOperators')}
+            </ClusterOperatorsLink>
+          </FlexItem>
+          {/* TODO:  update link to include filter once installed Operators filters are updated */}
+          <FlexItem>
+            <Link onClick={onCancel} to={resourceListPathFromModel(ClusterServiceVersionModel)}>
+              {t('public~View installed Operators')}
+            </Link>
+          </FlexItem>
+        </Flex>
       }
       data-test="cluster-settings-alerts-not-upgradeable"
     >

--- a/frontend/public/module/k8s/cluster-settings.ts
+++ b/frontend/public/module/k8s/cluster-settings.ts
@@ -349,9 +349,6 @@ export const getConditionUpgradeableFalse = (resource) =>
     (c) => c.type === 'Upgradeable' && c.status === K8sResourceConditionStatus.False,
   );
 
-export const getNotUpgradeableResources = (resources) =>
-  resources.filter((resource) => getConditionUpgradeableFalse(resource));
-
 export enum NodeTypes {
   master = 'master',
   worker = 'worker',


### PR DESCRIPTION
This is a backport of #16904 to release-4.21 (via #17013 for release-4.22).

The ClusterNotUpgradeableAlert component fetched all ClusterServiceVersions cluster-wide (resulting in up to 600MB object sizes in the browser on clusters with 350+ namespaces and lots of operators) on every visit to Cluster Settings when Upgradeable=False was set.

The only use of CSVs was to decide whether or not to show navigation links.

For installed operators this was ineffective: CSV status.conditions use phase/reason fields, not type/status, so getConditionUpgradeableFalse() always returned undefined on CSVs — meaning notUpgradeableCSVsPresent was permanently false and the 'View installed Operators' link was never shown.

Additionally the link URL used /k8s/ns/all-namespaces/ instead of /k8s/all-namespaces/, causing 'No Operators found' on navigation.

**Fix:** remove both the ClusterOperator and CSV watches. Both navigation links are now always shown when the alert renders — correct since the alert only mounts when Upgradeable=False is already confirmed on ClusterVersion. Use resourceListPathFromModel() for the correct all-namespaces URL.

**Backport note:** On release-4.21 the `ClusterNotUpgradeableAlert` lives in `cluster-settings.tsx` (not `cluster-settings-utils.tsx` as in main) and uses `SyncMarkdownView`/`removeQueryArgument` (not `MarkdownView`/`useQueryParamsMutator`) due to refactoring between 4.21 and main. The fix is otherwise identical. Test fixtures updated for stricter `UpdateHistory`/`ClusterVersionStatus` types on 4.21, and jest.mock factories use `React.createElement` instead of JSX (older babel-plugin-jest-hoist constraint).

https://issues.redhat.com/browse/OCPBUGS-109521