### PR TITLE
OCPBUGS-113631: Fix text alignment in guided tour welcome modal

### DIFF
--- a/frontend/packages/console-app/src/components/tour/TourStepComponent.scss
+++ b/frontend/packages/console-app/src/components/tour/TourStepComponent.scss
@@ -1,3 +1,9 @@
 .co-tour-step-component {
-  display: none !important;
+  .pf-v6-l-grid {
+    align-items: center;
+  }
+
+  > .pf-v6-c-modal-box__footer {
+    display: block;
+  }
 }

--- a/frontend/packages/console-app/src/components/tour/TourStepComponent.scss
+++ b/frontend/packages/console-app/src/components/tour/TourStepComponent.scss
@@ -1,9 +1,3 @@
 .co-tour-step-component {
-  .pf-v6-l-grid {
-    align-items: center;
-  }
-
-  > .pf-v6-c-modal-box__footer {
-    display: block;
-  }
+  display: none !important;
 }

--- a/frontend/packages/console-app/src/components/tour/TourStepComponent.scss
+++ b/frontend/packages/console-app/src/components/tour/TourStepComponent.scss
@@ -1,3 +1,9 @@
-.co-tour-step-component > .pf-v6-c-modal-box__footer {
-  display: block;
+.co-tour-step-component {
+  .pf-v6-l-grid {
+    align-items: center;
+  }
+
+  > .pf-v6-c-modal-box__footer {
+    display: block;
+  }
 }


### PR DESCRIPTION
**Analysis / Root cause**:
The guided tour welcome modal uses a PatternFly `Grid` layout with the illustration banner in a `span={4}` column and the text content in a `span={8}` column. By default, CSS Grid aligns items to the top of the row, causing the text content to appear misaligned (top-heavy) relative to the banner image.

**Solution description**:
Added `align-items: center` to the grid within `.co-tour-step-component`, which vertically centers both the illustration and text content within the grid row.

**Screenshots / screen recording**:
*TODO: Add before/after screenshots*

**Test setup:**
Spin up a clean OpenShift cluster and log in for the first time to trigger the guided tour welcome modal, or reset the `console.guidedTour` user preference in the `user-settings-<username>` ConfigMap in the `openshift-console-user-settings` namespace.

**Test cases:**
- Verify the text content in the welcome modal is vertically centered relative to the illustration
- Verify the modal layout looks correct in both light and dark themes
- Verify the guided tour steps still function correctly after dismissing or launching the tour

**Browser conformance**:
- [x] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
https://redhat.atlassian.net/browse/OCPBUGS-113631

**Reviewers and assignees:**
@openshift/team-ux-review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved tour step layout by vertically centering its content.
  - Preserved the modal footer’s existing block layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->