### PR TITLE
OCPBUGS-114052: Restore login scenario to test-prow-e2e.sh

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -7,6 +7,7 @@
 #
 # Scenarios (first argument; default: e2e):
 #   e2e, release  — full Playwright suite (default project / config)
+#   login         — auth-multiuser-login spec only (--project=console)
 #   smoke         — Playwright smoke project (--project=smoke)
 #
 # Environment (typical Prow / installer):
@@ -59,6 +60,11 @@ fi
 
 if [ "$SCENARIO" == "e2e" ] || [ "$SCENARIO" == "release" ]; then
   ./integration-tests/test-playwright.sh "$@"
+elif [ "$SCENARIO" == "login" ]; then
+  export BRIDGE_HTPASSWD_IDP="${BRIDGE_HTPASSWD_IDP:-test}"
+  export BRIDGE_HTPASSWD_USERNAME="${BRIDGE_HTPASSWD_USERNAME:-test}"
+  export BRIDGE_HTPASSWD_PASSWORD="${BRIDGE_HTPASSWD_PASSWORD:-test}"
+  ./integration-tests/test-playwright.sh -- --project=console e2e/tests/console/app/auth-multiuser-login.spec.ts "$@"
 elif [ "$SCENARIO" == "smoke" ]; then
   # End of script flags before Playwright's --project (test-playwright.sh only parses -c).
   ./integration-tests/test-playwright.sh -- --project=smoke "$@"


### PR DESCRIPTION
**Analysis / Root cause:**
Commit [8cb612eea9](https://github.com/openshift/console/commit/8cb612eea9ce2720e3e02d666c57d6f749e04473) (OCPBUGS-112462, Aug 20th) removed the login scenario from test-prow-e2e.sh when cleaning up the empty Cypress integration-tests package. However, the e2e-console-login CI job in openshift-release still passes login as the scenario argument, causing a hard failure: error: unknown scenario 'login' (use: e2e, release, or smoke). This has been perma-failing since August 20th and is blocking PRs in openshift/cluster-authentication-operator.

**Solution description:**
Re-add the login scenario to test-prow-e2e.sh, now routing to the Playwright equivalent (e2e/tests/console/app/auth-multiuser-login.spec.ts) instead of the old Cypress path. The htpasswd environment variables (BRIDGE_HTPASSWD_IDP, BRIDGE_HTPASSWD_USERNAME, BRIDGE_HTPASSWD_PASSWORD) are exported so the Playwright test can authenticate as the test user.

**Screenshots / screen recording:**
N/A — CI script change only.

**Test setup:**
Trigger the e2e-console-login CI job on a cluster-authentication-operator PR.

**Test cases:**

e2e-console-login CI job passes instead of failing with "unknown scenario"
The Playwright auth-multiuser-login spec runs and validates both htpasswd and kubeadmin login
**Browser conformance:**
N/A — CI script change only.

**Additional info:**
Fixes the perma-failing ci/prow/e2e-console-login job that has been blocking openshift/cluster-authentication-operator merges since Aug 20th.

Reviewers and assignees:
/assign @logonoff 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documented end-to-end login test scenario.
  * The scenario now configures default test credentials and runs the multi-user login checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->