### PR TITLE
[release-4.21] OCPBUGS-116250:
  Validate chart URL in /api/helm/verify

### DIFF
--- a/pkg/helm/handlers/handlerChartVerifier.go
+++ b/pkg/helm/handlers/handlerChartVerifier.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/openshift/console/pkg/auth"
 	"github.com/openshift/console/pkg/helm/actions"
@@ -13,6 +14,13 @@ import (
 	"github.com/openshift/console/pkg/version"
 	"helm.sh/helm/v3/pkg/action"
 	"k8s.io/client-go/rest"
+)
+
+var (
+	dnsLabel  = `[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?`
+	hostPort  = dnsLabel + `(?:\.` + dnsLabel + `)*\.?(?::\d+)?`
+	ociURLRe  = regexp.MustCompile(`(?i)^oci://` + hostPort)
+	httpURLRe = regexp.MustCompile(`(?i)^https?://` + hostPort + `/.+\.(?:tar\.gz|tgz)$`)
 )
 
 // helmHandlers provides handlers to handle helm related requests
@@ -47,12 +55,23 @@ func (h *verifierHandlers) restConfig(bearerToken string) *rest.Config {
 		Transport:   h.Transport,
 	}
 }
+
+// isValidChartURL validates chart URLs using RFC-compliant hostname labels.
+// Accepts oci://<registry>/<path> and http(s)://<host>/<path>.tgz|tar.gz URLs.
+func isValidChartURL(raw string) bool {
+	return ociURLRe.MatchString(raw) || httpURLRe.MatchString(raw)
+}
+
 func (h *verifierHandlers) HandleChartVerifier(user *auth.User, w http.ResponseWriter, r *http.Request) {
 	var req HelmVerifierRequest
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: fmt.Sprintf("Failed to parse request: %v", err)})
+		return
+	}
+	if !isValidChartURL(req.ChartUrl) {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: "invalid chart URL: must be oci:// or http(s)://*.tgz"})
 		return
 	}
 	conf := h.getActionConfigurations(h.ApiServerHost, "default", user.Token, &h.Transport)

--- a/pkg/helm/handlers/handler_chartVerifier_test.go
+++ b/pkg/helm/handlers/handler_chartVerifier_test.go
@@ -13,6 +13,8 @@ import (
 
 var fakeReportSummary = `{"passed":"0","failed":"0","messages":null}`
 
+const validChartURL = "https://example.com/charts/mychart-1.0.0.tgz"
+
 func fakeVerifierHandler() verifierHandlers {
 	return verifierHandlers{
 		getActionConfigurations: getFakeActionConfigurations,
@@ -21,12 +23,15 @@ func fakeVerifierHandler() verifierHandlers {
 
 func fakeChartVerification(reportSummary string, err error) func(chartUrl string, values map[string]interface{}, conf *action.Configuration) (string, error) {
 	return func(chartUrl string, values map[string]interface{}, conf *action.Configuration) (r string, er error) {
-		return r, err
+		return reportSummary, err
 	}
 }
 func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
+	validBody := `{"chart_url":"` + validChartURL + `"}`
+
 	tests := []struct {
 		name             string
+		body             string
 		expectedResponse string
 		ReportSummary    string
 		error
@@ -34,15 +39,17 @@ func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
 	}{
 		{
 			name:             "Error occurred",
+			body:             validBody,
 			expectedResponse: `{"error":"Failed to verify chart: Chart path is invalid"}`,
 			error:            errors.New("Chart path is invalid"),
 			httpStatusCode:   http.StatusBadGateway,
 		},
 		{
 			name:             "Successful chart verification",
+			body:             validBody,
 			ReportSummary:    fakeReportSummary,
 			httpStatusCode:   http.StatusOK,
-			expectedResponse: ``,
+			expectedResponse: fakeReportSummary,
 		},
 	}
 	for _, tt := range tests {
@@ -50,7 +57,7 @@ func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
 			handlers := fakeVerifierHandler()
 			handlers.chartVerifier = fakeChartVerification(tt.ReportSummary, tt.error)
 
-			request := httptest.NewRequest("", "/foo", strings.NewReader("{}"))
+			request := httptest.NewRequest("", "/foo", strings.NewReader(tt.body))
 			response := httptest.NewRecorder()
 
 			handlers.HandleChartVerifier(&auth.User{}, response, request)
@@ -62,6 +69,101 @@ func TestHelmHandlers_HandleChartVerifier(t *testing.T) {
 			}
 			if response.Body.String() != tt.expectedResponse {
 				t.Errorf("response body not matching expected is %s and received is %s", tt.expectedResponse, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestHelmHandlers_HandleChartVerifier_AcceptsValidURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"valid OCI registry", "oci://ghcr.io/charts/mychart:1.0.0"},
+		{"valid OCI registry with port", "oci://registry.example.com:5000/charts/mychart"},
+		{"valid HTTPS tgz", validChartURL},
+		{"valid HTTP tgz", "http://example.com/charts/mychart-1.0.0.tgz"},
+		{"valid HTTPS tar.gz", "https://example.com/charts/mychart-1.0.0.tar.gz"},
+		{"valid HTTP IPv4 tgz", "http://172.28.1.76:8849/chart.tgz"},
+		{"valid HTTP localhost tgz", "http://localhost/chart.tgz"},
+		{"valid HTTP loopback tgz", "http://127.0.0.1/chart.tgz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := fakeVerifierHandler()
+			actionConfigCalled := false
+			verifierCalled := false
+			handlers.getActionConfigurations = func(string, string, string, *http.RoundTripper) *action.Configuration {
+				actionConfigCalled = true
+				return &action.Configuration{}
+			}
+			handlers.chartVerifier = func(chartURL string, values map[string]interface{}, conf *action.Configuration) (string, error) {
+				verifierCalled = true
+				return fakeReportSummary, nil
+			}
+
+			request := httptest.NewRequest(http.MethodPost, "/api/helm/verify", strings.NewReader(`{"chart_url":"`+tt.url+`"}`))
+			response := httptest.NewRecorder()
+
+			handlers.HandleChartVerifier(&auth.User{}, response, request)
+
+			if response.Code != http.StatusOK {
+				t.Errorf("expected status 200 but got %v", response.Code)
+			}
+			if !actionConfigCalled {
+				t.Error("expected action configuration to be created")
+			}
+			if !verifierCalled {
+				t.Error("expected chart verifier to be called")
+			}
+		})
+	}
+}
+
+func TestHelmHandlers_HandleChartVerifier_RejectsInvalidURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"rejects internal IP without tgz", `{"chart_url":"http://172.28.1.76:8849/nacos"}`},
+		{"rejects non-tgz HTTP URL", `{"chart_url":"http://example.com/charts/mychart"}`},
+		{"rejects empty chart URL", `{"chart_url":""}`},
+		{"rejects hostless OCI URL", `{"chart_url":"oci:///chart"}`},
+		{"rejects ftp scheme", `{"chart_url":"ftp://example.com/chart.tgz"}`},
+		{"rejects file scheme", `{"chart_url":"file:///etc/passwd"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handlers := fakeVerifierHandler()
+			actionConfigCalled := false
+			verifierCalled := false
+			handlers.getActionConfigurations = func(string, string, string, *http.RoundTripper) *action.Configuration {
+				actionConfigCalled = true
+				return &action.Configuration{}
+			}
+			handlers.chartVerifier = func(chartURL string, values map[string]interface{}, conf *action.Configuration) (string, error) {
+				verifierCalled = true
+				return fakeReportSummary, nil
+			}
+
+			request := httptest.NewRequest(http.MethodPost, "/api/helm/verify", strings.NewReader(tt.body))
+			response := httptest.NewRecorder()
+
+			handlers.HandleChartVerifier(&auth.User{}, response, request)
+
+			if response.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400 but got %v", response.Code)
+			}
+			if response.Body.String() != `{"error":"invalid chart URL: must be oci:// or http(s)://*.tgz"}` {
+				t.Errorf("unexpected response body: %s", response.Body.String())
+			}
+			if actionConfigCalled {
+				t.Error("did not expect action configuration to be created")
+			}
+			if verifierCalled {
+				t.Error("did not expect chart verifier to be called")
 			}
 		})
 	}


### PR DESCRIPTION
## CONSOLE Features and Fixes

Manual backport / adaptation of [#17118](https://github.com/openshift/console/pull/17118) for [OCPBUGS-116250](https://redhat.atlassian.net/browse/OCPBUGS-116250) to `release-4.21`.

## Solution description

Invalid chart URLs now return HTTP 400 before chart verification begins, preventing the verifier from making an outbound request for invalid input. The validation accepts OCI registry references and HTTP(S) Helm chart archives ending in `.tgz` or `.tar.gz`.

The 4.21 Helm code layout lacks the reusable validator used by the 4.22 backport, so this applies the equivalent validation in the verifier handler.

## Test cases

- `go test ./pkg/helm/handlers`
- Handler coverage verifies invalid, empty, non-archive HTTP(S), `ftp://`, and `file://` chart URLs are rejected with HTTP 400 before downstream verification is invoked.

## Additional info

Original fix: [#16786](https://github.com/openshift/console/pull/16786)

4.22 backport: [#17118](https://github.com/openshift/console/pull/17118)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart verification now validates chart URLs before processing requests.
  * Invalid, unsupported, or incomplete URLs receive a clear 400 error response.
  * Valid OCI and HTTP(S) chart archive URLs continue through the existing verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->