### PR TITLE
OCPBUGS-98420: [release-4.18] CVE-2026-59869 bump js-yaml

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -180,7 +180,7 @@
     "immutable": "^3.8.3",
     "istextorbinary": "^9.5.0",
     "js-base64": "^2.5.1",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^3.15.0",
     "json-schema": "^0.3.0",
     "lodash-es": "^4.18.1",
     "monaco-languageclient": "^0.13.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -15496,15 +15496,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.7.0, js-yaml@npm:^3.9.0":
-  version: 3.14.0
-  resolution: "js-yaml@npm:3.14.0"
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.15.0, js-yaml@npm:^3.7.0, js-yaml@npm:^3.9.0":
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/9b21ab19f03aae734c83e5c8a3d5e6f80bab5ce0e24bdbb186e531fb0887ff0034affd96ae3eed993c33e33bc606a6b78389207b853df97094393804d6c37184
+  checksum: 10c0/6c693b8c59ffe12021df3b36994b090df19d920826dd810baab81652b40861e1974509dd11fe92225ab4c00cc14de053300c94db015c2c0e211edea39b118737
   languageName: node
   linkType: hard
 
@@ -18477,7 +18477,7 @@ __metadata:
     jest-resolve: "npm:^26.4.0"
     jest-transform-graphql: "npm:^2.1.0"
     js-base64: "npm:^2.5.1"
-    js-yaml: "npm:^3.13.1"
+    js-yaml: "npm:^3.15.0"
     json-schema: "npm:^0.3.0"
     lint-staged: "npm:^10.2.2"
     lodash-es: "npm:^4.18.1"


### PR DESCRIPTION
Analysis / Root cause:
https://github.com/advisories/GHSA-52cp-r559-cp3m: js-yaml versions 3.0.0 to before 3.15.0 and 4.0.0 to before 4.3.0 can spend quadratic CPU time parsing YAML documents with chained merge keys, enabling Denial of Service
via crafted payloads of only tens of kilobytes.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-98420

Solution description:
Bump the direct js-yaml dependency from ^3.13.1 to ^3.15.0 (patched). The yarn lockfile
naturally resolves v4 consumers to 4.3.0 (also patched), so both v3 and v4 dependents get the
fix with their expected API.

Screenshots / screen recording:
N/A — dependency-only change, no UI impact.

Test setup:
No special setup required.

Test cases:

yarn install completes successfully
yarn build completes successfully
Verify yarn.lock shows js-yaml 3.15.0 for v3 consumers and 4.3.0 for v4 consumers
Browser conformance:
N/A — no UI changes.
