### PR TITLE
[release-4.22] OCPBUGS-114725: display operators in catalog when Tech Preview enabled

### DIFF
--- a/frontend/packages/operator-lifecycle-manager-v1/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/console-extensions.json
@@ -33,6 +33,40 @@
     }
   },
   {
+    "type": "console.catalog/item-type",
+    "properties": {
+      "type": "operator",
+      "title": "%olm-v1~Operators%",
+      "catalogDescription": "%olm-v1~Browse for Operators provided by Operator Lifecycle Manager.%",
+      "typeDescription": "%olm-v1~**Operators** are software extensions to OpenShift that make use of custom resources to manage applications and their components. They are managed by Operator Lifecycle Manager.%",
+      "filters": [
+        {
+          "label": "%olm-v1~Source%",
+          "attribute": "source"
+        },
+        {
+          "label": "%olm-v1~Provider%",
+          "attribute": "provider"
+        },
+        {
+          "label": "%olm-v1~Capability level%",
+          "attribute": "capabilities"
+        },
+        {
+          "label": "%olm-v1~Infrastructure features%",
+          "attribute": "infrastructureFeatures"
+        },
+        {
+          "label": "%olm-v1~Valid subscription%",
+          "attribute": "validSubscription"
+        }
+      ]
+    },
+    "flags": {
+      "required": ["CLUSTER_CATALOG_API", "TECH_PREVIEW", "OLMV1_ENABLED"]
+    }
+  },
+  {
     "type": "console.catalog/item-provider",
     "properties": {
       "catalogId": "dev-catalog",

--- a/frontend/packages/operator-lifecycle-manager-v1/locales/en/olm-v1.json
+++ b/frontend/packages/operator-lifecycle-manager-v1/locales/en/olm-v1.json
@@ -1,5 +1,12 @@
 {
   "Operators": "Operators",
+  "Browse for Operators provided by Operator Lifecycle Manager.": "Browse for Operators provided by Operator Lifecycle Manager.",
+  "**Operators** are software extensions to OpenShift that make use of custom resources to manage applications and their components. They are managed by Operator Lifecycle Manager.": "**Operators** are software extensions to OpenShift that make use of custom resources to manage applications and their components. They are managed by Operator Lifecycle Manager.",
+  "Source": "Source",
+  "Provider": "Provider",
+  "Capability level": "Capability level",
+  "Infrastructure features": "Infrastructure features",
+  "Valid subscription": "Valid subscription",
   "OLMv1 Catalog": "OLMv1 Catalog",
   "Enable the OLMv1 catalog experience. OLMv1 is a technology preview feature that provides an updated operator catalog interface.": "Enable the OLMv1 catalog experience. OLMv1 is a technology preview feature that provides an updated operator catalog interface.",
   "Enable OLMv1 catalog": "Enable OLMv1 catalog",

--- a/frontend/packages/operator-lifecycle-manager-v1/src/hooks/__tests__/useCatalogItems.spec.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/hooks/__tests__/useCatalogItems.spec.ts
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { coFetch } from '@console/shared/src/utils/console-fetch';
+import {
+  getConsoleRequestHeaders,
+  normalizeConsoleHeaders,
+} from '@console/shared/src/utils/console-fetch-utils';
+import useCatalogItems from '../useCatalogItems';
+
+jest.mock('@console/shared/src/hooks/usePoll', () => {
+  const { useEffect } = jest.requireActual('react');
+  return {
+    usePoll: function usePoll(callback: () => void) {
+      useEffect(() => {
+        callback();
+      }, [callback]);
+    },
+  };
+});
+
+jest.mock('@console/shared/src/utils/console-fetch', () => ({
+  coFetch: jest.fn(),
+}));
+
+jest.mock('@console/shared/src/utils/console-fetch-utils', () => ({
+  getConsoleRequestHeaders: jest.fn(),
+  normalizeConsoleHeaders: jest.fn(),
+}));
+
+jest.mock('../../utils/catalog-item', () => ({
+  normalizeCatalogItem: jest.fn((item) => item),
+}));
+
+const coFetchMock = jest.mocked(coFetch);
+
+describe('useCatalogItems', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(getConsoleRequestHeaders).mockReturnValue({});
+    jest.mocked(normalizeConsoleHeaders).mockReturnValue({});
+  });
+
+  it('starts with loaded=false before fetch resolves', () => {
+    coFetchMock.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useCatalogItems());
+
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('sets loaded=true after a successful fetch', async () => {
+    coFetchMock.mockResolvedValue(({
+      status: 200,
+      headers: { get: () => 'Thu, 01 Jan 2026 00:00:00 GMT' },
+      json: () => Promise.resolve([]),
+    } as unknown) as Response);
+
+    const { result } = renderHook(() => useCatalogItems());
+
+    await waitFor(() => expect(result.current[1]).toBe(true));
+    expect(result.current[2]).toBe('');
+  });
+
+  it('sets loaded=true after a fetch error', async () => {
+    coFetchMock.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useCatalogItems());
+
+    await waitFor(() => expect(result.current[1]).toBe(true));
+    expect(result.current[2]).toContain('Network error');
+  });
+});

--- a/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useCatalogCategories.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useCatalogCategories.ts
@@ -5,9 +5,9 @@ import useCatalogItems from './useCatalogItems';
 
 type UseCatalogCategories = () => [CatalogCategory[], boolean, string];
 const useCatalogCategories: UseCatalogCategories = () => {
-  const [items, loading, error] = useCatalogItems();
+  const [items, loaded, error] = useCatalogItems();
   const categories = useMemo(() => {
-    if (loading || error) {
+    if (!loaded || error) {
       return [];
     }
     return _.uniq(
@@ -23,9 +23,9 @@ const useCatalogCategories: UseCatalogCategories = () => {
           tags: [id, label],
         };
       });
-  }, [error, items, loading]);
+  }, [error, items, loaded]);
 
-  return [categories, loading, error];
+  return [categories, loaded, error];
 };
 
 export default useCatalogCategories;

--- a/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useCatalogItems.ts
+++ b/frontend/packages/operator-lifecycle-manager-v1/src/hooks/useCatalogItems.ts
@@ -18,7 +18,7 @@ export type OLMCatalogItemData = {
 type UseCatalogItems = () => [CatalogItem<OLMCatalogItemData>[], boolean, string];
 const useCatalogItems: UseCatalogItems = () => {
   const [olmCatalogItems, setOLMCatalogItems] = useState<OLMCatalogItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState('');
   const [lastModified, setLastModified] = useState('');
   const abortControllerRef = useRef<AbortController>();
@@ -54,12 +54,12 @@ const useCatalogItems: UseCatalogItems = () => {
         if (olmItems !== null) {
           setOLMCatalogItems(olmItems);
         }
-        setLoading(false);
+        setLoaded(true);
       })
       .catch((err) => {
         if (err.name === 'AbortError') return;
         setError(err.toString());
-        setLoading(false);
+        setLoaded(true);
       });
   }, [headers]);
 
@@ -73,7 +73,7 @@ const useCatalogItems: UseCatalogItems = () => {
 
   const items = useMemo(() => olmCatalogItems.map(normalizeCatalogItem), [olmCatalogItems]);
 
-  return [items, loading, error];
+  return [items, loaded, error];
 };
 
 export default useCatalogItems;

--- a/frontend/packages/operator-lifecycle-manager/console-extensions.json
+++ b/frontend/packages/operator-lifecycle-manager/console-extensions.json
@@ -434,6 +434,9 @@
           }
         }
       ]
+    },
+    "flags": {
+      "disallowed": ["OLMV1_ENABLED"]
     }
   },
   {


### PR DESCRIPTION
backport of https://github.com/openshift/console/pull/16976 and https://github.com/openshift/console/pull/16666

Supersedes the automated backport with failing CI https://github.com/openshift/console/pull/17103.

Backports OLMv1 catalog fix commits to release-4.22:
- Add console.catalog/item-type for OLMv1 operator catalog
- fix(olm-v1): correct inverted loaded/loading semantics in catalog hooks
- fix(olm): disable OLMv0 operator item-type when OLMv1 is enabled

Note: The Playwright test commit (https://github.com/openshift/console/commit/990629042a6f887915f729bdb576dd4f7c980e41) was skipped due to conflicts — those test files were removed in the 4.22 branch.

/hold
