### PR TITLE
fix: show Helm tab when CRDs are installed but no instances exist

### DIFF
--- a/frontend/packages/helm-plugin/src/catalog/utils/__tests__/catalog-utils.spec.ts
+++ b/frontend/packages/helm-plugin/src/catalog/utils/__tests__/catalog-utils.spec.ts
@@ -1,0 +1,69 @@
+import { t } from '@console/shared/src/test-utils/i18n-test-utils';
+import type { HelmChartMetaData, HelmChartEntries } from '../../../types/helm-types';
+import { normalizeHelmCharts } from '../catalog-utils';
+
+jest.mock('@console/internal/components/catalog/catalog-item-icon', () => ({
+  getImageForIconClass: jest.fn(() => 'test-icon-url'),
+}));
+
+const validChart: HelmChartMetaData = {
+  name: 'test-chart',
+  version: '1.0.0',
+  apiVersion: 'v1',
+  description: 'A test chart',
+  urls: ['https://example.com/charts/test-chart-1.0.0.tgz'],
+};
+
+describe('normalizeHelmCharts', () => {
+  it('should skip charts with undefined urls', () => {
+    const malformedChart = { ...validChart, urls: undefined } as unknown as HelmChartMetaData;
+    const entries: HelmChartEntries = {
+      'test--repo': [malformedChart],
+    };
+    const result = normalizeHelmCharts(entries, [], 'default', t);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should skip charts with empty urls array', () => {
+    const malformedChart: HelmChartMetaData = { ...validChart, urls: [] };
+    const entries: HelmChartEntries = {
+      'test--repo': [malformedChart],
+    };
+    const result = normalizeHelmCharts(entries, [], 'default', t);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should normalize charts with valid urls', () => {
+    const entries: HelmChartEntries = {
+      'test-chart--repo': [validChart],
+    };
+    const result = normalizeHelmCharts(entries, [], 'default', t);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Test Chart');
+    expect(result[0].type).toBe('HelmChart');
+  });
+
+  it('should skip malformed entries while keeping valid ones', () => {
+    const malformedChart = {
+      ...validChart,
+      name: 'bad',
+      urls: undefined,
+    } as unknown as HelmChartMetaData;
+    const entries: HelmChartEntries = {
+      'charts--repo': [malformedChart, validChart],
+    };
+    const result = normalizeHelmCharts(entries, [], 'default', t);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Test Chart');
+  });
+
+  it('should handle null chartEntries', () => {
+    const result = normalizeHelmCharts(null, [], 'default', t);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle undefined chartEntries', () => {
+    const result = normalizeHelmCharts(undefined, [], 'default', t);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
+++ b/frontend/packages/helm-plugin/src/catalog/utils/catalog-utils.tsx
@@ -39,6 +39,12 @@ export const normalizeHelmCharts = (
       charts.forEach((chart: HelmChartMetaData) => {
         const { name, created, version, appVersion, description, keywords, annotations } = chart;
 
+        // Skip charts with missing or empty urls — malformed chart metadata
+        // from misconfigured repositories can omit the urls field entirely.
+        if (!chart.urls?.length) {
+          return;
+        }
+
         const annotatedName = annotations?.[CHART_NAME_ANNOTATION] ?? '';
         const providerType = annotations?.[PROVIDER_TYPE_ANNOTATION] ?? '';
         const providerName = annotations?.[PROVIDER_NAME_ANNOTATION] ?? '';

--- a/frontend/packages/helm-plugin/src/providers/__tests__/helm-detection-provider.spec.ts
+++ b/frontend/packages/helm-plugin/src/providers/__tests__/helm-detection-provider.spec.ts
@@ -2,14 +2,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { HttpError } from '@console/dynamic-plugin-sdk/src/utils/error/http-error';
 import { k8sListResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
 import { settleAllPromises } from '@console/dynamic-plugin-sdk/src/utils/promise';
-import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
-import { mockHelmChartRepositories } from '../../components/__tests__/helm-release-mock-data';
 import { FLAG_OPENSHIFT_HELM } from '../../const';
 import { HelmChartRepositoryModel, ProjectHelmChartRepositoryModel } from '../../models/helm';
-import { hasEnabledHelmCharts, useDetectHelmChartRepositories } from '../helm-detection-provider';
+import { useDetectHelmChartRepositories } from '../helm-detection-provider';
 
-const ns: string = 'ns';
+const ns: string = 'test-ns';
 
 jest.mock('@console/dynamic-plugin-sdk/src/utils/promise', () => ({
   settleAllPromises: jest.fn(),
@@ -28,55 +26,21 @@ const settleAllPromisesMock = settleAllPromises as jest.Mock;
 const useActiveNamespaceMock = useActiveNamespace as jest.Mock;
 const k8sListResourceMock = k8sListResource as jest.Mock;
 
-describe('hasEnabledHelmCharts', () => {
-  it('should return false if all chart repositories are disabled', () => {
-    const disabledHelmChartRepositories: K8sResourceKind[] = mockHelmChartRepositories.map(
-      (hcr) => ({ ...hcr, spec: { ...hcr.spec, disabled: true } }),
-    );
-    expect(hasEnabledHelmCharts(disabledHelmChartRepositories)).toBe(false);
-  });
-  it('should return true if any chart repository is not disabled', () => {
-    const helmChartRepositories: K8sResourceKind[] = mockHelmChartRepositories.map((hcr, index) => {
-      if (index === 0) {
-        return { ...hcr, spec: { ...hcr.spec, disabled: true } };
-      }
-      return hcr;
-    });
-    expect(hasEnabledHelmCharts(helmChartRepositories)).toBe(true);
-  });
-  it('should return false if helmChartRepositories is null or undefined', () => {
-    expect(hasEnabledHelmCharts(undefined)).toBe(false);
-  });
-  it('should return false if helmChartRepositories is an empty array', () => {
-    expect(hasEnabledHelmCharts([])).toBe(false);
-  });
-});
-
 describe('useDetectHelmChartRepositories', () => {
   const setFeatureFlag = jest.fn();
-  // Dummy promise that resolves - actual return value doesn't matter since settleAllPromises is mocked
   const dummyPromise = Promise.resolve({});
 
   beforeEach(() => {
-    jest.useFakeTimers();
     useActiveNamespaceMock.mockReturnValue([ns]);
-    // Default mock for k8sListResource - returns a resolved promise
     k8sListResourceMock.mockReturnValue(dummyPromise);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    jest.clearAllTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
   });
 
   it('should call k8sListResource with HelmChartRepositoryModel and ProjectHelmChartRepositoryModel', async () => {
-    settleAllPromisesMock.mockReturnValue(
-      Promise.resolve([[mockHelmChartRepositories, mockHelmChartRepositories], [], []]),
-    );
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[[], []], [], []]));
     renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
     expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
     expect(k8sListResourceMock.mock.calls[0]).toEqual([
@@ -87,103 +51,102 @@ describe('useDetectHelmChartRepositories', () => {
     ]);
   });
 
-  it('should call setFeatureFlag with FLAG_OPENSHIFT_HELM flag and true if only cluster scoped helm chart repository is available', async () => {
+  it('should set flag to true when CRDs exist with instances', async () => {
     settleAllPromisesMock.mockReturnValue(
-      Promise.resolve([[mockHelmChartRepositories, []], [], []]),
+      Promise.resolve([[[{ metadata: { name: 'repo1' } }], []], [], []]),
     );
     renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
     await waitFor(() => {
       expect(setFeatureFlag).toHaveBeenCalledTimes(1);
     });
-    expect(setFeatureFlag.mock.calls[0]).toEqual([FLAG_OPENSHIFT_HELM, true]);
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, true);
   });
 
-  it('should call setFeatureFlag with FLAG_OPENSHIFT_HELM flag and true if only project scoped helm chart repository is available', async () => {
-    settleAllPromisesMock.mockReturnValue(
-      Promise.resolve([[[], mockHelmChartRepositories], [], []]),
-    );
-    renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
-    await waitFor(() => {
-      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
-    });
-    expect(setFeatureFlag.mock.calls[0]).toEqual([FLAG_OPENSHIFT_HELM, true]);
-  });
-
-  it('should call setFeatureFlag with FLAG_OPENSHIFT_HELM flag and true if both project and cluster scoped helm chart repositories are available', async () => {
-    settleAllPromisesMock.mockReturnValue(
-      Promise.resolve([[mockHelmChartRepositories, mockHelmChartRepositories], [], []]),
-    );
-    renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
-    await waitFor(() => {
-      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
-    });
-    expect(setFeatureFlag.mock.calls[0]).toEqual([FLAG_OPENSHIFT_HELM, true]);
-  });
-
-  it('should call setFeatureFlag with FLAG_OPENSHIFT_HELM flag and false if no CR helm chart repository is available', async () => {
+  it('should set flag to true when CRDs exist but no instances (empty lists)', async () => {
     settleAllPromisesMock.mockReturnValue(Promise.resolve([[[], []], [], []]));
     renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
     await waitFor(() => {
       expect(setFeatureFlag).toHaveBeenCalledTimes(1);
     });
-    expect(setFeatureFlag.mock.calls[0]).toEqual([FLAG_OPENSHIFT_HELM, false]);
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, true);
   });
 
-  it('should call setFeatureFlag with FLAG_OPENSHIFT_HELM flag and false if k8sListResource returns rejected promise for both cluster and project scoped helm chart repositories with atleast one of them being error 404', async () => {
-    const error404 = new HttpError('404', 404, {
-      status: 404,
-    } as Response);
-    const error200 = new HttpError('200', 200, {
-      status: 200,
-    } as Response);
-
-    // settleAllPromises mock returns errors in rejectedReasons array
-    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error404, error200], []]));
-
+  it('should set flag to true when only one CRD API succeeds', async () => {
+    // One fulfilled, one rejected
+    const error404 = new HttpError('404', 404, { status: 404 } as Response);
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[[]], [error404], []]));
     renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
     await waitFor(() => {
-      expect(setFeatureFlag).toHaveBeenCalledTimes(2);
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
     });
-    expect(setFeatureFlag.mock.calls[0]).toEqual([FLAG_OPENSHIFT_HELM, false]);
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, true);
   });
 
-  it('should call setFeatureFlag with FLAG_OPENSHIFT_HELM flag and undefined if k8sListResource returns rejected promise for both cluster and project scoped helm chart repositories with none of them being error 404', async () => {
-    const error200 = new HttpError('200', 200, {
-      status: 200,
-    } as Response);
-    // settleAllPromises mock returns errors in rejectedReasons array
-    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error200, error200], []]));
+  it('should set flag to false when all CRD APIs return 404', async () => {
+    const error404a = new HttpError('404', 404, { status: 404 } as Response);
+    const error404b = new HttpError('404', 404, { status: 404 } as Response);
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error404a, error404b], []]));
     renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
     await waitFor(() => {
-      expect(setFeatureFlag).toHaveBeenCalledTimes(2);
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
     });
-    expect(setFeatureFlag.mock.calls[0]).toEqual([FLAG_OPENSHIFT_HELM, undefined]);
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, false);
   });
 
-  it('should call k8sListResource every 10 seconds', async () => {
-    settleAllPromisesMock.mockReturnValue(
-      Promise.resolve([[mockHelmChartRepositories, mockHelmChartRepositories], [], []]),
-    );
+  it('should set flag to true when all calls fail with 403 (CRD exists, RBAC-blocked)', async () => {
+    const error403a = new HttpError('403', 403, { status: 403 } as Response);
+    const error403b = new HttpError('403', 403, { status: 403 } as Response);
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error403a, error403b], []]));
     renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
+    await waitFor(() => {
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, true);
+  });
+
+  it('should set flag to true when errors are mixed 403 and 404 (403 proves CRD exists)', async () => {
+    const error403 = new HttpError('403', 403, { status: 403 } as Response);
+    const error404 = new HttpError('404', 404, { status: 404 } as Response);
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error403, error404], []]));
+    renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
+    await waitFor(() => {
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, true);
+  });
+
+  it('should set flag to undefined on transient (non-404) errors', async () => {
+    const error500a = new HttpError('500', 500, { status: 500 } as Response);
+    const error500b = new HttpError('500', 500, { status: 500 } as Response);
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error500a, error500b], []]));
+    renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
+    await waitFor(() => {
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, undefined);
+  });
+
+  it('should set flag to undefined when errors are mixed non-404 statuses', async () => {
+    const error404 = new HttpError('404', 404, { status: 404 } as Response);
+    const error500 = new HttpError('500', 500, { status: 500 } as Response);
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error404, error500], []]));
+    renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
+    await waitFor(() => {
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+    expect(setFeatureFlag).toHaveBeenCalledWith(FLAG_OPENSHIFT_HELM, undefined);
+  });
+
+  it('should not poll — detection runs only once', async () => {
+    settleAllPromisesMock.mockReturnValue(Promise.resolve([[[], []], [], []]));
+    const { rerender } = renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
+    await waitFor(() => {
+      expect(setFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+    rerender();
+    rerender();
+    // k8sListResource called only on the initial render (2 CRD models)
     expect(k8sListResourceMock).toHaveBeenCalledTimes(2);
-    jest.advanceTimersByTime(20 * 1000);
-    expect(k8sListResourceMock).toHaveBeenCalledTimes(6);
-  });
-
-  it('should not call k8sListResource every 10 seconds if k8sListResource returns rejected promise for both cluster and project scoped helm chart repositories', async () => {
-    const error404 = new HttpError('404', 404, {
-      status: 404,
-    } as Response);
-    const error200 = new HttpError('200', 200, {
-      status: 200,
-    } as Response);
-    // settleAllPromises mock returns errors in rejectedReasons array
-    settleAllPromisesMock.mockReturnValue(Promise.resolve([[], [error404, error200], []]));
-    renderHook(() => useDetectHelmChartRepositories(setFeatureFlag));
-    await waitFor(() => {
-      expect(k8sListResourceMock).toHaveBeenCalledTimes(4);
-    });
-    jest.advanceTimersByTime(20 * 1000);
-    expect(k8sListResourceMock).toHaveBeenCalledTimes(4);
+    expect(setFeatureFlag).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/packages/helm-plugin/src/providers/helm-detection-provider.ts
+++ b/frontend/packages/helm-plugin/src/providers/helm-detection-provider.ts
@@ -1,20 +1,38 @@
-import { useState, useCallback } from 'react';
+import { useEffect, useRef } from 'react';
 import type { SetFeatureFlag } from '@console/dynamic-plugin-sdk';
 import { k8sListResource } from '@console/dynamic-plugin-sdk/src/utils/k8s/k8s-resource';
 import { settleAllPromises } from '@console/dynamic-plugin-sdk/src/utils/promise';
 import type { K8sResourceKind } from '@console/internal/module/k8s';
 import { useActiveNamespace } from '@console/shared/src/hooks/useActiveNamespace';
-import { usePoll } from '@console/shared/src/hooks/usePoll';
 import { FLAG_OPENSHIFT_HELM } from '../const';
 import { HelmChartRepositoryModel, ProjectHelmChartRepositoryModel } from '../models/helm';
 
-export const hasEnabledHelmCharts = (helmChartRepositories: K8sResourceKind[]): boolean =>
-  helmChartRepositories?.some((hcr) => !hcr?.spec?.disabled) || false;
-
+/**
+ * Detects whether the Helm CRDs are installed on the cluster and sets
+ * the OPENSHIFT_HELM feature flag accordingly.
+ *
+ * Detection logic (one-time, no polling):
+ *   - CRDs exist (any list call succeeds, even with zero instances) → true
+ *   - CRDs exist but RBAC-blocked (any call returns 403) → true
+ *   - CRDs absent (all list calls return 404) → false
+ *   - Transient errors (all calls fail with non-404/non-403 status) → undefined
+ *
+ * This does NOT check whether individual HelmChartRepository instances
+ * are enabled/disabled — only whether the CRD APIs are reachable.
+ * RepositoriesListPage and useHelmCharts reference the CRD models
+ * directly and crash on 404 when the CRDs are absent, so the flag
+ * must be false in that case.
+ */
 export const useDetectHelmChartRepositories = (setFeatureFlag: SetFeatureFlag) => {
   const [namespace] = useActiveNamespace();
-  const [delay, setDelay] = useState<number>(10 * 1000);
-  const fetchHelmChartRepositories = useCallback(() => {
+  const hasFired = useRef(false);
+
+  useEffect(() => {
+    if (hasFired.current) {
+      return;
+    }
+    hasFired.current = true;
+
     const helmChartRepos: Promise<K8sResourceKind[]>[] = [
       k8sListResource<K8sResourceKind>({
         model: HelmChartRepositoryModel,
@@ -25,23 +43,34 @@ export const useDetectHelmChartRepositories = (setFeatureFlag: SetFeatureFlag) =
         queryParams: { ns: namespace },
       }) as Promise<K8sResourceKind[]>,
     ];
+
     settleAllPromises(helmChartRepos)
       .then(([fulfilledValues, rejectedReasons]) => {
-        if (fulfilledValues.some((l) => hasEnabledHelmCharts(l))) {
+        if (fulfilledValues.length > 0) {
+          // At least one CRD API responded — CRDs are installed.
           setFeatureFlag(FLAG_OPENSHIFT_HELM, true);
         } else if (rejectedReasons.length === helmChartRepos.length) {
-          const notFound = rejectedReasons.some((e) => e?.response?.status === 404);
-          notFound
-            ? setFeatureFlag(FLAG_OPENSHIFT_HELM, false)
-            : setFeatureFlag(FLAG_OPENSHIFT_HELM, undefined);
-          setDelay(null);
-        } else {
-          setFeatureFlag(FLAG_OPENSHIFT_HELM, false);
+          // All calls failed. A 403 (Forbidden) means the API endpoint exists
+          // but the user lacks permission — the CRD is installed.
+          const hasForbidden = rejectedReasons.some((e) => e?.response?.status === 403);
+          if (hasForbidden) {
+            setFeatureFlag(FLAG_OPENSHIFT_HELM, true);
+          } else {
+            const allNotFound = rejectedReasons.every((e) => e?.response?.status === 404);
+            if (allNotFound) {
+              // Every API returned 404 — CRDs are not installed.
+              setFeatureFlag(FLAG_OPENSHIFT_HELM, false);
+            } else {
+              // Non-404/non-403 errors — transient failure, leave flag undefined
+              // so the UI does not permanently hide or show the Helm tab.
+              setFeatureFlag(FLAG_OPENSHIFT_HELM, undefined);
+            }
+          }
         }
       })
       .catch((err) => {
+        // eslint-disable-next-line no-console
         console.log('failed to fetch helm chart repositories', err);
       });
   }, [namespace, setFeatureFlag]);
-  usePoll(fetchHelmChartRepositories, delay);
 };


### PR DESCRIPTION
**Analysis / Root cause**:

The `useDetectHelmChartRepositories` hook used `hasEnabledHelmCharts()` to check whether any `HelmChartRepository` or `ProjectHelmChartRepository` instances had `spec.disabled !== true`. When both API calls succeeded but returned empty lists (CRDs installed, zero instances), the hook fell through to the `else` branch and set `FLAG_OPENSHIFT_HELM` to `false` — hiding the Helm tab on clusters where the CRDs are installed but no repository instances exist yet.

Additionally, the hook polled every 10 seconds via `usePoll`, which was unnecessary overhead since CRD availability rarely changes at runtime.

**Solution description**:

Replace the polling-based detection (`usePoll` every 10s) with a one-time CRD-existence check using `useRef` to fire only once:

| Scenario | Flag value |
|---|---|
| Any list call succeeds (even empty) | `true` |
| All calls fail with 403 (RBAC-blocked, CRD exists) | `true` |
| Mixed 403 + 404 (403 proves CRD exists) | `true` |
| All calls return 404 (CRDs not installed) | `false` |
| All calls fail with non-404/non-403 (transient) | `undefined` |

Other changes:
- Removed the dead `hasEnabledHelmCharts` helper
- Removed `usePoll` dependency — detection runs once on mount
- Added a guard in `normalizeHelmCharts` for charts with missing/empty `urls` to prevent crashes from misconfigured repositories
- Added new test file `catalog-utils.spec.ts` for the malformed chart metadata guard
- Updated `helm-detection-provider.spec.ts` with comprehensive tests for all detection scenarios (403, 404, 500, mixed errors, empty lists, re-renders)

**Screenshots / screen recording**:
<!-- No visual changes — logic-only fix -->

**Test setup:**
No special setup required. Standard `yarn test` in the frontend directory.

**Test cases:**
- CRDs exist with instances → Helm tab visible
- CRDs exist but no instances (empty lists) → Helm tab visible
- Only one CRD API succeeds (other 404) → Helm tab visible
- All APIs return 403 (RBAC-blocked) → Helm tab visible
- Mixed 403 + 404 errors → Helm tab visible
- All APIs return 404 (CRDs absent) → Helm tab hidden
- Transient errors (500) → flag undefined (no false positive hide)
- Malformed chart metadata (missing/empty urls) → skipped gracefully
- Detection runs only once (no polling)

**Browser conformance**:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
This replaces the previous "unconditionally enable" approach after review feedback identified that `RepositoriesListPage` and `useHelmCharts` reference the CRD models directly and crash on 404 when CRDs are absent — so the flag must be `false` in that case.

**Reviewers and assignees:**
<!-- Please assign reviewers -->