### PR TITLE
OCPBUGS-78293: Defer 404 catch-all until plugin feature flags settle

### DIFF
--- a/frontend/packages/console-app/src/hooks/usePluginFlagsSettled.ts
+++ b/frontend/packages/console-app/src/hooks/usePluginFlagsSettled.ts
@@ -40,11 +40,6 @@ export const usePluginFlagsSettled = (pluginInfoEntries: PluginInfoEntry[]): boo
 
   const [flagSettlingTimedOut, setFlagSettlingTimedOut] = useState(false);
 
-  // Reset timeout when pending flags resolve so it can fire again
-  // if new flags become pending (e.g. a late-loading plugin).
-  // This uses React's setState-during-render pattern to avoid the
-  // cascading-render issues of calling setState inside useEffect.
-  // See https://react.dev/reference/react/useState#storing-information-from-previous-renders
   const [prevHasPending, setPrevHasPending] = useState(false);
   if (prevHasPending && !hasPendingPluginFlags) {
     setFlagSettlingTimedOut(false);

--- a/frontend/packages/console-app/src/hooks/usePluginFlagsSettled.ts
+++ b/frontend/packages/console-app/src/hooks/usePluginFlagsSettled.ts
@@ -40,16 +40,21 @@ export const usePluginFlagsSettled = (pluginInfoEntries: PluginInfoEntry[]): boo
 
   const [flagSettlingTimedOut, setFlagSettlingTimedOut] = useState(false);
 
-  useEffect(() => {
-    if (!hasPendingPluginFlags) {
-      // Reset timeout when pending flags resolve so it can fire again
-      // if new flags become pending (e.g. a late-loading plugin).
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setFlagSettlingTimedOut(false);
-      return;
-    }
+  // Reset timeout when pending flags resolve so it can fire again
+  // if new flags become pending (e.g. a late-loading plugin).
+  // This uses React's setState-during-render pattern to avoid the
+  // cascading-render issues of calling setState inside useEffect.
+  // See https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [prevHasPending, setPrevHasPending] = useState(false);
+  if (prevHasPending && !hasPendingPluginFlags) {
+    setFlagSettlingTimedOut(false);
+  }
+  if (prevHasPending !== hasPendingPluginFlags) {
+    setPrevHasPending(hasPendingPluginFlags);
+  }
 
-    if (flagSettlingTimedOut) {
+  useEffect(() => {
+    if (!hasPendingPluginFlags || flagSettlingTimedOut) {
       return;
     }
 

--- a/frontend/packages/console-app/src/hooks/usePluginFlagsSettled.ts
+++ b/frontend/packages/console-app/src/hooks/usePluginFlagsSettled.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useMemo } from 'react';
+import type { PluginInfoEntry } from '@openshift/dynamic-plugin-sdk';
+import { flagPending } from '@console/internal/reducers/features';
+import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
+
+const FLAG_SETTLING_TIMEOUT_MS = 3000;
+
+/**
+ * Checks whether all loaded plugin feature flags have settled.
+ *
+ * When a dynamic plugin finishes loading, its `console.flag/hookProvider`
+ * extensions run asynchronously. Until a hookProvider calls `setFeatureFlag`,
+ * its flag value is `undefined` (pending) in Redux. Routes gated on those
+ * flags are invisible to the router during this window.
+ *
+ * This hook inspects each loaded plugin's `manifest.extensions` for required
+ * flags that are still pending, and includes a timeout fallback so that
+ * broken hookProviders do not permanently block the 404 catch-all.
+ *
+ * @param pluginInfoEntries - current plugin information from `usePluginInfo()`
+ * @returns `true` when all plugin flags have resolved or the timeout has elapsed
+ */
+export const usePluginFlagsSettled = (pluginInfoEntries: PluginInfoEntry[]): boolean => {
+  const reduxFlags = useConsoleSelector((state) => state.FLAGS);
+
+  const hasPendingPluginFlags = useMemo(
+    () =>
+      pluginInfoEntries.some((entry) => {
+        if (entry.status === 'pending' || entry.status === 'failed') return false;
+        const extensions = entry.manifest?.extensions;
+        if (!Array.isArray(extensions)) return false;
+        return extensions.some((ext) => {
+          const required = ext.flags?.required;
+          if (!Array.isArray(required) || required.length === 0) return false;
+          return required.some((flagName: string) => flagPending(reduxFlags[flagName]));
+        });
+      }),
+    [pluginInfoEntries, reduxFlags],
+  );
+
+  const [flagSettlingTimedOut, setFlagSettlingTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!hasPendingPluginFlags) {
+      // Reset timeout when pending flags resolve so it can fire again
+      // if new flags become pending (e.g. a late-loading plugin).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setFlagSettlingTimedOut(false);
+      return;
+    }
+
+    if (flagSettlingTimedOut) {
+      return;
+    }
+
+    const timer = setTimeout(() => setFlagSettlingTimedOut(true), FLAG_SETTLING_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [hasPendingPluginFlags, flagSettlingTimedOut]);
+
+  return !hasPendingPluginFlags || flagSettlingTimedOut;
+};

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -10,6 +10,7 @@ import { getReferenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s'
 import { usePluginInfo } from '@console/plugin-sdk/src/api/usePluginInfo';
 import { ErrorBoundaryPage } from '@console/shared/src/components/error/fallbacks/ErrorBoundaryPage';
 import { FLAGS } from '@console/shared/src/constants/common';
+import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import {
   getPerspectiveVisitedKey,
   usePerspectives,
@@ -157,6 +158,36 @@ const AppContents: FC = () => {
     () => pluginInfoEntries.every((i) => i.status !== 'pending'),
     [pluginInfoEntries],
   );
+
+  const reduxFlags = useConsoleSelector((state) => state.FLAGS);
+
+  // Check if any loaded plugin has extensions with required flags still pending
+  const hasPendingPluginFlags = useMemo(
+    () =>
+      pluginInfoEntries.some((entry) => {
+        if (entry.status === 'pending' || entry.status === 'failed') return false;
+        const extensions = entry.manifest?.extensions;
+        if (!Array.isArray(extensions)) return false;
+        return extensions.some((ext) => {
+          const required = ext.flags?.required;
+          if (!Array.isArray(required) || required.length === 0) return false;
+          return required.some((flagName: string) => flagPending(reduxFlags[flagName]));
+        });
+      }),
+    [pluginInfoEntries, reduxFlags],
+  );
+
+  // Timeout fallback: if flags never resolve (broken hookProvider),
+  // stop blocking after 3 seconds
+  const [flagSettlingTimedOut, setFlagSettlingTimedOut] = useState(false);
+  useEffect(() => {
+    if (allPluginsProcessed && hasPendingPluginFlags && !flagSettlingTimedOut) {
+      const timer = setTimeout(() => setFlagSettlingTimedOut(true), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [allPluginsProcessed, hasPendingPluginFlags, flagSettlingTimedOut]);
+
+  const showNotFound = allPluginsProcessed && (!hasPendingPluginFlags || flagSettlingTimedOut);
 
   const contentRouter = (
     <Routes>
@@ -738,7 +769,7 @@ const AppContents: FC = () => {
       {inactivePluginPageRoutes}
       <Route path="/" element={<DefaultPage />} />
 
-      {allPluginsProcessed ? (
+      {showNotFound ? (
         <Route
           path="*"
           element={

--- a/frontend/public/components/app-contents.tsx
+++ b/frontend/public/components/app-contents.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useMemo, Suspense } from 'react';
 import { PageSection } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import { Route, Routes, Navigate, useParams, useLocation, matchRoutes } from 'react-router';
+import { usePluginFlagsSettled } from '@console/app/src/hooks/usePluginFlagsSettled';
 import { usePluginRoutes } from '@console/app/src/hooks/usePluginRoutes';
 import type { Perspective } from '@console/dynamic-plugin-sdk';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
@@ -10,7 +11,6 @@ import { getReferenceForModel } from '@console/dynamic-plugin-sdk/src/utils/k8s'
 import { usePluginInfo } from '@console/plugin-sdk/src/api/usePluginInfo';
 import { ErrorBoundaryPage } from '@console/shared/src/components/error/fallbacks/ErrorBoundaryPage';
 import { FLAGS } from '@console/shared/src/constants/common';
-import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import {
   getPerspectiveVisitedKey,
   usePerspectives,
@@ -159,35 +159,8 @@ const AppContents: FC = () => {
     [pluginInfoEntries],
   );
 
-  const reduxFlags = useConsoleSelector((state) => state.FLAGS);
-
-  // Check if any loaded plugin has extensions with required flags still pending
-  const hasPendingPluginFlags = useMemo(
-    () =>
-      pluginInfoEntries.some((entry) => {
-        if (entry.status === 'pending' || entry.status === 'failed') return false;
-        const extensions = entry.manifest?.extensions;
-        if (!Array.isArray(extensions)) return false;
-        return extensions.some((ext) => {
-          const required = ext.flags?.required;
-          if (!Array.isArray(required) || required.length === 0) return false;
-          return required.some((flagName: string) => flagPending(reduxFlags[flagName]));
-        });
-      }),
-    [pluginInfoEntries, reduxFlags],
-  );
-
-  // Timeout fallback: if flags never resolve (broken hookProvider),
-  // stop blocking after 3 seconds
-  const [flagSettlingTimedOut, setFlagSettlingTimedOut] = useState(false);
-  useEffect(() => {
-    if (allPluginsProcessed && hasPendingPluginFlags && !flagSettlingTimedOut) {
-      const timer = setTimeout(() => setFlagSettlingTimedOut(true), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [allPluginsProcessed, hasPendingPluginFlags, flagSettlingTimedOut]);
-
-  const showNotFound = allPluginsProcessed && (!hasPendingPluginFlags || flagSettlingTimedOut);
+  const pluginFlagsSettled = usePluginFlagsSettled(pluginInfoEntries);
+  const showNotFound = allPluginsProcessed && pluginFlagsSettled;
 
   const contentRouter = (
     <Routes>


### PR DESCRIPTION
The catch-all 404 route activates as soon as all plugins finish loading (allPluginsProcessed). However, plugin feature flag hookProviders need additional time to resolve their flags asynchronously. During this window, flag-gated routes are absent from the router because useExtensions filters out extensions whose required flags are still undefined, causing a momentary 404 flash.

This change adds a check for pending plugin feature flags before showing the 404 page. It inspects each loaded plugin's manifest.extensions for required flags that are still undefined in the Redux FLAGS store. A 3-second timeout fallback ensures broken hookProviders don't permanently block the 404 page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plugin loading and required settings before showing the not-found page.
  * Prevented the not-found page from appearing prematurely while plugin processing and settings are resolving.
  * Added a three-second fallback to keep the interface responsive when settings do not resolve in time.
  * Enhanced reliability when required plugin settings are delayed, unavailable, or fail to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->