### PR TITLE
fix(olm): stabilize legacy OperatorHub Cypress waits

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/create-namespace.cy.ts
@@ -1,5 +1,6 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 import { modal } from '../../../integration-tests-cypress/views/modal';
+import { operatorHub } from '../views/operator-hub.view';
 
 describe('Create namespace from install operators', () => {
   before(() => {
@@ -22,6 +23,7 @@ describe('Create namespace from install operators', () => {
     const operatorName = 'Red Hat Integration - 3scale';
     cy.log('test namespace creation from dropdown');
     cy.visit(`/operatorhub/ns/${testName}`);
+    operatorHub.waitForLoaded();
     cy.byTestID('search-operatorhub').type(operatorName);
     cy.byTestID(operatorSelector).click();
     cy.byLegacyTestID('operator-install-btn').click({ force: true });

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/tests/operator-hub.cy.ts
@@ -1,5 +1,6 @@
 import { checkErrors, testName } from '../../../integration-tests-cypress/support';
 import { nav } from '../../../integration-tests-cypress/views/nav';
+import { OPERATOR_HUB_LOAD_TIMEOUT, operatorHub } from '../views/operator-hub.view';
 
 describe('Interacting with OperatorHub', () => {
   before(() => {
@@ -19,11 +20,14 @@ describe('Interacting with OperatorHub', () => {
     cy.log('navigate to OperatorHub');
     nav.sidenav.clickNavLink(['Operators', 'OperatorHub']);
     cy.url().should('include', '/operatorhub/all-namespaces');
+    operatorHub.waitForLoaded();
     cy.log('more than one tile should be present');
     cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
 
     cy.log('enable the Red Hat filter');
-    cy.byTestID('catalogSourceDisplayName-red-hat').click();
+    cy.byTestID('catalogSourceDisplayName-red-hat', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+      .should('be.visible')
+      .click();
     cy.log('more than one tile should be present');
     cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
     cy.log('track which tile is first');
@@ -34,17 +38,20 @@ describe('Interacting with OperatorHub', () => {
         const origCatalogTitleTxt = $origCatalogTitle.find('.catalog-tile-pf-title').text();
         cy.log(`first Red Hat filtered tile title text is ${origCatalogTitleTxt}`);
         cy.log('disable the Red Hat filter');
-        cy.byTestID('catalogSourceDisplayName-red-hat').click();
+        cy.byTestID('catalogSourceDisplayName-red-hat', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+          .should('be.visible')
+          .click();
         cy.log('enable the Certified filter');
-        cy.byTestID('catalogSourceDisplayName-certified').click();
-        cy.log('more than one tile should be present');
-        cy.get('.co-catalog-tile').its('length').should('be.gt', 0);
-        cy.log('the first tile title text for Certified should not be the same as Red Hat');
-        cy.get('.co-catalog-tile')
-          .first()
-          .find('.catalog-tile-pf-title')
-          .invoke('text')
-          .should('not.equal', origCatalogTitleTxt);
+        cy.byTestID('catalogSourceDisplayName-certified', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+          .should('be.visible')
+          .click();
+        cy.log('wait for the Certified results to replace the Red Hat list');
+        cy.get('.co-catalog-tile').should(($tiles) => {
+          expect($tiles.length).to.be.gt(0);
+          expect($tiles.first().find('.catalog-tile-pf-title').text()).not.to.equal(
+            origCatalogTitleTxt,
+          );
+        });
       });
 
     cy.log('filters Operators by name');

--- a/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator-hub.view.ts
+++ b/frontend/packages/operator-lifecycle-manager/integration-tests-cypress/views/operator-hub.view.ts
@@ -1,0 +1,15 @@
+/** OperatorHub can render tiles before the search and filter controls are ready. */
+export const OPERATOR_HUB_LOAD_TIMEOUT = 60000;
+
+export const operatorHub = {
+  waitForLoaded: () => {
+    cy.get('.skeleton-catalog--grid', { timeout: OPERATOR_HUB_LOAD_TIMEOUT }).should('not.exist');
+    cy.byTestID('search-operatorhub', { timeout: OPERATOR_HUB_LOAD_TIMEOUT }).should('be.visible');
+    cy.get('[data-test-group-name="catalogSourceDisplayName"]', {
+      timeout: OPERATOR_HUB_LOAD_TIMEOUT,
+    }).should('be.visible');
+    cy.get('.co-catalog-tile', { timeout: OPERATOR_HUB_LOAD_TIMEOUT })
+      .its('length')
+      .should('be.gt', 0);
+  },
+};


### PR DESCRIPTION
Wait for the legacy OperatorHub search, filters, and tiles before interacting so the 4.16 OLM specs stop racing the page load.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->
