### PR TITLE
NO-JIRA: fix session-persistence tests failing due to pre-loaded storageState

### DIFF
--- a/frontend/e2e/tests/console/session-persistence.spec.ts
+++ b/frontend/e2e/tests/console/session-persistence.spec.ts
@@ -8,6 +8,7 @@ test.describe(
   'Session persistence across pod restarts',
   { tag: ['@admin', '@slow'] },
   () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
     test.setTimeout(300_000);
 
     test('session survives console pod deletion', async ({ page, k8sClient }) => {


### PR DESCRIPTION
**Analysis / Root cause**:
The `session-persistence.spec.ts` tests have been failing 100% of the time in CI
([`pull-ci-openshift-console-main-e2e-playwright`](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-console-main-e2e-playwright) — 86% overall failure rate, with these two tests contributing to every single failing run).

The root cause is that the `console` Playwright project injects `storageState: adminStorageState` into every browser context, pre-loading kubeadmin's OAuth cookies. When the session-persistence tests call `performLogin()`, the browser is already authenticated — `page.goto(baseURL)` lands on the dashboard instead of the OAuth login page, so the login element assertion (`[data-test-id="login"]` / `#inputUsername`) always times out after 30s with "element(s) not found".

Evidence:
- `auth-multiuser-login.spec.ts` uses `test.use({ storageState: { cookies: [], origins: [] } })` + `performLogin()` → **0% failure rate** across 139 runs
- `session-persistence.spec.ts` inherits `storageState: adminStorageState` + `performLogin()` → **100% failure rate**
- The only difference is the `storageState` configuration

**Solution description**:
Add `test.use({ storageState: { cookies: [], origins: [] } })` to the describe block so each test starts with a clean, unauthenticated browser context. This matches the existing pattern in `auth-multiuser-login.spec.ts`.

The session-persistence tests need to control their own authentication lifecycle from scratch — they log in, delete/restart console pods, then verify the session survives. Pre-loading cookies from `storageState` defeats this by skipping the login page entirely.

**Screenshots / screen recording**:
N/A — no visual changes.

**Test setup:**
No additional setup required. The fix is to the test itself.

**Test cases:**
- `session survives console pod deletion` — should now reach the OAuth login page, authenticate, delete pods, and verify session persistence
- `session survives console plugin toggle` — should now reach the OAuth login page, authenticate, toggle a plugin, and verify session persistence

**Browser conformance**:
- [x] Chrome (Playwright CI uses Chromium)
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
This is a one-line fix. The `storageState` override pattern is already established in the codebase at `frontend/e2e/tests/console/app/auth-multiuser-login.spec.ts:8`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved session persistence test reliability by ensuring each test starts with a clean browser state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->