### PR TITLE
OCPBUGS-114052: move yarn install to prow scripts

### DIFF
--- a/frontend/integration-tests/test-cypress.sh
+++ b/frontend/integration-tests/test-cypress.sh
@@ -18,10 +18,6 @@ if [ "$OPENSHIFT_CI" = true ]; then
   export NO_COLOR=1
 fi
 
-if [ ! -d node_modules ]; then
-  yarn install
-fi
-
 function copyArtifacts {
   if [ -d "$ARTIFACT_DIR" ] && [ -d "$SCREENSHOTS_DIR" ]; then
     echo "Copying artifacts from $(pwd)..."

--- a/frontend/integration-tests/test-playwright-e2e.sh
+++ b/frontend/integration-tests/test-playwright-e2e.sh
@@ -74,10 +74,6 @@ BRIDGE_BASE_PATH=${BRIDGE_BASE_PATH:-/}
 export BRIDGE_BASE_PATH
 export WEB_CONSOLE_URL="${WEB_CONSOLE_URL:-${BRIDGE_BASE_ADDRESS}${BRIDGE_BASE_PATH}}"
 
-if [ ! -d node_modules ]; then
-  yarn install
-fi
-
 if [ "$RUN_CREATE_USER" = true ]; then
   "${REPO_ROOT}/contrib/create-user.sh"
   export BRIDGE_HTPASSWD_IDP="${BRIDGE_HTPASSWD_IDP:-test}"

--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -14,6 +14,10 @@ export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jso
 
 pushd frontend
 
+if [ ! -d node_modules ]; then
+  yarn install
+fi
+
 SCENARIO="${1:-e2e}"
 
 if [ "$SCENARIO" == "nightly-cypress" ]; then

--- a/test-prow-playwright-e2e-techpreview.sh
+++ b/test-prow-playwright-e2e-techpreview.sh
@@ -43,6 +43,10 @@ export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jso
 
 pushd frontend
 
+if [ ! -d node_modules ]; then
+  yarn install
+fi
+
 ./integration-tests/test-playwright-e2e.sh -- e2e/tests/olm/operator-lifecycle-metadata.spec.ts e2e/tests/dev-console/catalog.spec.ts "$@"
 
 popd

--- a/test-prow-playwright-e2e.sh
+++ b/test-prow-playwright-e2e.sh
@@ -52,6 +52,10 @@ export GLOBAL_TIMEOUT_MS="${GLOBAL_TIMEOUT_MS:-6600000}"
 
 pushd frontend
 
+if [ ! -d node_modules ]; then
+  yarn install
+fi
+
 SCENARIO="${1:-e2e}"
 if [ $# -gt 0 ]; then
   shift


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

Previously if no scenarios were run, yarn install would not run for the test-prow scripts. node_modules would then not exist which is a broken state

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Move yarn install to /*e2e-.sh scripts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Test Improvements**
  * Updated end-to-end test workflows to install required dependencies automatically when they are unavailable.
  * Streamlined Cypress and Playwright integration test execution by relying on dependencies prepared in advance.
  * Improved consistency across test environments by applying dependency setup before Playwright test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->