### PR TITLE
OCPBUGS-101796: Bump postcss to 8.5.23 to fix CVE-2026-69153

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -352,7 +352,7 @@
     "ua-parser-js": "^0.7.24",
     "@types/jest": "21.x",
     "glob-parent": "^5.1.2",
-    "postcss": "^8.2.13",
+    "postcss": "8.5.23",
     "immutable": "3.8.3",
     "axios@npm:^0.21.1": "patch:axios@npm%3A0.33.0#~/.yarn/patches/axios-npm-0.33.0-023deda7e4.patch"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -19423,12 +19423,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.22":
-  version: 3.1.22
-  resolution: "nanoid@npm:3.1.22"
+"nanoid@npm:^3.3.16":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/58bc86b5f6c77fb4052ca6d29bb498120facde6318d7d29de9cd41c12a5183925d68e0284133b12cdd9865ce5eec195e3764d98bf6620e4ad4ec3c15fa57aa43
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -21363,14 +21363,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.13":
-  version: 8.2.13
-  resolution: "postcss@npm:8.2.13"
+"postcss@npm:8.5.23":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    colorette: "npm:^1.2.2"
-    nanoid: "npm:^3.1.22"
-    source-map: "npm:^0.6.1"
-  checksum: 10c0/a0ddadf2fdd288a27d6be15bdbd466c87151850506be8bb05ced967c0e947abde5c4ebfc39f31aa41f20b098573ad51c15eb88bd88ab14ebc2ad0f661b722acb
+    nanoid: "npm:^3.3.16"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
   languageName: node
   linkType: hard
 
@@ -24467,6 +24467,13 @@ __metadata:
   version: 2.0.1
   resolution: "source-list-map@npm:2.0.1"
   checksum: 10c0/2e5e421b185dcd857f46c3c70e2e711a65d717b78c5f795e2e248c9d67757882ea989b80ebc08cf164eeeda5f4be8aa95d3b990225070b2daaaf3257c5958149
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## CVE Remediation: CVE-2026-69153 (GHSA-fxqj-rqcc-2cmp)

Bumps `postcss` from 8.2.13 to 8.5.23 to fix an information disclosure vulnerability via crafted sourceMappingURL.

### Changes
- Updated `frontend/package.json` resolutions: `postcss` pinned to `8.5.23`
- Regenerated `frontend/yarn.lock`

### CVE Details
- **CVE:** [CVE-2026-69153](https://www.cve.org/CVERecord?id=CVE-2026-69153)
- **GHSA:** [GHSA-fxqj-rqcc-2cmp](https://github.com/postcss/postcss/security/advisories/GHSA-fxqj-rqcc-2cmp)
- **Severity:** Important (CVSS 7.5)
- **Fixed in:** postcss 8.5.23
- **Jira:** [OCPBUGS-101796](https://redhat.atlassian.net/browse/OCPBUGS-101796)

### Impact
postcss is a transitive build-time dependency (via css-loader, sanitize-html). The vulnerability allows information disclosure via directory traversal in sourceMappingURL when `from` is unset. Low runtime risk but requires patching for compliance.