### PR TITLE
OCPBUGS-113611: Preserve sort params after project delete

### DIFF
--- a/frontend/public/components/modals/__tests__/delete-namespace-modal.spec.tsx
+++ b/frontend/public/components/modals/__tests__/delete-namespace-modal.spec.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DeleteNamespaceModal } from '../delete-namespace-modal';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  Trans: () => <span />,
+  withTranslation: () => (Component: React.ComponentType) => Component,
+}));
+
+jest.mock('@console/dynamic-plugin-sdk/src/lib-core', () => ({
+  useOverlay: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('@console/internal/module/k8s', () => ({
+  k8sKill: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@console/shared/src/hooks/usePromiseHandler', () => ({
+  usePromiseHandler: () => [(promise: Promise<unknown>) => promise, false, null],
+}));
+
+jest.mock('@console/shared/src/hooks/useConsoleDispatch', () => ({
+  useConsoleDispatch: () => jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks/useConsoleSelector', () => ({
+  useConsoleSelector: () => 'other-namespace',
+}));
+
+jest.mock('@console/shared/src/hooks/useUserPreference', () => ({
+  useUserPreference: () => [null, jest.fn()],
+}));
+
+jest.mock('@console/shared/src/components/modals/ModalFooterWithAlerts', () => ({
+  ModalFooterWithAlerts: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../../../actions/ui', () => ({
+  setActiveNamespace: jest.fn(),
+  formatNamespaceRoute: jest.fn((ns, path) => path),
+}));
+
+const mockKind = {
+  kind: 'Project',
+  plural: 'projects',
+  labelKey: 'Project',
+};
+
+const mockResource = {
+  metadata: { name: 'test-sort-alpha' },
+};
+
+describe('DeleteNamespaceModal', () => {
+  const closeOverlay = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves URL search params (e.g. sort state) when navigating after delete', async () => {
+    window.history.pushState({}, '', '/k8s/cluster/projects?sortBy=Requester&orderBy=asc');
+
+    const user = userEvent.setup();
+    render(
+      <DeleteNamespaceModal
+        kind={mockKind as never}
+        resource={mockResource as never}
+        closeOverlay={closeOverlay}
+      />,
+    );
+
+    await user.type(screen.getByTestId('project-name-input'), 'test-sort-alpha');
+    await user.click(screen.getByTestId('confirm-action'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/k8s/cluster/projects?sortBy=Requester&orderBy=asc',
+      );
+    });
+  });
+});

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -27,7 +27,7 @@ import type { ModalComponentProps } from '@console/shared/src/types/modal';
 import { setActiveNamespace, formatNamespaceRoute } from '../../actions/ui';
 import { getActiveNamespace } from '../../reducers/ui';
 
-const DeleteNamespaceModal: OverlayComponent<DeleteNamespaceModalProps> = ({
+export const DeleteNamespaceModal: OverlayComponent<DeleteNamespaceModalProps> = ({
   kind,
   resource,
   closeOverlay,
@@ -61,7 +61,7 @@ const DeleteNamespaceModal: OverlayComponent<DeleteNamespaceModalProps> = ({
           setLastNamespace(ALL_NAMESPACES_KEY);
         }
         closeOverlay();
-        navigate(`/k8s/cluster/${kind.plural}`);
+        navigate(`/k8s/cluster/${kind.plural}${window.location.search}`);
       })
       .catch(() => {
         /* do nothing */


### PR DESCRIPTION
**Analysis / Root cause**: After a successful delete, the modal navigated to \`/k8s/cluster/${kind.plural}\` without search params, stripping \`sortBy\`/\`orderBy\` and causing ConsoleDataView to reset sort to the default column.

**Solution description**: Append \`window.location.search\` to the navigate call so sort (and page/perPage) params are preserved.

**Screenshots / screen recording**: <!-- add before/after -->

**Test setup:** Go to Home → Projects, sort by Requester, delete a project via the kebab menu.

**Test cases:**
- Sort by Requester, delete a project → sort remains on Requester
- No active sort params → navigate URL unchanged (empty search appended)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:** Regression introduced in 4.21 with the ConsoleDataView migration ([CONSOLE-4719](https://redhat.atlassian.net/browse/CONSOLE-4719)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing URL search parameters after successfully deleting a namespace.

* **Tests**
  * Added coverage to verify navigation retains URL query parameters after namespace deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->