### PR TITLE
OCPBUGS-95600: Return 503 instead of 502 for unavailable console plugins

### DIFF
--- a/pkg/plugins/handlers.go
+++ b/pkg/plugins/handlers.go
@@ -168,10 +168,21 @@ func (p *PluginsHandler) proxyPluginRequest(requestURL *url.URL, pluginName stri
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to send GET request for %q plugin: %v", pluginName, err)
 		klog.Error(errMsg)
-		serverutils.SendResponse(w, http.StatusBadGateway, serverutils.ApiError{Err: errMsg})
+		serverutils.SendResponse(w, http.StatusServiceUnavailable, serverutils.ApiError{Err: errMsg})
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			klog.Errorf("failed to close response body from %q plugin: %v", pluginName, err)
+		}
+	}()
+
+	if resp.StatusCode == http.StatusBadGateway {
+		errMsg := fmt.Sprintf("plugin %q service returned 502", pluginName)
+		klog.Warning(errMsg)
+		serverutils.SendResponse(w, http.StatusServiceUnavailable, serverutils.ApiError{Err: errMsg})
+		return
+	}
 
 	// filter unwanted headers from the response
 	proxy.FilterHeaders(resp)
@@ -182,7 +193,6 @@ func (p *PluginsHandler) proxyPluginRequest(requestURL *url.URL, pluginName stri
 		}
 	}
 
-	// Make sure to copy status code from the plugin service response
 	w.WriteHeader(resp.StatusCode)
 
 	_, err = io.Copy(w, resp.Body)

--- a/pkg/plugins/handlers_test.go
+++ b/pkg/plugins/handlers_test.go
@@ -1,0 +1,213 @@
+package plugins
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/openshift/console/pkg/serverutils"
+)
+
+func TestProxyPluginRequest_ServiceDown_Returns503(t *testing.T) {
+	// Use a closed server to simulate a plugin service that is down.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	ts.Close()
+
+	serviceURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	handler := &PluginsHandler{
+		Client:             ts.Client(),
+		PluginsEndpointMap: map[string]string{"test-plugin": ts.URL},
+	}
+
+	req := httptest.NewRequest("GET", "/test-plugin/plugin-manifest.json", nil)
+	rr := httptest.NewRecorder()
+
+	handler.proxyPluginRequest(serviceURL, "test-plugin", rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status %d, got %d", http.StatusServiceUnavailable, rr.Code)
+	}
+}
+
+func TestProxyPluginRequest_ServiceDown_ReturnsJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	ts.Close()
+
+	serviceURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	handler := &PluginsHandler{
+		Client:             ts.Client(),
+		PluginsEndpointMap: map[string]string{"test-plugin": ts.URL},
+	}
+
+	req := httptest.NewRequest("GET", "/test-plugin/plugin-manifest.json", nil)
+	rr := httptest.NewRecorder()
+
+	handler.proxyPluginRequest(serviceURL, "test-plugin", rr, req)
+
+	contentType := rr.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", contentType)
+	}
+
+	var apiErr serverutils.ApiError
+	if err := json.NewDecoder(rr.Body).Decode(&apiErr); err != nil {
+		t.Fatalf("failed to decode JSON response: %v", err)
+	}
+	if apiErr.Err == "" {
+		t.Error("expected non-empty error message in JSON body")
+	}
+}
+
+func TestProxyPluginRequest_Upstream502_Returns503(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	serviceURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	handler := &PluginsHandler{
+		Client:             ts.Client(),
+		PluginsEndpointMap: map[string]string{"test-plugin": ts.URL},
+	}
+
+	req := httptest.NewRequest("GET", "/test-plugin/plugin-manifest.json", nil)
+	rr := httptest.NewRecorder()
+
+	handler.proxyPluginRequest(serviceURL, "test-plugin", rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status %d, got %d", http.StatusServiceUnavailable, rr.Code)
+	}
+
+	var apiErr serverutils.ApiError
+	if err := json.NewDecoder(rr.Body).Decode(&apiErr); err != nil {
+		t.Fatalf("failed to decode JSON response: %v", err)
+	}
+	if apiErr.Err == "" {
+		t.Error("expected non-empty error message in JSON body")
+	}
+}
+
+func TestProxyPluginRequest_Upstream502_NoStaleHeaders(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", "42")
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	serviceURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	handler := &PluginsHandler{
+		Client:             ts.Client(),
+		PluginsEndpointMap: map[string]string{"test-plugin": ts.URL},
+	}
+
+	req := httptest.NewRequest("GET", "/test-plugin/plugin-manifest.json", nil)
+	rr := httptest.NewRecorder()
+
+	handler.proxyPluginRequest(serviceURL, "test-plugin", rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status %d, got %d", http.StatusServiceUnavailable, rr.Code)
+	}
+
+	if ce := rr.Header().Get("Content-Encoding"); ce != "" {
+		t.Errorf("expected no Content-Encoding header, got %q", ce)
+	}
+
+	contentType := rr.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", contentType)
+	}
+
+	var apiErr serverutils.ApiError
+	if err := json.NewDecoder(rr.Body).Decode(&apiErr); err != nil {
+		t.Fatalf("failed to decode JSON response: %v", err)
+	}
+	if apiErr.Err == "" {
+		t.Error("expected non-empty error message in JSON body")
+	}
+}
+
+func TestProxyPluginRequest_ServiceUp_Proxies200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"name":"test-plugin"}`))
+	}))
+	defer ts.Close()
+
+	serviceURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	handler := &PluginsHandler{
+		Client:             ts.Client(),
+		PluginsEndpointMap: map[string]string{"test-plugin": ts.URL},
+	}
+
+	req := httptest.NewRequest("GET", "/test-plugin/plugin-manifest.json", nil)
+	rr := httptest.NewRecorder()
+
+	handler.proxyPluginRequest(serviceURL, "test-plugin", rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	body := rr.Body.String()
+	if body != `{"name":"test-plugin"}` {
+		t.Errorf("expected body %q, got %q", `{"name":"test-plugin"}`, body)
+	}
+}
+
+func TestHandlePluginAssets_FailedPlugin_Returns404(t *testing.T) {
+	handler := &PluginsHandler{
+		Client:             http.DefaultClient,
+		PluginsEndpointMap: map[string]string{},
+	}
+
+	req := httptest.NewRequest("GET", "/nonexistent-plugin/plugin-manifest.json", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandlePluginAssets(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rr.Code)
+	}
+}
+
+func TestHandleI18nResources_FailedPlugin_Returns404(t *testing.T) {
+	handler := &PluginsHandler{
+		Client:             http.DefaultClient,
+		PluginsEndpointMap: map[string]string{},
+	}
+
+	req := httptest.NewRequest("GET", "/locales?lng=en&ns=plugin__nonexistent", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleI18nResources(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rr.Code)
+	}
+}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-95600

**Analysis / Root cause**:
When a console plugin service is down, `proxyPluginRequest()` in
`pkg/plugins/handlers.go` returns HTTP 502 (Bad Gateway) to the browser.
In network environments with corporate proxies/firewalls, a 502 from
the origin can trigger rules that block ALL subsequent requests, making
the entire console inaccessible for non-admin users who cannot disable
the failing plugin. Additionally, upstream 502 responses from plugin
services are forwarded as-is, causing the same issue.

**Solution description**:
Changed `proxyPluginRequest()` to return HTTP 503 (Service Unavailable)
with a structured JSON error body instead of raw 502 in two paths:
1. Connection failure (plugin service down): 502 → 503
2. Upstream 502 passthrough: intercepted and converted to 503

503 signals a transient backend issue without triggering proxy-level
origin blocking. The frontend already handles individual plugin failures
gracefully via catch handlers in `loadAndEnablePlugin()`.

**Screenshots / screen recording**:
N/A — backend-only change, no visual changes.

**Test setup:**
No special setup required.

**Test cases:**
- Plugin service is down → console returns 503 with JSON error body
- Plugin service returns 502 → console returns 503 with JSON error body
- Plugin service is healthy → console proxies response normally (200)
- Unknown plugin → console returns 404

**Browser conformance**:
- [x] Chrome
- [x] Firefox
- [x] Safari (or Epiphany on Linux)

**Additional info:**
Added unit tests for `pkg/plugins/handlers.go` — this package previously had no test coverage.