### PR TITLE
NO-JIRA: Add unit tests for Cinder CSI ReadWriteOncePod access modes

### DIFF
--- a/frontend/public/components/storage/__tests__/shared.spec.ts
+++ b/frontend/public/components/storage/__tests__/shared.spec.ts
@@ -2,67 +2,54 @@ import {
   getAccessModeForProvisioner,
   getProvisionerModeMapping,
   getVolumeModeForProvisioner,
-  initialAccessModes,
 } from '../shared';
 
 describe('storage shared helpers', () => {
   describe('getAccessModeForProvisioner', () => {
-    const accessModeCases: {
-      description: string;
-      provisioner: string;
-      ignoreReadOnly?: boolean;
-      volumeMode?: string;
-      expected: string[];
-    }[] = [
-      {
-        description: 'includes ReadWriteOncePod for Cinder CSI Filesystem',
-        provisioner: 'cinder.csi.openstack.org',
-        ignoreReadOnly: false,
-        volumeMode: 'Filesystem',
-        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
-      },
-      {
-        description: 'includes ReadWriteOncePod for Cinder CSI Block',
-        provisioner: 'cinder.csi.openstack.org',
-        ignoreReadOnly: false,
-        volumeMode: 'Block',
-        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
-      },
-      {
-        description: 'includes ReadWriteOncePod for in-tree Cinder without duplicates',
-        provisioner: 'kubernetes.io/cinder',
-        ignoreReadOnly: false,
-        volumeMode: 'Filesystem',
-        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
-      },
-      {
-        description: 'does not enable RWOP for Manila CSI',
-        provisioner: 'manila.csi.openstack.org',
-        expected: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
-      },
-      {
-        description: 'filters ReadOnlyMany when ignoreReadOnly is true',
-        provisioner: 'manila.csi.openstack.org',
-        ignoreReadOnly: true,
-        volumeMode: 'Filesystem',
-        expected: ['ReadWriteOnce', 'ReadWriteMany'],
-      },
-      {
-        description: 'falls back to initialAccessModes for unknown provisioners',
-        provisioner: 'unknown.provisioner.example',
-        expected: initialAccessModes,
-      },
-    ];
+    it('includes ReadWriteOncePod for Cinder CSI Filesystem', () => {
+      expect(getAccessModeForProvisioner('cinder.csi.openstack.org', false, 'Filesystem')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteOncePod',
+      ]);
+    });
 
-    accessModeCases.forEach(
-      ({ description, provisioner, ignoreReadOnly, volumeMode, expected }) => {
-        it(description, () => {
-          expect(getAccessModeForProvisioner(provisioner, ignoreReadOnly, volumeMode)).toEqual(
-            expected,
-          );
-        });
-      },
-    );
+    it('includes ReadWriteOncePod for Cinder CSI Block', () => {
+      expect(getAccessModeForProvisioner('cinder.csi.openstack.org', false, 'Block')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteOncePod',
+      ]);
+    });
+
+    it('includes ReadWriteOncePod for in-tree Cinder without duplicates', () => {
+      expect(getAccessModeForProvisioner('kubernetes.io/cinder', false, 'Filesystem')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteOncePod',
+      ]);
+    });
+
+    it('does not enable RWOP for Manila CSI', () => {
+      expect(getAccessModeForProvisioner('manila.csi.openstack.org')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteMany',
+        'ReadOnlyMany',
+      ]);
+    });
+
+    it('filters ReadOnlyMany when ignoreReadOnly is true', () => {
+      expect(getAccessModeForProvisioner('manila.csi.openstack.org', true, 'Filesystem')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteMany',
+      ]);
+    });
+
+    it('falls back to all access modes for unknown provisioners', () => {
+      expect(getAccessModeForProvisioner('unknown.provisioner.example')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteMany',
+        'ReadOnlyMany',
+        'ReadWriteOncePod',
+      ]);
+    });
 
     it('does not offer RWX or ROX for Cinder CSI', () => {
       const modes = getAccessModeForProvisioner('cinder.csi.openstack.org');

--- a/frontend/public/components/storage/__tests__/shared.spec.ts
+++ b/frontend/public/components/storage/__tests__/shared.spec.ts
@@ -1,0 +1,99 @@
+import {
+  getAccessModeForProvisioner,
+  getProvisionerModeMapping,
+  getVolumeModeForProvisioner,
+  initialAccessModes,
+} from '../shared';
+
+describe('storage shared helpers', () => {
+  describe('getAccessModeForProvisioner', () => {
+    const accessModeCases: {
+      description: string;
+      provisioner: string;
+      ignoreReadOnly?: boolean;
+      volumeMode?: string;
+      expected: string[];
+    }[] = [
+      {
+        description: 'includes ReadWriteOncePod for Cinder CSI Filesystem',
+        provisioner: 'cinder.csi.openstack.org',
+        ignoreReadOnly: false,
+        volumeMode: 'Filesystem',
+        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      },
+      {
+        description: 'includes ReadWriteOncePod for Cinder CSI Block',
+        provisioner: 'cinder.csi.openstack.org',
+        ignoreReadOnly: false,
+        volumeMode: 'Block',
+        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      },
+      {
+        description: 'includes ReadWriteOncePod for in-tree Cinder without duplicates',
+        provisioner: 'kubernetes.io/cinder',
+        ignoreReadOnly: false,
+        volumeMode: 'Filesystem',
+        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      },
+      {
+        description: 'does not enable RWOP for Manila CSI',
+        provisioner: 'manila.csi.openstack.org',
+        expected: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
+      },
+      {
+        description: 'filters ReadOnlyMany when ignoreReadOnly is true',
+        provisioner: 'manila.csi.openstack.org',
+        ignoreReadOnly: true,
+        volumeMode: 'Filesystem',
+        expected: ['ReadWriteOnce', 'ReadWriteMany'],
+      },
+      {
+        description: 'falls back to initialAccessModes for unknown provisioners',
+        provisioner: 'unknown.provisioner.example',
+        expected: initialAccessModes,
+      },
+    ];
+
+    accessModeCases.forEach(
+      ({ description, provisioner, ignoreReadOnly, volumeMode, expected }) => {
+        it(description, () => {
+          expect(getAccessModeForProvisioner(provisioner, ignoreReadOnly, volumeMode)).toEqual(
+            expected,
+          );
+        });
+      },
+    );
+
+    it('does not offer RWX or ROX for Cinder CSI', () => {
+      const modes = getAccessModeForProvisioner('cinder.csi.openstack.org');
+      expect(modes).toEqual(['ReadWriteOnce', 'ReadWriteOncePod']);
+      expect(modes).not.toContain('ReadWriteMany');
+      expect(modes).not.toContain('ReadOnlyMany');
+    });
+  });
+
+  describe('getProvisionerModeMapping', () => {
+    it('returns Filesystem and Block mappings for Cinder CSI including RWOP', () => {
+      expect(getProvisionerModeMapping('cinder.csi.openstack.org')).toEqual({
+        Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+        Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      });
+    });
+
+    it('does not duplicate ReadWriteOncePod for in-tree Cinder', () => {
+      expect(getProvisionerModeMapping('kubernetes.io/cinder')).toEqual({
+        Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+        Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      });
+    });
+  });
+
+  describe('getVolumeModeForProvisioner', () => {
+    it('allows Filesystem and Block for Cinder CSI with ReadWriteOncePod', () => {
+      expect(getVolumeModeForProvisioner('cinder.csi.openstack.org', 'ReadWriteOncePod')).toEqual([
+        'Filesystem',
+        'Block',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
**Analysis / Root cause**:
The Create PersistentVolumeClaim form does not discover CSI access-mode capabilities dynamically. Allowed modes come from a static provisioner map in `frontend/public/components/storage/shared.ts`. For `cinder.csi.openstack.org` that map listed only `ReadWriteOnce`, so `AccessModeSelector` rendered ReadWriteOncePod as disabled. YAML creation of RWOP PVCs already worked on Cinder CSI (OpenShift 4.20 / OpenStack 18).

The mapping fix landed on `main` in #16870, but that PR did not close #16866 and added no unit tests.

**Solution description**:
Add regression tests for the provisioner access-mode helpers:
- `cinder.csi.openstack.org` allows `ReadWriteOnce` and `ReadWriteOncePod` for Filesystem and Block
- in-tree `kubernetes.io/cinder` includes RWOP without duplicates
- `manila.csi.openstack.org` is unchanged (no RWOP)
- `ignoreReadOnly` still filters `ReadOnlyMany`
- unknown provisioners still fall back to `initialAccessModes`

No mapping, API, extension, or i18n changes on `main`.

**Screenshots / screen recording**:
N/A (unit tests only; no UI change on `main`)

**Test setup:**
None. `cd frontend && yarn test public/components/storage/__tests__/shared.spec.ts`

**Test cases:**
1. Cinder CSI Filesystem/Block include RWOP
2. Cinder CSI does not include RWX or ROX
3. In-tree Cinder mapping has no duplicate RWOP entries
4. Manila CSI still does not offer RWOP
5. `ignoreReadOnly` filters ReadOnlyMany
6. Unknown provisioner returns `initialAccessModes`
7. Volume mode selector still allows Filesystem and Block for Cinder CSI + RWOP

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info**:
Closes #16866

Mapping fix: #16870
Cinder CSI capabilities: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/features.md

`release-4.20` / `release-4.21` / `release-4.22` still have the original mapping bug. Backports of #16870 plus these tests are prepared locally.

**Reviewers and assignees:**
/assign spadgett

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for storage access mode selection across CSI and in-tree provisioners.
  * Added validation for read-only filtering, unknown-provisioner fallback, and Cinder CSI handling of supported access modes.
  * Added tests for provisioner mode mappings, duplicate prevention, and volume mode selection, including single-pod read/write volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->