### PR TITLE
OCPBUGS-100511: Bump postcss to fix CVE-2026-45623

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -358,7 +358,7 @@
     "ua-parser-js": "^0.7.24",
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
-    "postcss": "^8.2.13",   
+    "postcss": "^8.5.12",
     "shell-quote": "^1.8.4",
     "axios": "^0.33.0",
     "immutable": "3.8.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -19928,12 +19928,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
-  version: 3.3.6
-  resolution: "nanoid@npm:3.3.6"
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/606b355960d0fcbe3d27924c4c52ef7d47d3b57208808ece73279420d91469b01ec1dce10fae512b6d4a8c5a5432b352b228336a8b2202a6ea68e67fa348e2ee
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -21674,13 +21674,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "picocolors@npm:1.0.0"
-  checksum: 10c0/20a5b249e331c14479d94ec6817a182fd7a5680debae82705747b2db7ec50009a5f6648d0621c561b0572703f84dbef0858abcbd5856d3c5511426afcb1961f7
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -21914,14 +21907,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.13":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
+"postcss@npm:^8.5.12":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
+    nanoid: "npm:^3.3.17"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
   languageName: node
   linkType: hard
 
@@ -25092,10 +25085,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "source-map-js@npm:1.0.2"
-  checksum: 10c0/32f2dfd1e9b7168f9a9715eb1b4e21905850f3b50cf02cf476e47e4eebe8e6b762b63a64357896aa29b37e24922b4282df0f492e0d2ace572b43d15525976ff8
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## CVE-2026-45623: PostCSS Information Disclosure and DoS

Bumps postcss to remediate CVE-2026-45623 (CVSS 7.5 Moderate).

PostCSS versions ≤8.5.11 parse `sourceMappingURL` comments and dereference paths against the local filesystem without validation, enabling file-read disclosure and DoS. Fixed in postcss ≥8.5.12.

### Changes
- **postcss**: 8.4.31 → 8.5.26 (via resolutions in `frontend/package.json`)
- Resolution range updated from `^8.2.13` to `^8.5.12`
- Lockfile (`frontend/yarn.lock`) regenerated

Sub-dependency updates (automatic via lockfile):
- nanoid 3.3.6 → 3.3.18
- picocolors 1.0.0 → 1.1.1
- source-map-js 1.0.2 → 1.2.1

### Validation
- Clean yarn install
- postcss functional verification (processes CSS correctly at 8.5.26)
- All postcss consumers resolve to 8.5.26
- Unit tests pass (jest 2/2)
- Lint clean (eslint)

### References
- Jira: https://redhat.atlassian.net/browse/OCPBUGS-100511
- CVE: https://access.redhat.com/security/cve/CVE-2026-45623
- GHSA: https://github.com/postcss/postcss/security/advisories/GHSA-6g55-p6wh-862q