### PR TITLE
[release-4.21] OCPBUGS-113732: make cloud provider fields optional during operator install

### DIFF
--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx
@@ -102,7 +102,7 @@ const InputField: React.FC<InputFieldProps> = ({
   return (
     <div className="form-group">
       <fieldset>
-        <label className="co-required">{label}</label>
+        <label>{label}</label>
         <FieldLevelHelp>{helpText}</FieldLevelHelp>
         <div>
           <TextInput
@@ -489,56 +489,36 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     };
 
     switch (tokenizedAuth) {
-      case 'AWS':
-        subscription.spec.config = {
-          env: [
-            {
-              name: 'ROLEARN',
-              value: roleARNText,
-            },
-          ],
-        };
+      case 'AWS': {
+        const env = [{ name: 'ROLEARN', value: roleARNText }].filter((e) => e.value);
+        if (env.length > 0) {
+          subscription.spec.config = { env };
+        }
         break;
-      case 'Azure':
-        subscription.spec.config = {
-          env: [
-            {
-              name: 'CLIENTID',
-              value: azureClientId,
-            },
-            {
-              name: 'TENANTID',
-              value: azureTenantId,
-            },
-            {
-              name: 'SUBSCRIPTIONID',
-              value: azureSubscriptionId,
-            },
-          ],
-        };
+      }
+      case 'Azure': {
+        const env = [
+          { name: 'CLIENTID', value: azureClientId },
+          { name: 'TENANTID', value: azureTenantId },
+          { name: 'SUBSCRIPTIONID', value: azureSubscriptionId },
+        ].filter((e) => e.value);
+        if (env.length > 0) {
+          subscription.spec.config = { env };
+        }
         break;
-      case 'GCP':
-        subscription.spec.config = {
-          env: [
-            {
-              name: 'PROJECT_NUMBER',
-              value: gcpProjectNumber,
-            },
-            {
-              name: 'POOL_ID',
-              value: gcpPoolId,
-            },
-            {
-              name: 'PROVIDER_ID',
-              value: gcpProviderId,
-            },
-            {
-              name: 'SERVICE_ACCOUNT_EMAIL',
-              value: gcpServiceAcctEmail,
-            },
-          ],
-        };
+      }
+      case 'GCP': {
+        const env = [
+          { name: 'PROJECT_NUMBER', value: gcpProjectNumber },
+          { name: 'POOL_ID', value: gcpPoolId },
+          { name: 'PROVIDER_ID', value: gcpProviderId },
+          { name: 'SERVICE_ACCOUNT_EMAIL', value: gcpServiceAcctEmail },
+        ].filter((e) => e.value);
+        if (env.length > 0) {
+          subscription.spec.config = { env };
+        }
         break;
+      }
       default:
         break;
     }
@@ -589,12 +569,7 @@ export const OperatorHubSubscribeForm: React.FC<OperatorHubSubscribeFormProps> =
     subscriptionExists(selectedTargetNamespace) ||
     !namespaceSupports(selectedTargetNamespace)(selectedInstallMode) ||
     (selectedTargetNamespace && cannotResolve) ||
-    !_.isEmpty(conflictingProvidedAPIs(selectedTargetNamespace)) ||
-    (tokenizedAuth === 'AWS' && _.isEmpty(roleARNText)) ||
-    (tokenizedAuth === 'Azure' &&
-      [azureClientId, azureTenantId, azureSubscriptionId].some((v) => _.isEmpty(v))) ||
-    (tokenizedAuth === 'GCP' &&
-      [gcpProjectNumber, gcpPoolId, gcpProviderId, gcpServiceAcctEmail].some((v) => _.isEmpty(v)));
+    !_.isEmpty(conflictingProvidedAPIs(selectedTargetNamespace));
 
   const formError = () => {
     return (


### PR DESCRIPTION
## Summary

Cherry-pick of #17014 (release-4.22) for release-4.21.

On Workload Identity / Federated Identity clusters (AWS STS, Azure WI, GCP WI), the Console UI incorrectly forces users to provide cloud-specific credentials before installing operators that have `token-auth-*` CSV annotations. These annotations indicate capability, not a mandatory requirement.

This fix makes the cloud provider configuration fields optional so users can install operators first and configure cloud credentials as a Day-2 task.

Note: The 4.21 branch does not include `RESOURCEGROUP` for Azure, so this cherry-pick includes only the 3 Azure env vars (CLIENTID, TENANTID, SUBSCRIPTIONID) vs 4 on 4.22.

## Changes

- Removed `required` attribute and `co-required` CSS class from cloud provider input fields
- Updated subscription creation to filter out empty env vars before setting `spec.config`
- Removed form validation that blocked submission when cloud credential fields were empty

## Test plan

- [ ] Install an operator with `token-auth-*` CSV annotations on a WI/FI cluster with all cloud fields empty — subscription should be created without `spec.config`
- [ ] Install with partial cloud fields — only populated values should appear in `spec.config.env`
- [ ] Install with all cloud fields filled — behavior unchanged from before
- [ ] Verify non-WI cluster operator installation is unaffected