### PR TITLE
[release-4.18] OCPBUGS-113759: block GraphQL introspection over websocket

### DIFF
--- a/pkg/graphql/introspection.go
+++ b/pkg/graphql/introspection.go
@@ -1,0 +1,139 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	graphql "github.com/graph-gophers/graphql-go"
+)
+
+// introspectionFieldNames are the GraphQL introspection meta-fields (__schema,
+// __type) and the Apollo Federation service field (_service) that must be
+// rejected. The __typename meta-field is intentionally omitted: it must always
+// be allowed (it is required to resolve unions and interfaces) and is injected
+// into most selection sets by Apollo Client.
+var introspectionFieldNames = map[string]struct{}{
+	"__schema": {},
+	"__type":   {},
+	"_service": {},
+}
+
+// graphQLSubscriber is the subset of *graphql.Schema that the graphql-ws
+// websocket transport uses to execute operations. It mirrors the graphqlws
+// connection.GraphQLService interface (which is defined in an internal package
+// and therefore cannot be referenced directly).
+type graphQLSubscriber interface {
+	Subscribe(ctx context.Context, document string, operationName string, variableValues map[string]interface{}) (<-chan interface{}, error)
+}
+
+// introspectionBlocker wraps a graphQLSubscriber and rejects GraphQL
+// introspection queries sent over the graphql-ws websocket transport.
+//
+// graph-gophers/graphql-go v1.5.0 only honors graphql.DisableIntrospection() on
+// the HTTP (Exec) path. Its Subscribe path -- which the console also uses to run
+// ordinary queries over the websocket -- executes with introspection enabled
+// regardless, so the schema can be enumerated over the websocket even though it
+// is blocked over plain HTTP. This wrapper closes that gap by rejecting
+// introspection documents before they reach the schema.
+//
+// The leak is fixed upstream in graphql-go v1.6.0+ (shipped in OpenShift 4.19
+// and later, which are not affected), so this guard is only needed on branches
+// pinned to v1.5.0. See https://issues.redhat.com/browse/OCPBUGS-113759.
+type introspectionBlocker struct {
+	subscriber graphQLSubscriber
+}
+
+// NewIntrospectionBlocker returns a graphql-ws service that rejects introspection
+// queries before delegating to the wrapped schema's Subscribe.
+func NewIntrospectionBlocker(schema *graphql.Schema) *introspectionBlocker {
+	return &introspectionBlocker{subscriber: schema}
+}
+
+// Subscribe rejects any operation whose document selects an introspection
+// meta-field and otherwise delegates to the wrapped subscriber. It satisfies the
+// graphqlws connection.GraphQLService interface.
+func (b *introspectionBlocker) Subscribe(ctx context.Context, document string, operationName string, variableValues map[string]interface{}) (<-chan interface{}, error) {
+	if selectsIntrospectionField(document) {
+		return nil, errors.New("GraphQL introspection is disabled")
+	}
+	return b.subscriber.Subscribe(ctx, document, operationName, variableValues)
+}
+
+// selectsIntrospectionField reports whether the GraphQL document references an
+// introspection meta-field as an actual name token. It scans the document while
+// skipping comments and string values (both regular and block strings) so that
+// an introspection name appearing only inside a comment or a string argument
+// does not cause a legitimate query to be rejected.
+func selectsIntrospectionField(document string) bool {
+	for i := 0; i < len(document); {
+		c := document[i]
+		switch {
+		case c == '#':
+			// Comment: skip to end of line.
+			for i < len(document) && document[i] != '\n' {
+				i++
+			}
+		case c == '"':
+			i = skipString(document, i)
+		case isNameStart(c):
+			start := i
+			i++
+			for i < len(document) && isNameContinue(document[i]) {
+				i++
+			}
+			if _, ok := introspectionFieldNames[document[start:i]]; ok {
+				return true
+			}
+		default:
+			i++
+		}
+	}
+	return false
+}
+
+// skipString advances past a GraphQL string value that begins at index i (which
+// must point at a '"') and returns the index of the first character after it. It
+// handles both regular strings ("...") with backslash escapes and block strings
+// ("""...""") with the \""" escape sequence.
+func skipString(document string, i int) int {
+	if strings.HasPrefix(document[i:], `"""`) {
+		i += 3
+		for i < len(document) {
+			if strings.HasPrefix(document[i:], `\"""`) {
+				i += 4
+				continue
+			}
+			if strings.HasPrefix(document[i:], `"""`) {
+				return i + 3
+			}
+			i++
+		}
+		return i
+	}
+
+	i++ // opening quote
+	for i < len(document) {
+		switch document[i] {
+		case '\\':
+			i += 2
+		case '"':
+			return i + 1
+		case '\n':
+			return i // unterminated string; stop scanning this token
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+// isNameStart reports whether b can start a GraphQL name (/[_A-Za-z]/).
+func isNameStart(b byte) bool {
+	return b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+// isNameContinue reports whether b can continue a GraphQL name (/[_0-9A-Za-z]/).
+func isNameContinue(b byte) bool {
+	return isNameStart(b) || (b >= '0' && b <= '9')
+}

--- a/pkg/graphql/introspection_test.go
+++ b/pkg/graphql/introspection_test.go
@@ -1,0 +1,106 @@
+package graphql
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeSubscriber struct {
+	called bool
+}
+
+func (f *fakeSubscriber) Subscribe(ctx context.Context, document string, operationName string, variableValues map[string]interface{}) (<-chan interface{}, error) {
+	f.called = true
+	ch := make(chan interface{})
+	close(ch)
+	return ch, nil
+}
+
+func TestIntrospectionBlockerSubscribe(t *testing.T) {
+	tests := []struct {
+		name     string
+		document string
+		blocked  bool
+	}{
+		{
+			name:     "schema introspection is blocked",
+			document: `query IntrospectionCheck { __schema { queryType { name } mutationType { name } } }`,
+			blocked:  true,
+		},
+		{
+			name:     "type introspection is blocked",
+			document: `query { __type(name: "Query") { name } }`,
+			blocked:  true,
+		},
+		{
+			name:     "aliased schema introspection is blocked",
+			document: `query { s: __schema { types { name } } }`,
+			blocked:  true,
+		},
+		{
+			name:     "minified schema introspection is blocked",
+			document: `{__schema{queryType{name}}}`,
+			blocked:  true,
+		},
+		{
+			name:     "federation service field is blocked",
+			document: `query { _service { sdl } }`,
+			blocked:  true,
+		},
+		{
+			name:     "__typename is allowed",
+			document: `query { console { __typename } }`,
+			blocked:  false,
+		},
+		{
+			name:     "introspection name inside a string argument is allowed",
+			document: `query { urls(filter: "__schema") { key value } }`,
+			blocked:  false,
+		},
+		{
+			name:     "introspection name inside a block string argument is allowed",
+			document: `query { urls(filter: """__type""") { key value } }`,
+			blocked:  false,
+		},
+		{
+			name:     "introspection name inside a comment is allowed",
+			document: "query {\n  urls { key } # really not __schema here\n}",
+			blocked:  false,
+		},
+		{
+			name:     "ordinary query is allowed",
+			document: `query GetURL { urls { key value } }`,
+			blocked:  false,
+		},
+		{
+			name:     "subscription is allowed",
+			document: `subscription { pollURL { key value } }`,
+			blocked:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeSubscriber{}
+			blocker := &introspectionBlocker{subscriber: fake}
+
+			_, err := blocker.Subscribe(context.Background(), tt.document, "", nil)
+
+			if tt.blocked {
+				if err == nil {
+					t.Errorf("expected introspection document to be rejected, got no error")
+				}
+				if fake.called {
+					t.Errorf("wrapped subscriber must not be called for a blocked document")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected document to be allowed, got error: %v", err)
+				}
+				if !fake.called {
+					t.Errorf("wrapped subscriber must be called for an allowed document")
+				}
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -350,7 +350,11 @@ func (s *Server) HTTPHandler() (http.Handler, error) {
 	schema := graphql.MustParseSchema(string(graphQLSchema), &rootResolver, opts...)
 	handler := graphqlws.NewHandler()
 	handler.InitPayload = resolver.InitPayload
-	graphQLHandler := handler.NewHandlerFunc(schema, gql.NewHttpHandler(schema))
+	// NOTE: graph-gophers/graphql-go v1.5.0 only disables introspection on the
+	// HTTP (Exec) path, not on the websocket (Subscribe) path used by graphql-ws.
+	// Wrap the schema so introspection queries are also rejected over the
+	// websocket. See OCPBUGS-113759. (Fixed upstream in v1.6.0, used by 4.19+.)
+	graphQLHandler := handler.NewHandlerFunc(gql.NewIntrospectionBlocker(schema), gql.NewHttpHandler(schema))
 	handle("/api/graphql", authHandlerWithUser(func(user *auth.User, w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(context.Background(), resolver.HeadersKey, map[string]string{
 			"Authorization": fmt.Sprintf("Bearer %s", user.Token),


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>

OCPBUGS-113759: block GraphQL introspection over the console's `/api/graphql` websocket (graphql-ws) transport, closing the gap left by OCPBUGS-43671 / #14639.

<h2 id="solution-description">Solution description</h2>

**Problem.** OCPBUGS-43671 (#14639) added `graphql.DisableIntrospection()` to disable introspection on the console GraphQL endpoint. In graph-gophers/graphql-go **v1.5.0** (used by release-4.18) that option only affects the HTTP `Schema.Exec` path. The same `/api/graphql` endpoint is also served over a graphql-ws websocket, which runs operations through `Schema.Subscribe`; that path builds its request without the introspection flag, so introspection stays enabled. A client can enumerate the schema by sending the introspection query over the websocket instead of HTTP:

```json
{"type":"start","id":"1","payload":{"query":"query { __schema { queryType { name } } }"}}
```

**Fix.** Wrap the schema in an `introspectionBlocker` (`pkg/graphql/introspection.go`) that implements the graphql-ws service interface. It rejects any document selecting an introspection meta-field (`__schema`, `__type`, `_service`) before delegating to `Schema.Subscribe`, and continues to allow `__typename` (required for unions/interfaces and injected by Apollo Client). The HTTP path is unchanged; only the websocket service argument is swapped in `pkg/server/server.go`.

**Affected versions.**
- **release-4.18 / release-4.17** — vulnerable (graphql-go v1.5.0). This PR targets release-4.18.
- **release-4.19 through release-4.22** — already resolved: all ship graphql-go **v1.6.0**, where the introspection option was reworked so the `Subscribe` (websocket) path defaults to introspection disabled. No change needed.
- **main** — not applicable: the GraphQL endpoint has been removed entirely.

<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>

<!-- TODO: tag an OCP console engineer to review, e.g. /assign @spadgett @jhadvig @rhamilto @TheRealJon -->

<h2 id="test-cases">Test cases:</h2>

Unit test `TestIntrospectionBlockerSubscribe` (`pkg/graphql/introspection_test.go`):
- **Blocked:** `__schema`, `__type`, aliased `__schema`, minified `__schema`, `_service`.
- **Allowed:** `__typename`, an ordinary query, and a subscription.

Manual verification: with a console built from this branch, sending the introspection query over the websocket now returns an error instead of the schema; sending it over plain HTTP is unchanged (already blocked).

<h2 id="additional-info">Additional info:</h2>

Root cause is in graph-gophers/graphql-go v1.5.0: `Schema.Exec` sets the introspection flag on its request but `Schema.subscribe` does not, so introspection is only suppressed on the HTTP path. This guard is only needed on branches pinned to v1.5.0.

<h2 id="screenshots">Screen shots / gifs / design review:</h2>

N/A — backend-only change, no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * GraphQL schema introspection requests over WebSocket subscriptions are now rejected, including schema, type, and federation service introspection fields.
  * `__typename`, regular queries, and non-introspection subscriptions continue to work as expected.
* **Bug Fixes**
  * Introspection blocking is now consistently applied across both HTTP requests and WebSocket subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->