### PR TITLE
NO-JIRA: [release-4.22] Enable ReadWriteOncePod for Cinder CSI

### DIFF
--- a/frontend/public/components/storage/__tests__/shared.spec.ts
+++ b/frontend/public/components/storage/__tests__/shared.spec.ts
@@ -2,67 +2,54 @@ import {
   getAccessModeForProvisioner,
   getProvisionerModeMapping,
   getVolumeModeForProvisioner,
-  initialAccessModes,
 } from '../shared';
 
 describe('storage shared helpers', () => {
   describe('getAccessModeForProvisioner', () => {
-    const accessModeCases: {
-      description: string;
-      provisioner: string;
-      ignoreReadOnly?: boolean;
-      volumeMode?: string;
-      expected: string[];
-    }[] = [
-      {
-        description: 'includes ReadWriteOncePod for Cinder CSI Filesystem',
-        provisioner: 'cinder.csi.openstack.org',
-        ignoreReadOnly: false,
-        volumeMode: 'Filesystem',
-        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
-      },
-      {
-        description: 'includes ReadWriteOncePod for Cinder CSI Block',
-        provisioner: 'cinder.csi.openstack.org',
-        ignoreReadOnly: false,
-        volumeMode: 'Block',
-        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
-      },
-      {
-        description: 'includes ReadWriteOncePod for in-tree Cinder without duplicates',
-        provisioner: 'kubernetes.io/cinder',
-        ignoreReadOnly: false,
-        volumeMode: 'Filesystem',
-        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
-      },
-      {
-        description: 'does not enable RWOP for Manila CSI',
-        provisioner: 'manila.csi.openstack.org',
-        expected: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
-      },
-      {
-        description: 'filters ReadOnlyMany when ignoreReadOnly is true',
-        provisioner: 'manila.csi.openstack.org',
-        ignoreReadOnly: true,
-        volumeMode: 'Filesystem',
-        expected: ['ReadWriteOnce', 'ReadWriteMany'],
-      },
-      {
-        description: 'falls back to initialAccessModes for unknown provisioners',
-        provisioner: 'unknown.provisioner.example',
-        expected: initialAccessModes,
-      },
-    ];
+    it('includes ReadWriteOncePod for Cinder CSI Filesystem', () => {
+      expect(getAccessModeForProvisioner('cinder.csi.openstack.org', false, 'Filesystem')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteOncePod',
+      ]);
+    });
 
-    accessModeCases.forEach(
-      ({ description, provisioner, ignoreReadOnly, volumeMode, expected }) => {
-        it(description, () => {
-          expect(getAccessModeForProvisioner(provisioner, ignoreReadOnly, volumeMode)).toEqual(
-            expected,
-          );
-        });
-      },
-    );
+    it('includes ReadWriteOncePod for Cinder CSI Block', () => {
+      expect(getAccessModeForProvisioner('cinder.csi.openstack.org', false, 'Block')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteOncePod',
+      ]);
+    });
+
+    it('includes ReadWriteOncePod for in-tree Cinder without duplicates', () => {
+      expect(getAccessModeForProvisioner('kubernetes.io/cinder', false, 'Filesystem')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteOncePod',
+      ]);
+    });
+
+    it('does not enable RWOP for Manila CSI', () => {
+      expect(getAccessModeForProvisioner('manila.csi.openstack.org')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteMany',
+        'ReadOnlyMany',
+      ]);
+    });
+
+    it('filters ReadOnlyMany when ignoreReadOnly is true', () => {
+      expect(getAccessModeForProvisioner('manila.csi.openstack.org', true, 'Filesystem')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteMany',
+      ]);
+    });
+
+    it('falls back to all access modes for unknown provisioners', () => {
+      expect(getAccessModeForProvisioner('unknown.provisioner.example')).toEqual([
+        'ReadWriteOnce',
+        'ReadWriteMany',
+        'ReadOnlyMany',
+        'ReadWriteOncePod',
+      ]);
+    });
 
     it('does not offer RWX or ROX for Cinder CSI', () => {
       const modes = getAccessModeForProvisioner('cinder.csi.openstack.org');

--- a/frontend/public/components/storage/__tests__/shared.spec.ts
+++ b/frontend/public/components/storage/__tests__/shared.spec.ts
@@ -1,0 +1,99 @@
+import {
+  getAccessModeForProvisioner,
+  getProvisionerModeMapping,
+  getVolumeModeForProvisioner,
+  initialAccessModes,
+} from '../shared';
+
+describe('storage shared helpers', () => {
+  describe('getAccessModeForProvisioner', () => {
+    const accessModeCases: {
+      description: string;
+      provisioner: string;
+      ignoreReadOnly?: boolean;
+      volumeMode?: string;
+      expected: string[];
+    }[] = [
+      {
+        description: 'includes ReadWriteOncePod for Cinder CSI Filesystem',
+        provisioner: 'cinder.csi.openstack.org',
+        ignoreReadOnly: false,
+        volumeMode: 'Filesystem',
+        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      },
+      {
+        description: 'includes ReadWriteOncePod for Cinder CSI Block',
+        provisioner: 'cinder.csi.openstack.org',
+        ignoreReadOnly: false,
+        volumeMode: 'Block',
+        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      },
+      {
+        description: 'includes ReadWriteOncePod for in-tree Cinder without duplicates',
+        provisioner: 'kubernetes.io/cinder',
+        ignoreReadOnly: false,
+        volumeMode: 'Filesystem',
+        expected: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      },
+      {
+        description: 'does not enable RWOP for Manila CSI',
+        provisioner: 'manila.csi.openstack.org',
+        expected: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'],
+      },
+      {
+        description: 'filters ReadOnlyMany when ignoreReadOnly is true',
+        provisioner: 'manila.csi.openstack.org',
+        ignoreReadOnly: true,
+        volumeMode: 'Filesystem',
+        expected: ['ReadWriteOnce', 'ReadWriteMany'],
+      },
+      {
+        description: 'falls back to initialAccessModes for unknown provisioners',
+        provisioner: 'unknown.provisioner.example',
+        expected: initialAccessModes,
+      },
+    ];
+
+    accessModeCases.forEach(
+      ({ description, provisioner, ignoreReadOnly, volumeMode, expected }) => {
+        it(description, () => {
+          expect(getAccessModeForProvisioner(provisioner, ignoreReadOnly, volumeMode)).toEqual(
+            expected,
+          );
+        });
+      },
+    );
+
+    it('does not offer RWX or ROX for Cinder CSI', () => {
+      const modes = getAccessModeForProvisioner('cinder.csi.openstack.org');
+      expect(modes).toEqual(['ReadWriteOnce', 'ReadWriteOncePod']);
+      expect(modes).not.toContain('ReadWriteMany');
+      expect(modes).not.toContain('ReadOnlyMany');
+    });
+  });
+
+  describe('getProvisionerModeMapping', () => {
+    it('returns Filesystem and Block mappings for Cinder CSI including RWOP', () => {
+      expect(getProvisionerModeMapping('cinder.csi.openstack.org')).toEqual({
+        Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+        Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      });
+    });
+
+    it('does not duplicate ReadWriteOncePod for in-tree Cinder', () => {
+      expect(getProvisionerModeMapping('kubernetes.io/cinder')).toEqual({
+        Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+        Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
+      });
+    });
+  });
+
+  describe('getVolumeModeForProvisioner', () => {
+    it('allows Filesystem and Block for Cinder CSI with ReadWriteOncePod', () => {
+      expect(getVolumeModeForProvisioner('cinder.csi.openstack.org', 'ReadWriteOncePod')).toEqual([
+        'Filesystem',
+        'Block',
+      ]);
+    });
+  });
+});

--- a/frontend/public/components/storage/shared.ts
+++ b/frontend/public/components/storage/shared.ts
@@ -48,8 +48,8 @@ export const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object
     Block: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
   },
   'kubernetes.io/cinder': {
-    Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod', 'ReadWriteOncePod'],
-    Block: ['ReadWriteOnce', 'ReadWriteOncePod', 'ReadWriteOncePod'],
+    Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+    Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
   },
   'kubernetes.io/azure-file': {
     Filesystem: ['ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany', 'ReadWriteOncePod'],
@@ -101,8 +101,8 @@ export const provisionerAccessModeMapping: ProvisionerAccessModeMapping = Object
     Block: ['ReadWriteOnce'],
   },
   'cinder.csi.openstack.org': {
-    Filesystem: ['ReadWriteOnce'],
-    Block: ['ReadWriteOnce'],
+    Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],
+    Block: ['ReadWriteOnce', 'ReadWriteOncePod'],
   },
   'pd.csi.storage.gke.io': {
     Filesystem: ['ReadWriteOnce', 'ReadWriteOncePod'],


### PR DESCRIPTION
**Analysis / Root cause**:
The Create PersistentVolumeClaim form gates access modes with a static provisioner map in `frontend/public/components/storage/shared.ts`. On 4.22, `cinder.csi.openstack.org` lists only `ReadWriteOnce`, so ReadWriteOncePod is grayed out. YAML creation of RWOP PVCs already works. The in-tree `kubernetes.io/cinder` entry also listed `ReadWriteOncePod` twice.

**Solution description**:
Backport of #16870 plus regression tests:
- `cinder.csi.openstack.org`: add `ReadWriteOncePod` for Filesystem and Block
- `kubernetes.io/cinder`: remove duplicate `ReadWriteOncePod` entries
- unit tests for the provisioner access-mode helpers

**Screenshots / screen recording**:
N/A (access-mode dropdown option enablement)

**Test setup:**
OpenShift on OpenStack with a StorageClass whose provisioner is `cinder.csi.openstack.org`.

**Test cases:**
1. Storage → PersistentVolumeClaims → Create PersistentVolumeClaim
2. Select a Cinder CSI StorageClass
3. Access mode options include "Read write once pod (RWOP)" alongside "Single user (RWO)"
4. Create a PVC with RWOP / Filesystem and confirm it binds
5. Repeat with volume mode Block
6. Regression: Manila CSI access modes unchanged

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info**:
Related to #16866
Backport of #16870
Tests on main: #17105

Cinder CSI reports `SINGLE_NODE_SINGLE_WRITER`, which maps to ReadWriteOncePod.

**Reviewers and assignees:**
/assign spadgett