### PR TITLE
[release-4.16] OCPBUGS-105796: Fix operator-hub e2e test by replacing unavailable Red Hat catalog source with Community

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
@@ -24,8 +24,8 @@ describe('Interacting with OperatorHub', () => {
     cy.log('more than one tile should be present');
     cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
 
-    cy.log('enable the Red Hat filter');
-    cy.byTestID('catalogSourceDisplayName-red-hat', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+    cy.log('enable the Community filter');
+    cy.byTestID('catalogSourceDisplayName-community', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
       .should('be.visible')
       .click();
     cy.log('more than one tile should be present');
@@ -36,16 +36,16 @@ describe('Interacting with OperatorHub', () => {
       .first()
       .then(($origCatalogTitle) => {
         const origCatalogTitleTxt = $origCatalogTitle.find('.catalog-tile-pf-title').text();
-        cy.log(`first Red Hat filtered tile title text is ${origCatalogTitleTxt}`);
-        cy.log('disable the Red Hat filter');
-        cy.byTestID('catalogSourceDisplayName-red-hat', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+        cy.log(`first Community filtered tile title text is ${origCatalogTitleTxt}`);
+        cy.log('disable the Community filter');
+        cy.byTestID('catalogSourceDisplayName-community', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
           .should('be.visible')
           .click();
         cy.log('enable the Certified filter');
         cy.byTestID('catalogSourceDisplayName-certified', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
           .should('be.visible')
           .click();
-        cy.log('wait for the Certified results to replace the Red Hat list');
+        cy.log('wait for the Certified results to replace the Community list');
         cy.get('.co-catalog-tile').should(($tiles) => {
           expect($tiles.length).to.be.gt(0);
           expect($tiles.first().find('.catalog-tile-pf-title').text()).not.to.equal(


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes: </h2>

https://issues.redhat.com/browse/OCPBUGS-105796

<h2 id="solution-description">Solution description</h2>

`operator-hub.cy.ts` fails consistently on release-4.16, giving the
`e2e-gcp-console` presubmit a 0% pass rate and blocking all PRs to the branch.
The test clicks the "Red Hat" catalog source filter, but the CI cluster only
provides Community and Certified sources, so the click times out.

This ports the fix from OCPBUGS-34958 (already on release-4.17 and main) to
release-4.16, switching the filter from Red Hat to Community. Test-only change.

<h2 id="reviewers-and-assignees">Reviewers and assignees</h2>:

/assign TheRealJon

<h2 id="test-cases">Test cases:</h2>

`operator-hub.cy.ts` "displays OperatorHub tile view with expected available
Operators" now passes against the CI cluster's available catalog sources.

<h2 id="additional-info">Additional info:</h2>

Related: OCPBUGS-105793 (CI block), OCPBUGS-105795 (release-4.15 equivalent).
Supersedes the temporary disable in openshift/console#16958.

<h2 id="screenshots">Screen shots / gifs / design review:</h2>

N/A — test-only change, no UI impact.