### PR TITLE
OCPBUGS-109632: Fix webhook creation in Git for PAC

### DIFF
--- a/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
+++ b/frontend/packages/dev-console/src/components/import/import-validation-utils.ts
@@ -29,15 +29,7 @@ const pipelinesAccessTokenValidationSchema = (t: TFunction) =>
       .when('gitProvider', ([gitProvider], schema) =>
         gitProvider === GitProvider.BITBUCKET
           ? schema.shape({
-              user: yup
-                .string()
-                .matches(nameRegex, {
-                  message: t(
-                    'devconsole~Name must consist of lower-case letters, numbers and hyphens. It must start with a letter and end with a letter or number.',
-                  ),
-                  excludeEmptyString: true,
-                })
-                .required(t('devconsole~Required')),
+              user: yup.string().required(t('devconsole~Required')),
             })
           : schema,
       )

--- a/frontend/packages/dev-console/src/components/pipeline-section/pipeline/WebhookSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-section/pipeline/WebhookSection.tsx
@@ -62,9 +62,8 @@ const WebhookSection: FC<WebhoookSectionProps> = ({ pac, formContextField }) => 
   const fieldPrefix = formContextField ? `${formContextField}.` : '';
   const { gitProvider, webhook } = _.get(values, formContextField) || values;
   const [controllerUrl, setControllerUrl] = useState('');
-  const [webhookSecret, setWebhookSecret] = useState('');
+  const webhookSecret = webhook?.secret ?? '';
   const { t } = useTranslation('devconsole');
-
   useEffect(() => {
     const ctlUrl = pac?.data?.['controller-url'];
     if (ctlUrl) {
@@ -100,7 +99,7 @@ const WebhookSection: FC<WebhoookSectionProps> = ({ pac, formContextField }) => 
   );
 
   const generateWebhookSecret = () => {
-    setWebhookSecret(generateSecret());
+    setFieldValue(`${fieldPrefix}webhook.secret`, generateSecret());
   };
 
   const getPermssionSectionHeading = (git: GitProvider) => {
@@ -226,7 +225,7 @@ const WebhookSection: FC<WebhoookSectionProps> = ({ pac, formContextField }) => 
                     setFieldValue(`${fieldPrefix}webhook.secretObj`, res);
                     const secret = res?.data['webhook.secret'];
                     if (secret) {
-                      setWebhookSecret(Base64.decode(secret));
+                      setFieldValue(`${fieldPrefix}webhook.secret`, Base64.decode(secret));
                     }
                   }
                 }}

--- a/frontend/packages/dev-console/src/components/pipeline-section/pipeline/utils.ts
+++ b/frontend/packages/dev-console/src/components/pipeline-section/pipeline/utils.ts
@@ -202,7 +202,6 @@ export const createRemoteWebhook = async (
   } else {
     authToken = method === 'token' ? token : Base64.decode(secretObj?.data?.['provider.token']);
   }
-
   const webhookCreationStatus = await gitService.createRepoWebhook(
     authToken,
     webhookURL,

--- a/frontend/packages/git-service/src/services/base-service.ts
+++ b/frontend/packages/git-service/src/services/base-service.ts
@@ -128,3 +128,11 @@ export abstract class BaseService {
     }
   }
 }
+
+export const headersToRecord = (headers: Headers): Record<string, string[]> => {
+  const result: Record<string, string[]> = {};
+  headers.forEach((value, key) => {
+    result[key] = [value];
+  });
+  return result;
+};

--- a/frontend/packages/git-service/src/services/bitbucket-service.ts
+++ b/frontend/packages/git-service/src/services/bitbucket-service.ts
@@ -6,7 +6,7 @@ import type { GitSource } from '../types/git';
 import { SecretType } from '../types/git';
 import type { RepoMetadata, BranchList, RepoLanguageList, RepoFileList } from '../types/repo';
 import { RepoStatus } from '../types/repo';
-import { BaseService } from './base-service';
+import { BaseService, headersToRecord } from './base-service';
 
 type BBWebhookBody = {
   url: string;
@@ -16,7 +16,7 @@ type BBWebhookBody = {
 };
 
 type BitbucketWebhookRequest = {
-  headers: Headers;
+  headers: Record<string, string[]>;
   isServer: boolean;
   baseURL: string;
   owner: string;
@@ -233,7 +233,7 @@ export class BitbucketService extends BaseService {
     };
 
     const webhookRequestBody: BitbucketWebhookRequest = {
-      headers,
+      headers: headersToRecord(headers),
       isServer: this.isServer,
       baseURL: this.baseURL,
       owner: this.metadata.owner,

--- a/frontend/packages/git-service/src/services/github-service.ts
+++ b/frontend/packages/git-service/src/services/github-service.ts
@@ -7,7 +7,7 @@ import type { GitSource } from '../types/git';
 import { SecretType } from '../types/git';
 import type { RepoMetadata, BranchList, RepoLanguageList, RepoFileList } from '../types/repo';
 import { RepoStatus } from '../types/repo';
-import { BaseService } from './base-service';
+import { BaseService, headersToRecord } from './base-service';
 
 type GHWebhookBody = {
   name: string;
@@ -22,7 +22,7 @@ type GHWebhookBody = {
 };
 
 type GithubWebhookRequest = {
-  headers: Headers;
+  headers: Record<string, string[]>;
   hostName: string;
   owner: string;
   repoName: string;
@@ -182,7 +182,7 @@ export class GithubService extends BaseService {
       : `${this.metadata.host}/api/v3`;
 
     const webhookRequestBody: GithubWebhookRequest = {
-      headers,
+      headers: headersToRecord(headers),
       hostName: AddWebhookBaseURL,
       owner: this.metadata.owner,
       repoName: this.metadata.repoName,

--- a/frontend/packages/git-service/src/services/gitlab-service.ts
+++ b/frontend/packages/git-service/src/services/gitlab-service.ts
@@ -8,7 +8,7 @@ import type { GitSource } from '../types/git';
 import { SecretType } from '../types/git';
 import type { RepoMetadata, BranchList, RepoLanguageList, RepoFileList } from '../types/repo';
 import { RepoStatus } from '../types/repo';
-import { BaseService } from './base-service';
+import { BaseService, headersToRecord } from './base-service';
 
 type GitlabRepo = {
   id: number;
@@ -24,7 +24,7 @@ type GLWebhookBody = {
 };
 
 type GitlabWebhookRequest = {
-  headers: Headers;
+  headers: Record<string, string[]>;
   hostName: string;
   projectID: string;
   body: GLWebhookBody;
@@ -208,7 +208,7 @@ export class GitlabService extends BaseService {
     };
 
     const webhookRequestBody: GitlabWebhookRequest = {
-      headers,
+      headers: headersToRecord(headers),
       hostName: this.metadata.host,
       projectID: projectID.toString(),
       body,


### PR DESCRIPTION
**Analysis / Root cause**:
Webhook creation in Git services (GitHub, GitLab, Bitbucket) for Pipelines as Code (PAC) was failing due to type mismatches when sending webhook requests to the backend. The `Headers` object was being passed directly instead of being serialized to a `Record<string, string[]>` format expected by the backend API.

Additionally, the Bitbucket username validation was overly strict, rejecting valid usernames that didn't match the Kubernetes name regex pattern.

**Solution description**:
1. **Unified webhook header handling**: Created a `headersToRecord` helper function in `base-service.ts` that converts the `Headers` object to `Record<string, string[]>` format before sending to backend
2. **Updated all Git service providers**: Modified GitHub, GitLab, and Bitbucket services to use the new helper when creating webhook requests
3. **Relaxed Bitbucket validation**: Removed the overly restrictive `nameRegex` validation on Bitbucket username field while keeping the required field validation
4. **Fixed React hooks violation**: Removed local `webhookSecret` state in `WebhookSection.tsx` and replaced with direct `setFieldValue` calls to avoid set-state-in-effect violations

**Screenshots / screen recording**:
<!-- User to add screenshots showing webhook creation working -->

**Test setup:**
1. Set up a git repository (GitHub, GitLab, or Bitbucket)
2. Navigate to Developer Console → Import from Git
3. Configure Pipelines as Code with webhook creation

**Test cases:**
- [ ] Webhook creation succeeds for GitHub repositories
- [ ] Webhook creation succeeds for GitLab repositories  
- [ ] Webhook creation succeeds for Bitbucket Cloud repositories
- [ ] Webhook creation succeeds for Bitbucket Server repositories
- [ ] Bitbucket username field accepts valid usernames (doesn't require Kubernetes name format)
- [ ] Webhook secret is properly generated and stored
- [ ] No React hooks violations in browser console

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Pre-push review results**: CodeRabbit and Claude AI validation completed with 0 critical issues found. All type signature changes validated clean.

**Reviewers and assignees:**
<!-- Tag an OCP console engineer to review -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bitbucket webhook user validation now accepts any non-empty username.
  - Webhook secrets now remain synchronized when generated or selected.
  - Improved webhook request handling across Bitbucket, GitHub, and GitLab integrations.
- **Improvements**
  - Webhook headers are now consistently formatted when requests are sent, improving compatibility with backend processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->