### PR TITLE
CONSOLE-5000: Remove Redux activeNamespace in favor of NamespaceContext

### DIFF
--- a/frontend/packages/console-app/src/components/detect-context/namespace.ts
+++ b/frontend/packages/console-app/src/components/detect-context/namespace.ts
@@ -1,12 +1,9 @@
 import { createContext, useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import {
-  setActiveNamespace as setActiveNamespaceForStore,
-  formatNamespaceRoute,
-} from '@console/internal/actions/ui';
+import { formatNamespaceRoute, setActiveApplication } from '@console/internal/actions/ui';
 import { getNamespace } from '@console/internal/components/utils/link';
 import { flagPending } from '@console/internal/reducers/features';
-import { FLAGS } from '@console/shared/src/constants/common';
+import { ALL_APPLICATIONS_KEY, FLAGS } from '@console/shared/src/constants/common';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { usePreferredNamespace } from '../user-preferences/namespace/usePreferredNamespace';
@@ -48,13 +45,13 @@ export const useValuesForNamespaceContext: UseValuesForNamespaceContext = () => 
     (ns: string) => {
       if (ns !== activeNamespaceRef.current) {
         setActiveNamespace(ns);
+        dispatch(setActiveApplication(ALL_APPLICATIONS_KEY));
         const oldPath = window.location.pathname;
         const newPath = formatNamespaceRoute(ns, oldPath, window.location);
         if (newPath !== oldPath) {
           navigateRef.current(newPath);
         }
       }
-      dispatch(setActiveNamespaceForStore(ns));
     },
     [dispatch],
   );

--- a/frontend/packages/console-shared/src/hooks/redux-selectors.ts
+++ b/frontend/packages/console-shared/src/hooks/redux-selectors.ts
@@ -1,4 +1,0 @@
-import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
-
-export const useActiveNamespace = (): string =>
-  useConsoleSelector<string>(({ UI }) => UI.activeNamespace);

--- a/frontend/packages/console-shared/src/hooks/useTabbedTableBreadcrumb.ts
+++ b/frontend/packages/console-shared/src/hooks/useTabbedTableBreadcrumb.ts
@@ -4,8 +4,7 @@ import type { Location } from 'react-router';
 import { createPath } from 'react-router';
 import { getBreadcrumbPath } from '@console/internal/components/utils/breadcrumbs';
 import type { K8sKind } from '@console/internal/module/k8s';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
-import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { ALL_NAMESPACES_KEY } from '../constants/common';
 
 export const useTabbedTableBreadcrumbsFor = (
@@ -20,7 +19,7 @@ export const useTabbedTableBreadcrumbsFor = (
 ) => {
   const { t } = useTranslation('console-shared');
   const { label, labelKey, labelPlural, labelPluralKey } = kindObj;
-  const currentNamespace = useConsoleSelector((state) => getActiveNamespace(state));
+  const [currentNamespace] = useActiveNamespace();
   const nsURL =
     ALL_NAMESPACES_KEY === currentNamespace ? 'all-namespaces' : `ns/${currentNamespace}`;
   return useMemo(

--- a/frontend/packages/dev-console/src/components/import/ImportStrategySelector.tsx
+++ b/frontend/packages/dev-console/src/components/import/ImportStrategySelector.tsx
@@ -13,13 +13,13 @@ import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { useAccessReview } from '@console/dynamic-plugin-sdk/src';
 import { GitProvider, ImportStrategy } from '@console/git-service/src/types/git';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { BuildStrategyType } from '@console/internal/components/utils/build-utils';
 import { FLAG_KNATIVE_SERVING_SERVICE } from '@console/knative-plugin/src/const';
 import { ServiceModel as ksvcModel } from '@console/knative-plugin/src/models';
 import { ServerlessBuildStrategyType } from '@console/knative-plugin/src/types';
 import { ServerlessFunctionIcon } from '@console/knative-plugin/src/utils/icons';
 import { getFieldId } from '@console/shared/src/components/formik-fields/field-utils';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { useFormikValidationFix } from '@console/shared/src/hooks/useFormikValidationFix';
 
@@ -78,10 +78,11 @@ const ImportStrategySelector: FC = () => {
     },
   ];
 
+  const [activeNamespace] = useActiveNamespace();
   const [knativeServiceAccess] = useAccessReview({
     group: ksvcModel.apiGroup,
     resource: ksvcModel.plural,
-    namespace: getActiveNamespace(),
+    namespace: activeNamespace,
     verb: 'create',
   });
 

--- a/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/git/GitSection.tsx
@@ -12,12 +12,12 @@ import { GitProvider, ImportStrategy } from '@console/git-service/src/types/git'
 import { RepoStatus } from '@console/git-service/src/types/repo';
 import type { DetectedBuildType } from '@console/git-service/src/utils/build-tool-type-detector';
 import { detectImportStrategies } from '@console/git-service/src/utils/import-strategy-detector';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { BuildStrategyType } from '@console/internal/components/utils/build-utils';
 import { FLAG_KNATIVE_SERVING_SERVICE } from '@console/knative-plugin/src/const';
 import { ServiceModel as ksvcModel } from '@console/knative-plugin/src/models';
 import { ServerlessBuildStrategyType } from '@console/knative-plugin/src/types';
 import { InputField } from '@console/shared/src/components/formik-fields/InputField';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useDebounceCallback } from '@console/shared/src/hooks/useDebounceCallback';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { useFormikValidationFix } from '@console/shared/src/hooks/useFormikValidationFix';
@@ -109,11 +109,12 @@ const GitSection: FC<GitSectionProps> = ({
     setFieldTouched: formikSetFieldTouched,
   } = useFormikContext<GitSectionFormData>();
 
+  const [activeNamespace] = useActiveNamespace();
   const isKnativeServingAvailable = useFlag(FLAG_KNATIVE_SERVING_SERVICE);
   const [canCreateKnativeService, canCreateKnativeServiceLoading] = useAccessReview({
     group: ksvcModel.apiGroup,
     resource: ksvcModel.plural,
-    namespace: getActiveNamespace(),
+    namespace: activeNamespace,
     verb: 'create',
   });
 

--- a/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
+++ b/frontend/packages/dev-console/src/components/import/section/ResourceSection.tsx
@@ -6,7 +6,6 @@ import * as _ from 'lodash';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { ImportStrategy } from '@console/git-service/src/types/git';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
 import { DeploymentModel, DeploymentConfigModel } from '@console/internal/models';
 import { connectToFlags } from '@console/internal/reducers/connectToFlags';
@@ -15,6 +14,7 @@ import { FLAG_KNATIVE_SERVING_SERVICE } from '@console/knative-plugin/src/const'
 import { ServiceModel } from '@console/knative-plugin/src/models';
 import type { SelectInputOption } from '@console/shared/src/components/formik-fields/field-types';
 import { SingleDropdownField } from '@console/shared/src/components/formik-fields/SingleDropdownField';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { FLAG_OPENSHIFT_DEPLOYMENTCONFIG } from '../../../const';
 import { Resources, ReadableResourcesNames } from '../import-types';
 import FormSection from './FormSection';
@@ -39,10 +39,11 @@ const ResourceSection: FC<ResourceSectionProps> = ({ flags }) => {
       setFieldValue('resources', resourceType);
   }, [resourceType, setFieldValue, values.formType]);
 
+  const [activeNamespace] = useActiveNamespace();
   const knativeServiceAccess = useAccessReview({
     group: ServiceModel.apiGroup,
     resource: ServiceModel.plural,
-    namespace: getActiveNamespace(),
+    namespace: activeNamespace,
     verb: 'create',
   });
   const canIncludeKnative =

--- a/frontend/packages/dev-console/src/components/import/section/build-section/usePipelineAccessReview.ts
+++ b/frontend/packages/dev-console/src/components/import/section/build-section/usePipelineAccessReview.ts
@@ -1,9 +1,10 @@
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { CLUSTER_PIPELINE_NS } from '../../../../const';
 import { PipelineModel } from '../../../../models/pipelines';
 
 export const usePipelineAccessReview = (): boolean => {
+  const [activeNamespace] = useActiveNamespace();
   const canListPipelines = useAccessReview({
     group: PipelineModel.apiGroup,
     resource: PipelineModel.plural,
@@ -14,7 +15,7 @@ export const usePipelineAccessReview = (): boolean => {
   const canCreatePipelines = useAccessReview({
     group: PipelineModel.apiGroup,
     resource: PipelineModel.plural,
-    namespace: getActiveNamespace(),
+    namespace: activeNamespace,
     verb: 'create',
   });
 

--- a/frontend/packages/dev-console/src/components/pipeline-section/pipeline/PipelineSection.tsx
+++ b/frontend/packages/dev-console/src/components/pipeline-section/pipeline/PipelineSection.tsx
@@ -11,10 +11,10 @@ import {
   CLUSTER_PIPELINE_NS,
 } from '@console/dev-console/src/const';
 import type { NormalizedBuilderImages } from '@console/dev-console/src/utils/imagestream-utils';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { useAccessReview } from '@console/internal/components/utils';
 import { connectToFlags } from '@console/internal/reducers/connectToFlags';
 import type { FlagsObject } from '@console/internal/reducers/features';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { PipelineModel } from '../../../models/pipelines';
 import type { PipelineKind } from '../../../types/pipeline';
 import PipelineTemplate from './PipelineTemplate';
@@ -28,6 +28,7 @@ type PipelineSectionProps = {
 };
 
 const usePipelineAccessReview = (): boolean => {
+  const [activeNamespace] = useActiveNamespace();
   const canListPipelines = useAccessReview({
     group: PipelineModel.apiGroup,
     resource: PipelineModel.plural,
@@ -38,7 +39,7 @@ const usePipelineAccessReview = (): boolean => {
   const canCreatePipelines = useAccessReview({
     group: PipelineModel.apiGroup,
     resource: PipelineModel.plural,
-    namespace: getActiveNamespace(),
+    namespace: activeNamespace,
     verb: 'create',
   });
 

--- a/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
+++ b/frontend/packages/knative-plugin/src/components/add/SecretKeySelector.tsx
@@ -3,15 +3,13 @@ import { useState, useEffect } from 'react';
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from '@patternfly/react-core';
 import type { FormikValues } from 'formik';
 import { useFormikContext, useField } from 'formik';
-import { connect } from 'react-redux';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { ErrorModal } from '@console/internal/components/modals/error-modal';
 import { ValueFromPair } from '@console/internal/components/utils/value-from-pair';
 import { SecretModel } from '@console/internal/models';
 import { k8sGet } from '@console/internal/module/k8s';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
-import type { RootState } from '@console/internal/redux';
 import { getFieldId } from '@console/shared/src/components/formik-fields/field-utils';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useFormikValidationFix } from '@console/shared/src/hooks/useFormikValidationFix';
 
 interface SecretKeySelectorProps {
@@ -20,22 +18,14 @@ interface SecretKeySelectorProps {
   isRequired?: boolean;
 }
 
-interface StateProps {
-  namespace: string;
-}
-
-const SecretKeySelector: FC<SecretKeySelectorProps & StateProps> = ({
-  name,
-  label,
-  namespace,
-  isRequired = false,
-}) => {
+const SecretKeySelector: FC<SecretKeySelectorProps> = ({ name, label, isRequired = false }) => {
   const { setFieldValue, setFieldTouched } = useFormikContext<FormikValues>();
   const [field, { touched, error }] = useField(name);
   const [secrets, setSecrets] = useState({});
   const launchModal = useOverlay();
   const fieldId = getFieldId(name, 'secret-key-input');
   const isValid = !(touched && error);
+  const [namespace] = useActiveNamespace();
 
   const getErrorMessage = (err: string | { name?: string; key?: string }): string => {
     let errMsg = '';
@@ -85,10 +75,4 @@ const SecretKeySelector: FC<SecretKeySelectorProps & StateProps> = ({
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
-  namespace: getActiveNamespace(state),
-});
-
-export default connect<StateProps, null, SecretKeySelectorProps>(mapStateToProps)(
-  SecretKeySelector,
-);
+export default SecretKeySelector;

--- a/frontend/packages/knative-plugin/src/components/dropdowns/ServiceAccountDropdown.tsx
+++ b/frontend/packages/knative-plugin/src/components/dropdowns/ServiceAccountDropdown.tsx
@@ -2,30 +2,21 @@ import type { FC } from 'react';
 import { useMemo } from 'react';
 import * as fuzzy from 'fuzzysearch';
 import { useTranslation } from 'react-i18next';
-import { connect } from 'react-redux';
 import { useK8sWatchResource } from '@console/internal/components/utils/k8s-watch-hook';
 import { ServiceAccountModel } from '@console/internal/models';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
-import type { RootState } from '@console/internal/redux';
 import type { ResourceDropdownItems } from '@console/shared/src/components/dropdown/ResourceDropdown';
 import { ResourceDropdownField } from '@console/shared/src/components/formik-fields/ResourceDropdownField';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 
 interface ServiceAccountDropdownProps {
   name: string;
   onLoad?: (items: ResourceDropdownItems) => void;
 }
 
-interface StateProps {
-  namespace: string;
-}
-
-const ServiceAccountDropdown: FC<ServiceAccountDropdownProps & StateProps> = ({
-  name,
-  onLoad,
-  namespace,
-}) => {
+const ServiceAccountDropdown: FC<ServiceAccountDropdownProps> = ({ name, onLoad }) => {
   const { t } = useTranslation('knative-plugin');
+  const [namespace] = useActiveNamespace();
   const autocompleteFilter = (strText, item): boolean => fuzzy(strText, item?.props?.name);
 
   const [saData, saLoaded, saLoadError] = useK8sWatchResource<K8sResourceKind[]>({
@@ -63,10 +54,4 @@ const ServiceAccountDropdown: FC<ServiceAccountDropdownProps & StateProps> = ({
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => ({
-  namespace: getActiveNamespace(state),
-});
-
-export default connect<StateProps, null, ServiceAccountDropdownProps>(mapStateToProps)(
-  ServiceAccountDropdown,
-);
+export default ServiceAccountDropdown;

--- a/frontend/packages/operator-lifecycle-manager/src/components/__tests__/clusterserviceversion.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/__tests__/clusterserviceversion.spec.tsx
@@ -34,10 +34,6 @@ jest.mock('@console/dynamic-plugin-sdk', () => ({
   useAccessReviewAllowed: () => true,
 }));
 
-jest.mock('@console/shared/src/hooks/redux-selectors', () => ({
-  useActiveNamespace: jest.fn(),
-}));
-
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useParams: jest.fn(() => ({})),

--- a/frontend/packages/operator-lifecycle-manager/src/components/__tests__/package-manifest.spec.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/__tests__/package-manifest.spec.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import * as UIActions from '@console/internal/actions/ui';
 import { ResourceLink } from '@console/internal/components/utils';
 import { Timestamp } from '@console/shared/src/components/datetime/Timestamp';
 import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-utils';
@@ -23,13 +22,6 @@ jest.mock('@console/internal/components/utils', () => ({
   ...jest.requireActual('@console/internal/components/utils'),
   ResourceLink: jest.fn(() => null),
 }));
-
-jest.mock('@console/internal/actions/ui', () => ({
-  ...jest.requireActual('@console/internal/actions/ui'),
-  getActiveNamespace: jest.fn(),
-}));
-
-const getActiveNamespaceMock = UIActions.getActiveNamespace as jest.Mock;
 
 const mockClusterServiceVersionLogo = ClusterServiceVersionLogo as jest.Mock;
 const mockTimestamp = Timestamp as jest.Mock;
@@ -62,7 +54,6 @@ describe('PackageManifestTableHeaderWithCatalogSource', () => {
 describe('PackageManifestTableRow', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getActiveNamespaceMock.mockReturnValue('default');
   });
 
   it('renders column for package name and logo', () => {

--- a/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/clusterserviceversion.tsx
@@ -80,7 +80,7 @@ import {
   COLUMN_MANAGEMENT_USER_PREFERENCE_KEY,
 } from '@console/shared/src/constants/common';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants/resource';
-import { useActiveNamespace } from '@console/shared/src/hooks/redux-selectors';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { useK8sModel } from '@console/shared/src/hooks/useK8sModel';
 import { useUserPreference } from '@console/shared/src/hooks/useUserPreference';
@@ -663,7 +663,7 @@ const CSVListEmptyMsg = () => {
 
 const CSVListNoDataEmptyMsg = () => {
   const { t } = useTranslation('olm');
-  const project = useActiveNamespace();
+  const [project] = useActiveNamespace();
   const noOperatorsInSingleNamespaceMessage = t(
     'No Operators are available for project {{project}}.',
     { project },
@@ -712,7 +712,7 @@ const ClusterServiceVersionList: FC<ClusterServiceVersionListProps> = ({
   ...rest
 }) => {
   const { t } = useTranslation('olm');
-  const activeNamespace = useActiveNamespace();
+  const [activeNamespace] = useActiveNamespace();
   const lifecycleEnabled = useFlag(Flags.OPERATOR_LIFECYCLE_METADATA);
 
   const nameHeader: Header = {

--- a/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/modals/uninstall-operator-modal.tsx
@@ -21,7 +21,6 @@ import type { OverlayComponent } from '@console/dynamic-plugin-sdk/src/app/modal
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/useOverlay';
 import { k8sGetResource } from '@console/dynamic-plugin-sdk/src/utils/k8s';
 import { settleAllPromises } from '@console/dynamic-plugin-sdk/src/utils/promise';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import {
   LinkifyExternal,
   ResourceLink,
@@ -41,6 +40,7 @@ import {
 } from '@console/internal/module/k8s';
 import { ModalFooterWithAlerts } from '@console/shared/src/components/modals/ModalFooterWithAlerts';
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '@console/shared/src/constants/resource';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useOperands } from '@console/shared/src/hooks/useOperands';
 import { usePromiseHandler } from '@console/shared/src/hooks/usePromiseHandler';
 import type { ModalComponentProps } from '@console/shared/src/types/modal';
@@ -71,6 +71,7 @@ export const UninstallOperatorModal: FC<UninstallOperatorModalProps> = ({
 }) => {
   const { t } = useTranslation('olm');
   const navigate = useNavigate();
+  const [activeNamespace] = useActiveNamespace();
   const [
     handleOperatorUninstallPromise,
     operatorUninstallInProgress,
@@ -235,9 +236,9 @@ export const UninstallOperatorModal: FC<UninstallOperatorModalProps> = ({
       window.location.pathname.split('/').includes(subscription.metadata.name) ||
       window.location.pathname.split('/').includes(subscription?.status?.installedCSV)
     ) {
-      navigate(resourceListPathFromModel(ClusterServiceVersionModel, getActiveNamespace()));
+      navigate(resourceListPathFromModel(ClusterServiceVersionModel, activeNamespace));
     }
-  }, [close, navigate, subscription]);
+  }, [activeNamespace, close, navigate, subscription]);
 
   useEffect(() => {
     if (isSubmitFinished && !hasSubmitErrors) {

--- a/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
+++ b/frontend/packages/operator-lifecycle-manager/src/components/operator-group.tsx
@@ -3,10 +3,10 @@ import { Component as ReactComponent } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { referenceForModel, referenceForGroupVersionKind } from '@console/internal/module/k8s';
 import { ConsoleEmptyState } from '@console/shared/src/components/empty-state/ConsoleEmptyState';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { OPERATOR_NAMESPACE_ANNOTATION } from '../const';
 import { OperatorGroupModel } from '../models';
 import type { OperatorGroupKind, SubscriptionKind, PackageManifestKind } from '../types';
@@ -21,10 +21,11 @@ export const operatorGroupFor = (obj: K8sResourceKind) =>
 
 const NoOperatorGroupMsg: FC = () => {
   const { t } = useTranslation('olm');
+  const [activeNamespace] = useActiveNamespace();
   const actions = [
     <Link
       key="create-operator-group"
-      to={`/ns/${getActiveNamespace()}/${referenceForModel(OperatorGroupModel)}/~new`}
+      to={`/ns/${activeNamespace}/${referenceForModel(OperatorGroupModel)}/~new`}
     >
       {t('Create an OperatorGroup for this Namespace')}
     </Link>,

--- a/frontend/packages/topology/src/components/application-panel/ApplicationGroupResource.tsx
+++ b/frontend/packages/topology/src/components/application-panel/ApplicationGroupResource.tsx
@@ -2,10 +2,10 @@ import type { FC } from 'react';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-import { getActiveNamespace } from '@console/internal/actions/ui';
 import { SidebarSectionHeading } from '@console/internal/components/utils';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { referenceFor } from '@console/internal/module/k8s';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import TopologyApplicationResourceList from './TopologyApplicationList';
 
 const MAX_RESOURCES = 5;
@@ -22,13 +22,14 @@ const ApplicationGroupResource: FC<ApplicationGroupResourceProps> = ({
   group,
 }) => {
   const { t } = useTranslation('topology');
+  const [activeNamespace] = useActiveNamespace();
   return !_.isEmpty(resourcesData) ? (
     <div className="overview__sidebar-pane-body">
       <SidebarSectionHeading text={title}>
         {_.size(resourcesData) > MAX_RESOURCES && (
           <Link
             className="sidebar__section-view-all"
-            to={`/search/ns/${getActiveNamespace()}?kind=${referenceFor(
+            to={`/search/ns/${activeNamespace}?kind=${referenceFor(
               resourcesData[0],
             )}&q=${encodeURIComponent(`app.kubernetes.io/part-of=${group}`)}`}
           >

--- a/frontend/packages/topology/src/components/dropdowns/NamespaceBarApplicationSelector.tsx
+++ b/frontend/packages/topology/src/components/dropdowns/NamespaceBarApplicationSelector.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 import { setActiveApplication } from '@console/internal/actions/ui';
-import { getActiveNamespace, getActiveApplication } from '@console/internal/reducers/ui';
+import { getActiveApplication } from '@console/internal/reducers/ui';
 import type { RootState } from '@console/internal/redux';
 import {
   ALL_NAMESPACES_KEY,
@@ -12,6 +12,7 @@ import {
   UNASSIGNED_APPLICATIONS_KEY,
   APPLICATION_USER_PREFERENCE_PREFIX,
 } from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import ApplicationDropdown from './ApplicationDropdown';
 
 interface NamespaceBarApplicationSelectorProps {
@@ -19,7 +20,6 @@ interface NamespaceBarApplicationSelectorProps {
 }
 
 interface StateProps {
-  namespace: string;
   application: string;
 }
 
@@ -29,12 +29,8 @@ interface DispatchProps {
 
 type Props = NamespaceBarApplicationSelectorProps & StateProps & DispatchProps;
 
-const NamespaceBarApplicationSelector: FC<Props> = ({
-  namespace,
-  application,
-  onChange,
-  disabled,
-}) => {
+const NamespaceBarApplicationSelector: FC<Props> = ({ application, onChange, disabled }) => {
+  const [namespace] = useActiveNamespace();
   const { t } = useTranslation('topology');
   const allApplicationsTitle = t('All applications');
   const noApplicationsTitle = t('No application group');
@@ -80,7 +76,6 @@ const NamespaceBarApplicationSelector: FC<Props> = ({
 };
 
 const mapStateToProps = (state: RootState): StateProps => ({
-  namespace: getActiveNamespace(state),
   application: getActiveApplication(state),
 });
 

--- a/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
+++ b/frontend/packages/topology/src/filters/TopologyFilterBar.tsx
@@ -22,9 +22,9 @@ import { ConsoleLinkModel } from '@console/internal/models';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { referenceForModel } from '@console/internal/module/k8s';
 import { requirementFromString } from '@console/internal/module/k8s/selector-requirement';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
 import type { RootState } from '@console/internal/redux';
 import { ExternalLink } from '@console/shared/src/components/links/ExternalLink';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
 import { useQueryParams } from '@console/shared/src/hooks/useQueryParams';
 import { useQueryParamsMutator } from '@console/shared/src/hooks/useQueryParamsMutator';
@@ -49,7 +49,6 @@ import './TopologyFilterBar.scss';
 type StateProps = {
   supportedFilters: string[];
   supportedKinds: { [key: string]: number };
-  namespace: string;
 };
 
 type OwnProps = {
@@ -67,9 +66,9 @@ const TopologyFilterBar: FC<TopologyFilterBarProps> = ({
   isDisabled,
   visualization,
   viewType,
-  namespace,
   setIsQuickSearchOpen,
 }) => {
+  const [namespace] = useActiveNamespace();
   const { setQueryArgument, removeQueryArgument, removeQueryArguments } = useQueryParamsMutator();
   const { t } = useTranslation('topology');
   const { filters, setTopologyFilters: onFiltersChange } = useContext(FilterContext);
@@ -237,13 +236,9 @@ const TopologyFilterBar: FC<TopologyFilterBarProps> = ({
   );
 };
 
-const mapStateToProps = (state: RootState): StateProps => {
-  const states = {
-    supportedFilters: getSupportedTopologyFilters(state),
-    supportedKinds: getSupportedTopologyKinds(state),
-    namespace: getActiveNamespace(state),
-  };
-  return states;
-};
+const mapStateToProps = (state: RootState): StateProps => ({
+  supportedFilters: getSupportedTopologyFilters(state),
+  supportedKinds: getSupportedTopologyKinds(state),
+});
 
 export default connect<StateProps>(mapStateToProps)(TopologyFilterBar);

--- a/frontend/packages/webterminal-plugin/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
+++ b/frontend/packages/webterminal-plugin/src/components/cloud-shell/setup/CloudShellDeveloperSetup.tsx
@@ -9,6 +9,7 @@ import type { K8sKind } from '@console/internal/module/k8s';
 import { k8sCreate } from '@console/internal/module/k8s';
 import type { RootState } from '@console/internal/redux';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { newCloudShellWorkSpace, createCloudShellResourceName } from '../cloud-shell-utils';
 import type { CloudShellSetupFormData } from './cloud-shell-setup-utils';
 import {
@@ -20,7 +21,6 @@ import CloudShellSetupForm from './CloudShellSetupForm';
 import './CloudShellSetup.scss';
 
 interface StateProps {
-  activeNamespace: string;
   username: string;
 }
 
@@ -32,12 +32,12 @@ type Props = StateProps & {
 };
 
 const CloudShellDeveloperSetup: FC<Props> = ({
-  activeNamespace,
   workspaceModel,
   operatorNamespace,
   onSubmit,
   onCancel,
 }) => {
+  const [activeNamespace] = useActiveNamespace();
   const initialValues: CloudShellSetupFormData = {
     namespace: activeNamespace === ALL_NAMESPACES_KEY ? undefined : activeNamespace,
     advancedOptions: {
@@ -100,7 +100,6 @@ const CloudShellDeveloperSetup: FC<Props> = ({
 
 const mapStateToProps = (state: RootState): StateProps => ({
   username: getUser(state)?.username || '',
-  activeNamespace: state.UI.activeNamespace,
 });
 
 export default connect<StateProps>(mapStateToProps)(CloudShellDeveloperSetup);

--- a/frontend/public/actions/__tests__/ui.spec.ts
+++ b/frontend/public/actions/__tests__/ui.spec.ts
@@ -1,13 +1,4 @@
-import * as _ from 'lodash';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
-import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
-import { formatNamespacedRouteForResource } from '@console/shared/src/utils/namespace';
-import store from '../../redux';
 import * as UIActions from '../ui';
-
-const setActiveNamespace = (ns) => store.dispatch(UIActions.setActiveNamespace(ns));
-const getNamespacedRoute = (path) =>
-  UIActions.formatNamespaceRoute(getActiveNamespace(store.getState()), path);
 
 describe('ui-actions', () => {
   describe('UIActions.formatNamespaceRoute', () => {
@@ -55,70 +46,6 @@ describe('ui-actions', () => {
       const location = { search: '?page=2', hash: '' };
       expect(UIActions.formatNamespaceRoute('bar', '/k8s/ns/foo/pods', location)).toEqual(
         '/k8s/ns/bar/pods',
-      );
-    });
-  });
-
-  describe('setActiveNamespace', () => {
-    it('should set active namespace in memory', () => {
-      setActiveNamespace('test1');
-      expect(getActiveNamespace(store.getState())).toEqual('test1');
-      setActiveNamespace('test2');
-      expect(getActiveNamespace(store.getState())).toEqual('test2');
-    });
-
-    it('sets active namespace in memory to all-namespaces', () => {
-      setActiveNamespace('test');
-      setActiveNamespace(ALL_NAMESPACES_KEY);
-      expect(_.isUndefined(getActiveNamespace(store.getState()))).toBe(false);
-      expect(getActiveNamespace(store.getState())).toEqual(ALL_NAMESPACES_KEY);
-    });
-
-    it('should format namespaced location paths for known namespace-friendly prefixes', () => {
-      setActiveNamespace('dessert-topping');
-      expect(
-        formatNamespacedRouteForResource('pods', getActiveNamespace(store.getState())),
-      ).toEqual('/k8s/ns/dessert-topping/pods');
-    });
-
-    it('should format all-namespaces paths correctly', () => {
-      setActiveNamespace(ALL_NAMESPACES_KEY);
-      expect(
-        formatNamespacedRouteForResource('pods', getActiveNamespace(store.getState())),
-      ).toEqual('/k8s/all-namespaces/pods');
-    });
-
-    it('should set active namespace correctly', () => {
-      setActiveNamespace('dessert-topping');
-      expect(getActiveNamespace(store.getState())).toEqual('dessert-topping');
-    });
-  });
-
-  describe('getNamespacedRoute', () => {
-    it('formats a route correctly without an active namespace', () => {
-      setActiveNamespace(ALL_NAMESPACES_KEY);
-      expect(getNamespacedRoute('/k8s/ns/hello/pods')).toEqual('/k8s/all-namespaces/pods');
-      expect(getNamespacedRoute('/k8s/ns/hello/pods/GRIBBL')).toEqual('/k8s/all-namespaces/pods');
-    });
-
-    it('formats a route with the current active namespace', () => {
-      setActiveNamespace('test');
-      expect(getNamespacedRoute('/k8s/ns/hello/pods')).toEqual('/k8s/ns/test/pods');
-      expect(getNamespacedRoute('/k8s/ns/hello/pods/GRIBBL')).toEqual('/k8s/ns/test/pods');
-    });
-
-    it("preserves paths that aren't namespaced", () => {
-      setActiveNamespace(ALL_NAMESPACES_KEY);
-      expect(getNamespacedRoute('/')).toEqual('/');
-      expect(getNamespacedRoute('/gribbl')).toEqual('/gribbl');
-      expect(getNamespacedRoute('/pods')).toEqual('/pods');
-    });
-
-    it('parses resource from path', () => {
-      setActiveNamespace(ALL_NAMESPACES_KEY);
-      expect(getNamespacedRoute('/k8s/ns/foo/pods')).toEqual('/k8s/all-namespaces/pods');
-      expect(getNamespacedRoute('/k8s/ns/foo/pods/WACKY_SUFFIX')).toEqual(
-        '/k8s/all-namespaces/pods',
       );
     });
   });

--- a/frontend/public/actions/common.ts
+++ b/frontend/public/actions/common.ts
@@ -5,7 +5,6 @@ export enum ActionType {
   SelectOverviewDetailsTab = 'selectOverviewDetailsTab',
   SelectOverviewItem = 'selectOverviewItem',
   SetActiveApplication = 'setActiveApplication',
-  SetActiveNamespace = 'setActiveNamespace',
   SetCreateProjectMessage = 'setCreateProjectMessage',
   SetCurrentLocation = 'setCurrentLocation',
   SetServiceLevel = 'setServiceLevel',

--- a/frontend/public/actions/ui.ts
+++ b/frontend/public/actions/ui.ts
@@ -12,10 +12,7 @@ import type {
   NamespaceMetrics,
 } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import type { DeprecatedOperatorWarning } from '@console/operator-lifecycle-manager/src/types';
-import {
-  ALL_NAMESPACES_KEY,
-  LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY,
-} from '@console/shared/src/constants/common';
+import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
 import type { OverviewItem } from '@console/shared/src/types/resource';
 import type { OverviewSpecialGroup } from '../components/overview/constants';
 import type { K8sResourceKind, PodKind, NodeKind } from '../module/k8s';
@@ -55,7 +52,6 @@ export type PluginCSPViolations = {
   [pluginName: string]: boolean;
 };
 
-export const getActiveNamespace = (): string => store.getState().UI.activeNamespace;
 export const getActiveUserName = (): string => getUser(store.getState())?.username;
 
 export const getNamespaceMetric = (ns: K8sResourceKind, metric: string): number => {
@@ -156,21 +152,6 @@ export const setServiceLevel = (
 
 export const setActiveApplication = (application: string) =>
   action(ActionType.SetActiveApplication, { application });
-
-export const setActiveNamespace = (namespace: string = '') => {
-  const trimmedNamespace = namespace.trim();
-  // make it noop when new active namespace is the same
-  // otherwise users will get page refresh and cry about
-  // broken direct links and bookmarks
-  if (trimmedNamespace !== getActiveNamespace()) {
-    // save last namespace in session storage (persisted only for current browser tab). Used to remember/restore if
-    // "All Projects" was selected when returning to the list view (typically from details view) via breadcrumb or
-    // sidebar navigation
-    sessionStorage.setItem(LAST_NAMESPACE_NAME_LOCAL_STORAGE_KEY, trimmedNamespace);
-  }
-
-  return action(ActionType.SetActiveNamespace, { namespace: trimmedNamespace });
-};
 
 /**
  * Encodes a string for use in Kubernetes impersonation subprotocols.
@@ -280,7 +261,6 @@ const uiActions = {
   setCurrentLocation,
   setShowOperandsInAllNamespaces,
   setActiveApplication,
-  setActiveNamespace,
   sortList,
   setCreateProjectMessage,
   setClusterID,

--- a/frontend/public/components/api-explorer.tsx
+++ b/frontend/public/components/api-explorer.tsx
@@ -39,6 +39,7 @@ import { PageHeading } from '@console/shared/src/components/heading/PageHeading'
 import PaneBody from '@console/shared/src/components/layout/PaneBody';
 import { PageTitleContext } from '@console/shared/src/components/pagetitle/PageTitleContext';
 import { ALL_NAMESPACES_KEY, FLAGS } from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { useQueryParamsMutator } from '@console/shared/src/hooks/useQueryParamsMutator';
 import type { APIError } from '@console/shared/src/types/resource';
@@ -58,7 +59,6 @@ import {
   referenceForModel,
 } from '../module/k8s';
 import { connectToFlags } from '../reducers/connectToFlags';
-import type { RootState } from '../redux';
 import { DefaultPage } from './default-resource';
 import { ErrorPage404 } from './error';
 import { exactMatch, fuzzyCaseInsensitive } from './factory/table-filters';
@@ -71,10 +71,6 @@ import { LinkifyExternal } from './utils/link';
 import { ResourceIcon } from './utils/resource-icon';
 import { ScrollToTopOnMount } from './utils/scroll-to-top-on-mount';
 import { LoadError, LoadingBox } from './utils/status-box';
-
-const mapStateToProps = (state: RootState): APIResourceLinkStateProps => ({
-  activeNamespace: state.UI.activeNamespace,
-});
 
 const getAPIResourceLink = (activeNamespace: string, model: K8sKind) => {
   const ref = referenceForModel(model);
@@ -89,11 +85,9 @@ const getAPIResourceLink = (activeNamespace: string, model: K8sKind) => {
   return `/api-resource/ns/${activeNamespace}/${ref}`;
 };
 
-const InnerAPIResourceLink: FC<APIResourceLinkStateProps & APIResourceLinkOwnProps> = ({
-  activeNamespace,
-  model,
-}) => {
+const InnerAPIResourceLink: FC<APIResourceLinkOwnProps> = ({ model }) => {
   const { t } = useTranslation('public');
+  const [activeNamespace] = useActiveNamespace();
   const to = getAPIResourceLink(activeNamespace, model);
   return (
     <span className="co-resource-item">
@@ -106,9 +100,7 @@ const InnerAPIResourceLink: FC<APIResourceLinkStateProps & APIResourceLinkOwnPro
     </span>
   );
 };
-const APIResourceLink = connect<APIResourceLinkStateProps, {}, APIResourceLinkOwnProps>(
-  mapStateToProps,
-)(InnerAPIResourceLink);
+const APIResourceLink = InnerAPIResourceLink;
 
 const Group: FC<{ value: string }> = ({ value }) => {
   if (!value) {
@@ -1049,10 +1041,6 @@ const k8StateToProps = ({ k8s }) => ({
 export const APIResourcePage = connect(k8StateToProps)(
   connectToFlags(FLAGS.OPENSHIFT)(InnerAPIResourcePage),
 );
-
-type APIResourceLinkStateProps = {
-  activeNamespace: string;
-};
 
 type APIResourceLinkOwnProps = {
   model: K8sKind;

--- a/frontend/public/components/edit-yaml.tsx
+++ b/frontend/public/components/edit-yaml.tsx
@@ -18,7 +18,6 @@ import { useOverlay } from '@console/dynamic-plugin-sdk/src/app/modal-support/us
 import type { CodeEditorProps } from '@console/dynamic-plugin-sdk/src/extensions/console-types';
 import { useK8sWatchResources } from '@console/internal/components/utils/k8s-watch-hook';
 import { ActionType, getOLSCodeBlock } from '@console/internal/reducers/ols';
-import { getActiveNamespace } from '@console/internal/reducers/ui';
 import type { RootState } from '@console/internal/redux';
 import { ClusterServiceVersionModel } from '@console/operator-lifecycle-manager/src/models';
 import { getBadgeFromType } from '@console/shared/src/components/badges/badge-factory';
@@ -30,6 +29,7 @@ import { fold } from '@console/shared/src/components/editor/yaml-editor-utils';
 import { PageHeading } from '@console/shared/src/components/heading/PageHeading';
 import PageBody from '@console/shared/src/components/layout/PageBody';
 import { FLAGS, ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { useFlag } from '@console/shared/src/hooks/useFlag';
@@ -81,7 +81,6 @@ const generateObjToLoad = (
 };
 
 const stateToProps = (state: RootState) => ({
-  activeNamespace: getActiveNamespace(state),
   impersonate: getImpersonate(state),
   models: state.k8s.RESOURCES?.models as Record<string, K8sModel>,
 });
@@ -152,6 +151,7 @@ const EditYAMLInner: FC<EditYAMLInnerProps> = (props) => {
     isCodeImportRedirect,
   } = props;
 
+  const [activeNamespace] = useActiveNamespace();
   const navigate = useNavigate();
   const hasYAMLSampleFlag = useFlag(FLAGS.CONSOLE_YAML_SAMPLE);
 
@@ -231,9 +231,7 @@ const EditYAMLInner: FC<EditYAMLInnerProps> = (props) => {
   const navigateToResourceList = () => {
     if (model) {
       const namespace =
-        model.namespaced && props.activeNamespace !== ALL_NAMESPACES_KEY
-          ? props.activeNamespace
-          : undefined;
+        model.namespaced && activeNamespace !== ALL_NAMESPACES_KEY ? activeNamespace : undefined;
       navigate(resourceListPathFromModel(model, namespace));
     } else {
       navigate(-1); // fallback to previous page if no model available
@@ -573,13 +571,13 @@ const EditYAMLInner: FC<EditYAMLInnerProps> = (props) => {
 
       // If this is a namespaced resource, default to the active namespace when none is specified in the YAML.
       if (!obj.metadata.namespace && objModel.namespaced) {
-        if (props.activeNamespace === ALL_NAMESPACES_KEY) {
+        if (activeNamespace === ALL_NAMESPACES_KEY) {
           return t('No "metadata.namespace" field found in YAML.');
         }
-        obj.metadata.namespace = props.activeNamespace;
+        obj.metadata.namespace = activeNamespace;
       }
     },
-    [props.activeNamespace, t, getModel],
+    [activeNamespace, t, getModel],
   );
 
   const [saving, setSaving] = useState(false);

--- a/frontend/public/components/factory/table.tsx
+++ b/frontend/public/components/factory/table.tsx
@@ -26,6 +26,7 @@ import type {
 import { defaultChannelFor } from '@console/operator-lifecycle-manager/src/components';
 import type { PackageManifestKind } from '@console/operator-lifecycle-manager/src/types';
 import { ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import { useDeepCompareMemoize } from '@console/shared/src/hooks/useDeepCompareMemoize';
 import { getName } from '@console/shared/src/selectors/common';
@@ -153,11 +154,10 @@ const isColumnVisible = (
   columnID: string,
   columns: Set<string> = new Set(),
   showNamespaceOverride = undefined,
+  activeNamespace: string = '',
 ) => {
   const showNamespace =
-    columnID !== 'namespace' ||
-    UIActions.getActiveNamespace() === ALL_NAMESPACES_KEY ||
-    showNamespaceOverride;
+    columnID !== 'namespace' || activeNamespace === ALL_NAMESPACES_KEY || showNamespaceOverride;
   if (_.isEmpty(columns) && showNamespace) {
     return true;
   }
@@ -190,12 +190,20 @@ export const TableData: FC<TableDataProps> = ({
   dataTest,
   showNamespaceOverride,
   children,
-}) =>
-  isColumnVisible(window.innerWidth, columnID, columns, showNamespaceOverride) ? (
+}) => {
+  const [activeNamespace] = useActiveNamespace();
+  return isColumnVisible(
+    window.innerWidth,
+    columnID,
+    columns,
+    showNamespaceOverride,
+    activeNamespace,
+  ) ? (
     <Td data-label={columnID} className={className} role="gridcell" data-test={dataTest}>
       {children}
     </Td>
   ) : null;
+};
 TableData.displayName = 'TableData';
 export type TableDataProps = {
   children?: ReactNode;
@@ -322,6 +330,7 @@ const getActiveColumns = (
   activeColumns: Set<string>,
   columnManagementID: string,
   showNamespaceOverride: boolean,
+  activeNamespace: string,
 ): TableColumn[] => {
   let columns = Header(componentProps);
   let resolvedActiveColumns = activeColumns;
@@ -338,15 +347,19 @@ const getActiveColumns = (
   if (columnManagementID) {
     columns = columns?.filter(
       (col) =>
-        isColumnVisible(windowWidth, col.id, resolvedActiveColumns, showNamespaceOverride) ||
-        col.title === '',
+        isColumnVisible(
+          windowWidth,
+          col.id,
+          resolvedActiveColumns,
+          showNamespaceOverride,
+          activeNamespace,
+        ) || col.title === '',
     );
   } else {
     columns = columns?.filter((col) => resolvedActiveColumns.has(col.id) || col.title === '');
   }
 
-  const showNamespace =
-    UIActions.getActiveNamespace() === ALL_NAMESPACES_KEY || showNamespaceOverride;
+  const showNamespace = activeNamespace === ALL_NAMESPACES_KEY || showNamespaceOverride;
   if (!showNamespace) {
     columns = columns.filter((column) => column.id !== 'namespace');
   }
@@ -500,6 +513,7 @@ export const Table: FC<TableProps> = ({
 }) => {
   const dispatch = useConsoleDispatch();
   const navigate = useNavigate();
+  const [activeNamespace] = useActiveNamespace();
   const filters = useDeepCompareMemoize(initFilters);
   const Header = useDeepCompareMemoize(initHeader);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
@@ -532,6 +546,7 @@ export const Table: FC<TableProps> = ({
         activeColumns,
         columnManagementID,
         showNamespaceOverride,
+        activeNamespace,
       ),
     [
       windowWidth,
@@ -543,6 +558,7 @@ export const Table: FC<TableProps> = ({
       activeColumns,
       columnManagementID,
       showNamespaceOverride,
+      activeNamespace,
     ],
   );
 

--- a/frontend/public/components/graphs/__tests__/prometheus-graph.spec.tsx
+++ b/frontend/public/components/graphs/__tests__/prometheus-graph.spec.tsx
@@ -1,7 +1,6 @@
 import { act, screen } from '@testing-library/react';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { setFlag } from '@console/internal/actions/flags';
-import * as UIActions from '@console/internal/actions/ui';
 import {
   PrometheusGraph,
   PrometheusGraphLink,
@@ -11,6 +10,10 @@ import { renderWithProviders } from '@console/shared/src/test-utils/unit-test-ut
 
 jest.mock('@console/dynamic-plugin-sdk/src/perspective/useActivePerspective', () => ({
   default: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/hooks/useActiveNamespace', () => ({
+  useActiveNamespace: jest.fn(() => ['default', jest.fn()]),
 }));
 
 const useActivePerspectiveMock = useActivePerspective as jest.Mock;
@@ -62,7 +65,6 @@ describe('PrometheusGraphLink', () => {
     );
     act(() => {
       store.dispatch(setFlag(FLAGS.CAN_GET_NS, false));
-      store.dispatch(UIActions.setActiveNamespace('default'));
     });
 
     expect(screen.getByText('Test content')).toBeVisible();
@@ -94,7 +96,6 @@ describe('PrometheusGraphLink', () => {
         );
         act(() => {
           store.dispatch(setFlag(FLAGS.CAN_GET_NS, true));
-          store.dispatch(UIActions.setActiveNamespace('default'));
         });
 
         expect(screen.getByText(MOCK_CONTENT_TEXT)).toBeVisible();
@@ -113,7 +114,6 @@ describe('PrometheusGraphLink', () => {
         </PrometheusGraphLink>,
       );
       act(() => {
-        store.dispatch(UIActions.setActiveNamespace('default'));
         store.dispatch(setFlag(FLAGS.CAN_GET_NS, true));
       });
 
@@ -131,7 +131,6 @@ describe('PrometheusGraphLink', () => {
       </PrometheusGraphLink>,
     );
     act(() => {
-      store.dispatch(UIActions.setActiveNamespace('default'));
       store.dispatch(setFlag(FLAGS.CAN_GET_NS, false));
     });
 
@@ -152,7 +151,6 @@ describe('PrometheusGraphLink', () => {
       </PrometheusGraphLink>,
     );
     act(() => {
-      store.dispatch(UIActions.setActiveNamespace('default'));
       store.dispatch(setFlag(FLAGS.CAN_GET_NS, false));
     });
 

--- a/frontend/public/components/graphs/prometheus-graph.tsx
+++ b/frontend/public/components/graphs/prometheus-graph.tsx
@@ -7,24 +7,23 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { useActivePerspective } from '@console/dynamic-plugin-sdk';
 import { FLAGS } from '@console/shared/src/constants/common';
+import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { featureReducerName } from '../../reducers/features';
-import { getActiveNamespace } from '../../reducers/ui';
 import type { RootState } from '../../redux';
 
 const mapStateToProps = (state: RootState) => ({
   canAccessMonitoring:
     !!state[featureReducerName][FLAGS.CAN_GET_NS] && !!window.SERVER_FLAGS.prometheusBaseURL,
-  namespace: getActiveNamespace(state),
 });
 
 const InnerPrometheusGraphLink: FC<PrometheusGraphLinkProps> = ({
   canAccessMonitoring,
   children,
   query,
-  namespace,
   ariaChartLinkLabel,
 }) => {
   const [activePerspective, setActivePerspective] = useActivePerspective();
+  const [namespace] = useActiveNamespace();
   const queries = _.compact(_.castArray(query));
   if (!queries.length) {
     return <>{children}</>;
@@ -56,7 +55,7 @@ const InnerPrometheusGraphLink: FC<PrometheusGraphLinkProps> = ({
 };
 export const PrometheusGraphLink = connect(mapStateToProps)(
   InnerPrometheusGraphLink,
-) as ComponentType<Omit<PrometheusGraphLinkProps, 'namespace' | 'canAccessMonitoring'>>;
+) as ComponentType<Omit<PrometheusGraphLinkProps, 'canAccessMonitoring'>>;
 
 export const PrometheusGraph = forwardRef<HTMLDivElement, PrometheusGraphProps>(
   ({ children, className, title }, ref) => (
@@ -74,7 +73,6 @@ export const PrometheusGraph = forwardRef<HTMLDivElement, PrometheusGraphProps>(
 type PrometheusGraphLinkProps = {
   canAccessMonitoring: boolean;
   query: string | string[];
-  namespace?: string;
   ariaChartLinkLabel?: string;
   children?: ReactNode;
 };

--- a/frontend/public/components/modals/delete-namespace-modal.tsx
+++ b/frontend/public/components/modals/delete-namespace-modal.tsx
@@ -12,6 +12,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import type { OverlayComponent } from '@console/dynamic-plugin-sdk/src/lib-core';
 import { useOverlay } from '@console/dynamic-plugin-sdk/src/lib-core';
+import { getNamespace } from '@console/internal/components/utils/link';
 import type { K8sKind, K8sResourceKind } from '@console/internal/module/k8s';
 import { k8sKill } from '@console/internal/module/k8s';
 import { ModalFooterWithAlerts } from '@console/shared/src/components/modals/ModalFooterWithAlerts';
@@ -19,13 +20,10 @@ import {
   ALL_NAMESPACES_KEY,
   LAST_NAMESPACE_NAME_USER_PREFERENCE_KEY,
 } from '@console/shared/src/constants/common';
-import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
-import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { usePromiseHandler } from '@console/shared/src/hooks/usePromiseHandler';
 import { useUserPreference } from '@console/shared/src/hooks/useUserPreference';
 import type { ModalComponentProps } from '@console/shared/src/types/modal';
-import { setActiveNamespace, formatNamespaceRoute } from '../../actions/ui';
-import { getActiveNamespace } from '../../reducers/ui';
+import { formatNamespaceRoute } from '../../actions/ui';
 
 const DeleteNamespaceModal: OverlayComponent<DeleteNamespaceModalProps> = ({
   kind,
@@ -37,18 +35,13 @@ const DeleteNamespaceModal: OverlayComponent<DeleteNamespaceModalProps> = ({
   const [handlePromise, inProgress, errorMessage] = usePromiseHandler();
   const [confirmed, setConfirmed] = useState(false);
 
-  /**
-   * This is a workaround because modal launcher renders all modals outside of main app context.
-   * This leads to namespace context not being available in modal so we access the redux store and use settings directly as a workaround.
-   *  */
-  const dispatch = useConsoleDispatch();
-  const activeNamespace = useConsoleSelector((state) => getActiveNamespace(state));
   const [, setLastNamespace] = useUserPreference<string>(LAST_NAMESPACE_NAME_USER_PREFERENCE_KEY);
 
   const onSubmit = (event) => {
     event.preventDefault();
     handlePromise(k8sKill(kind, resource))
       .then(() => {
+        const activeNamespace = getNamespace(window.location.pathname);
         if (resource.metadata.name === activeNamespace) {
           if (ALL_NAMESPACES_KEY !== activeNamespace) {
             const oldPath = window.location.pathname;
@@ -57,7 +50,6 @@ const DeleteNamespaceModal: OverlayComponent<DeleteNamespaceModalProps> = ({
               navigate(newPath);
             }
           }
-          dispatch(setActiveNamespace(ALL_NAMESPACES_KEY));
           setLastNamespace(ALL_NAMESPACES_KEY);
         }
         closeOverlay();

--- a/frontend/public/components/namespace-bar.tsx
+++ b/frontend/public/components/namespace-bar.tsx
@@ -12,18 +12,13 @@ import type {
 import { useFlag } from '@console/dynamic-plugin-sdk/src/utils/flags';
 import { k8sGet } from '@console/internal/module/k8s';
 import { NamespaceDropdown } from '@console/shared/src/components/namespace/NamespaceDropdown';
-import {
-  ALL_APPLICATIONS_KEY,
-  FLAGS,
-  KEYBOARD_SHORTCUTS,
-} from '@console/shared/src/constants/common';
+import { FLAGS, KEYBOARD_SHORTCUTS } from '@console/shared/src/constants/common';
 import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
 import { useConsoleDispatch } from '@console/shared/src/hooks/useConsoleDispatch';
 import { useConsoleSelector } from '@console/shared/src/hooks/useConsoleSelector';
 import { useCreateNamespaceOrProjectModal } from '@console/shared/src/hooks/useCreateNamespaceOrProjectModal';
 import { useQueryParamsMutator } from '@console/shared/src/hooks/useQueryParamsMutator';
 import { setFlag } from '../actions/flags';
-import { setActiveApplication } from '../actions/ui';
 import { NamespaceModel, ProjectModel } from '../models';
 import { flagPending } from '../reducers/features';
 import { useK8sWatchResource } from './utils/k8s-watch-hook';
@@ -103,7 +98,6 @@ const NamespaceBarDropdowns: FC<NamespaceBarDropdownsProps> = ({
           onNamespaceChange?.(newNamespace);
           setActiveNamespace(newNamespace);
           removeQueryArgument('project-name');
-          activeNamespace !== newNamespace && dispatch(setActiveApplication(ALL_APPLICATIONS_KEY));
         }}
         onCreateNew={() => {
           createNamespaceOrProjectModal({

--- a/frontend/public/reducers/ui.ts
+++ b/frontend/public/reducers/ui.ts
@@ -1,10 +1,9 @@
 import * as _ from 'lodash';
 import { getUser } from '@console/dynamic-plugin-sdk';
-import { ALL_APPLICATIONS_KEY, ALL_NAMESPACES_KEY } from '@console/shared/src/constants/common';
+import { ALL_APPLICATIONS_KEY } from '@console/shared/src/constants/common';
 import { ActionType } from '../actions/common';
 import type { UIAction } from '../actions/ui';
 import { OverviewSpecialGroup } from '../components/overview/constants';
-import { getNamespace } from '../components/utils/link';
 import type { RootState } from '../redux';
 
 export type UIState = Record<string, any>;
@@ -16,7 +15,6 @@ export default (state: UIState, action: UIAction): UIState => {
       activeNavSectionId: 'workloads',
       location: pathname,
       showOperandsInAllNamespaces: true,
-      activeNamespace: ALL_NAMESPACES_KEY,
       activeApplication: ALL_APPLICATIONS_KEY,
       pluginCSPViolations: {},
       createProjectMessage: '',
@@ -54,23 +52,8 @@ export default (state: UIState, action: UIAction): UIState => {
     case ActionType.SetActiveApplication:
       return { ...state, activeApplication: action.payload.application };
 
-    case ActionType.SetActiveNamespace:
-      if (!action.payload.namespace) {
-        // eslint-disable-next-line no-console
-        console.warn('setActiveNamespace: Not setting to falsy!');
-        return state;
-      }
-
-      return { ...state, activeNamespace: action.payload.namespace };
-
-    case ActionType.SetCurrentLocation: {
-      const updated = { ...state, location: action.payload.location };
-      const ns = getNamespace(action.payload.location);
-      if (_.isUndefined(ns)) {
-        return updated;
-      }
-      return { ...updated, activeNamespace: ns };
-    }
+    case ActionType.SetCurrentLocation:
+      return { ...state, location: action.payload.location };
     case ActionType.SetServiceLevel:
       return {
         ...state,
@@ -237,8 +220,6 @@ export default (state: UIState, action: UIAction): UIState => {
 };
 
 export const userStateToProps = (state: RootState) => ({ user: getUser(state) });
-
-export const getActiveNamespace = ({ UI }: RootState): string => UI.activeNamespace;
 
 export const getActiveApplication = ({ UI }: RootState): string => UI.activeApplication;
 


### PR DESCRIPTION
**Analysis / Root cause**:
`activeNamespace` was tracked in two places simultaneously: Redux state
(`UI.activeNamespace`) and `NamespaceContext` (backed by user preferences).
This dual tracking added unnecessary complexity and kept the Redux store as
an implicit dependency for anything that needed the active namespace.

**Solution description**:
- Remove `getActiveNamespace` Redux selector and `setActiveNamespace` action creator
- Remove `ActionType.SetActiveNamespace` and its reducer case
- Remove `activeNamespace` from Redux initial state
- Remove `SetCurrentLocation`'s namespace side-effect in the reducer
- Centralise the `setActiveApplication(ALL_APPLICATIONS_KEY)` dispatch into
  `namespace.ts`'s `updateNamespace` so the app-state reset fires on every
  namespace change, not just dropdown selections
- Replace all `UI.activeNamespace` / `getActiveNamespace` usages (~20 files)
  with `useActiveNamespace()` hook from NamespaceContext
- `delete-namespace-modal` reads namespace from `window.location.pathname`
  since modals render outside NamespaceContext
- Update/remove tests that exercised the removed Redux behaviour

**Test cases:**
- Switch namespace via dropdown → URL updates, application filter resets to "All applications"
- Navigate directly to a namespaced URL → namespace bar reflects the URL namespace
- Delete the active namespace → navigates to all-namespaces
- All-namespaces view → namespace column visible in resource tables

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace handling for resource links, navigation, access checks, imports, topology, and operator management.
  * Namespace-dependent views and actions now more reliably reflect the selected namespace.
  * Improved application context behavior when changing namespaces.

* **Refactor**
  * Streamlined namespace state handling across the console for more consistent navigation and feature behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->