### PR TITLE
CONSOLE-4998: Add types for serverless resources

### DIFF
--- a/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
+++ b/frontend/packages/knative-plugin/src/components/services/__tests__/ServiceRow.spec.tsx
@@ -125,7 +125,7 @@ describe('ServiceRow', () => {
   });
 
   it('should render properly when conditions indicate not ready state', () => {
-    const notReadySvcData = {
+    const notReadySvcData: RowFunctionArgs<ServiceKind> = {
       ...svcData,
       obj: {
         ...svcData.obj,

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -1,27 +1,49 @@
-import type { K8sResourceCommon, K8sResourceCondition } from '@console/internal/module/k8s';
+import type {
+  K8sResourceCommon,
+  K8sResourceCondition,
+  ContainerSpec,
+} from '@console/internal/module/k8s';
 
-export interface RevisionKind extends K8sResourceCommon {
+export type RevisionKind = {
+  spec?: object;
   status?: {
     conditions?: RevisionCondition[];
+    serviceName?: string;
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
-export interface ServiceKind extends K8sResourceCommon {
-  metadata?: {
-    generation?: number;
+export type ServiceKind = {
+  spec?: {
+    template?: {
+      metadata?: {
+        labels?: { [key: string]: string };
+      };
+      spec?: {
+        containers?: ContainerSpec[];
+        imagePullSecrets?: { name?: string }[];
+      };
+    };
   };
   status?: {
     url?: string;
     traffic?: Traffic[];
+    conditions?: ServiceCondition[];
+    latestCreatedRevisionName?: string;
+    latestReadyRevisionName?: string;
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
-export interface RouteKind extends K8sResourceCommon {
-  status: {
-    url: string;
-    traffic: Traffic[];
+export type RouteKind = {
+  spec?: object;
+  status?: {
+    url?: string;
+    traffic?: Traffic[];
+    conditions?: RouteCondition[];
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
 export enum ConditionTypes {
   Ready = 'Ready',
@@ -30,9 +52,11 @@ export enum ConditionTypes {
   ResourcesAvailable = 'ResourcesAvailable',
 }
 
-interface RevisionCondition extends K8sResourceCondition {
-  type: keyof typeof ConditionTypes;
-}
+interface RevisionCondition extends K8sResourceCondition {}
+
+interface ServiceCondition extends K8sResourceCondition {}
+
+interface RouteCondition extends K8sResourceCondition {}
 
 export interface Traffic {
   revisionName: string;
@@ -50,19 +74,18 @@ export interface RoutesOverviewListItem {
   namespace: string;
 }
 
-export interface EventSourceKind extends K8sResourceCommon {
+export type EventSourceKind = {
   status?: {
     conditions?: EventSourceCondition[];
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
 export enum EventSourceConditionTypes {
   Ready = 'Ready',
 }
 
-interface EventSourceCondition extends K8sResourceCondition {
-  type: keyof typeof EventSourceConditionTypes;
-}
+interface EventSourceCondition extends K8sResourceCondition {}
 
 interface SinkRef {
   apiVersion?: string;
@@ -75,7 +98,7 @@ interface Sink {
   ref?: SinkRef;
 }
 
-export interface PingSourceKind extends EventSourceKind {
+export type PingSourceKind = {
   spec: {
     data?: string;
     schedule?: string;
@@ -83,9 +106,9 @@ export interface PingSourceKind extends EventSourceKind {
     deadLetterSink?: Sink;
     timeZone?: string;
   };
-}
+} & EventSourceKind;
 
-export interface ApiServerSourceKind extends EventSourceKind {
+export type ApiServerSourceKind = {
   spec: {
     mode: string;
     serviceAccountName?: string;
@@ -97,9 +120,9 @@ export interface ApiServerSourceKind extends EventSourceKind {
     sink?: Sink;
     deadLetterSink?: Sink;
   };
-}
+} & EventSourceKind;
 
-export interface ContainerSourceKind extends EventSourceKind {
+export type ContainerSourceKind = {
   spec: {
     template: {
       metadata?: object;
@@ -115,7 +138,7 @@ export interface ContainerSourceKind extends EventSourceKind {
     };
     sink?: Sink;
   };
-}
+} & EventSourceKind;
 
 interface KafkaSourceNetSecret {
   enable?: boolean;
@@ -155,7 +178,7 @@ interface KafkaSourceNetTls {
   };
 }
 
-export interface KafkaSourceKind extends EventSourceKind {
+export type KafkaSourceKind = {
   spec: {
     bootstrapServers?: string[];
     topics?: string[];
@@ -166,12 +189,12 @@ export interface KafkaSourceKind extends EventSourceKind {
     };
     sink?: Sink;
   };
-}
+} & EventSourceKind;
 
 export type AnySourceKind =
   PingSourceKind | ApiServerSourceKind | ContainerSourceKind | KafkaSourceKind;
 
-export interface KameletBindingKind extends EventSourceKind {
+export type KameletBindingKind = {
   spec: {
     source?: {
       ref?: SinkRef;
@@ -186,12 +209,9 @@ export interface KameletBindingKind extends EventSourceKind {
       };
     };
   };
-}
+} & EventSourceKind;
 
-export interface EventSubscriptionKind extends K8sResourceCommon {
-  metadata?: {
-    generation?: number;
-  };
+export type EventSubscriptionKind = {
   spec: {
     channel: {
       apiVersion: string;
@@ -206,59 +226,66 @@ export interface EventSubscriptionKind extends K8sResourceCommon {
       };
     };
   };
-  status: {
-    physicalSubscription: {
+  status?: {
+    physicalSubscription?: {
       subscriberURI: string;
     };
+    conditions?: SubscriptionCondition[];
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
-export interface EventChannelKind extends K8sResourceCommon {
-  metadata?: {
-    generation?: number;
+export type EventChannelKind = {
+  spec?: {
+    subscriber?: {
+      subscriberUri?: string;
+      uid?: string;
+    }[];
   };
-  status: {
-    address: {
+  status?: {
+    address?: {
       url: string;
     };
+    conditions?: ChannelCondition[];
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
 export enum ChannelConditionTypes {
   Ready = 'Ready',
 }
 
-export interface EventBrokerKind extends K8sResourceCommon {
-  metadata?: {
-    generation?: number;
-  };
-  status: {
-    address: {
+interface ChannelCondition extends K8sResourceCondition {}
+
+export type EventBrokerKind = {
+  status?: {
+    address?: {
       url: string;
     };
+    conditions?: BrokerCondition[];
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
 export enum TriggerConditionTypes {
   Ready = 'Ready',
 }
 
-interface TriggerCondition extends K8sResourceCondition {
-  type: keyof typeof TriggerConditionTypes;
-}
+interface TriggerCondition extends K8sResourceCondition {}
 
 export enum BrokerConditionTypes {
   Ready = 'Ready',
 }
 
+interface BrokerCondition extends K8sResourceCondition {}
+
 export enum SubscriptionConditionTypes {
   Ready = 'Ready',
 }
 
-export interface EventTriggerKind extends K8sResourceCommon {
-  metadata?: {
-    generation?: number;
-  };
+interface SubscriptionCondition extends K8sResourceCondition {}
+
+export type EventTriggerKind = {
   spec: {
     broker: string;
     filter: {
@@ -276,8 +303,9 @@ export interface EventTriggerKind extends K8sResourceCommon {
   };
   status?: {
     conditions?: TriggerCondition[];
+    observedGeneration?: number;
   };
-}
+} & K8sResourceCommon;
 
 export interface DomainMappingResponse {
   action: string;

--- a/frontend/packages/knative-plugin/src/types.ts
+++ b/frontend/packages/knative-plugin/src/types.ts
@@ -1,12 +1,12 @@
-import type { K8sResourceKind, K8sResourceCondition } from '@console/internal/module/k8s';
+import type { K8sResourceCommon, K8sResourceCondition } from '@console/internal/module/k8s';
 
-export type RevisionKind = {
+export interface RevisionKind extends K8sResourceCommon {
   status?: {
     conditions?: RevisionCondition[];
   };
-} & K8sResourceKind;
+}
 
-export type ServiceKind = K8sResourceKind & {
+export interface ServiceKind extends K8sResourceCommon {
   metadata?: {
     generation?: number;
   };
@@ -14,14 +14,14 @@ export type ServiceKind = K8sResourceKind & {
     url?: string;
     traffic?: Traffic[];
   };
-};
+}
 
-export type RouteKind = {
+export interface RouteKind extends K8sResourceCommon {
   status: {
     url: string;
     traffic: Traffic[];
   };
-} & K8sResourceKind;
+}
 
 export enum ConditionTypes {
   Ready = 'Ready',
@@ -30,41 +30,165 @@ export enum ConditionTypes {
   ResourcesAvailable = 'ResourcesAvailable',
 }
 
-type RevisionCondition = {
+interface RevisionCondition extends K8sResourceCondition {
   type: keyof typeof ConditionTypes;
-} & K8sResourceCondition;
+}
 
-export type Traffic = {
+export interface Traffic {
   revisionName: string;
   percent: number;
   latestRevision?: boolean;
   tag?: string;
   url?: string;
-};
+}
 
-export type RoutesOverviewListItem = {
+export interface RoutesOverviewListItem {
   uid: string;
   url: string;
   percent: string;
   name: string;
   namespace: string;
-};
+}
 
-export type EventSourceKind = {
-  status: {
-    conditions: EventSourceCondition[];
+export interface EventSourceKind extends K8sResourceCommon {
+  status?: {
+    conditions?: EventSourceCondition[];
   };
-} & K8sResourceKind;
+}
 
 export enum EventSourceConditionTypes {
   Ready = 'Ready',
 }
 
-type EventSourceCondition = {
+interface EventSourceCondition extends K8sResourceCondition {
   type: keyof typeof EventSourceConditionTypes;
-} & K8sResourceCondition;
+}
 
-export type EventSubscriptionKind = {
+interface SinkRef {
+  apiVersion?: string;
+  kind?: string;
+  name?: string;
+}
+
+interface Sink {
+  uri?: string;
+  ref?: SinkRef;
+}
+
+export interface PingSourceKind extends EventSourceKind {
+  spec: {
+    data?: string;
+    schedule?: string;
+    sink?: Sink;
+    deadLetterSink?: Sink;
+    timeZone?: string;
+  };
+}
+
+export interface ApiServerSourceKind extends EventSourceKind {
+  spec: {
+    mode: string;
+    serviceAccountName?: string;
+    resources?: {
+      apiVersion?: string;
+      kind?: string;
+      namespace?: string;
+    }[];
+    sink?: Sink;
+    deadLetterSink?: Sink;
+  };
+}
+
+export interface ContainerSourceKind extends EventSourceKind {
+  spec: {
+    template: {
+      metadata?: object;
+      spec: {
+        containers: {
+          image?: string;
+          name?: string;
+          args?: string[];
+          env?: { name?: string; value?: string; valueFrom?: object }[];
+        }[];
+        imagePullSecrets?: { name?: string }[];
+      };
+    };
+    sink?: Sink;
+  };
+}
+
+interface KafkaSourceNetSecret {
+  enable?: boolean;
+  user?: {
+    secretKeyRef?: {
+      name?: string;
+      key?: string;
+    };
+  };
+  password?: {
+    secretKeyRef?: {
+      name?: string;
+      key?: string;
+    };
+  };
+}
+
+interface KafkaSourceNetTls {
+  enable?: boolean;
+  caCert?: {
+    secretKeyRef?: {
+      name?: string;
+      key?: string;
+    };
+  };
+  cert?: {
+    secretKeyRef?: {
+      name?: string;
+      key?: string;
+    };
+  };
+  key?: {
+    secretKeyRef?: {
+      name?: string;
+      key?: string;
+    };
+  };
+}
+
+export interface KafkaSourceKind extends EventSourceKind {
+  spec: {
+    bootstrapServers?: string[];
+    topics?: string[];
+    consumerGroup?: string;
+    net?: {
+      sasl?: KafkaSourceNetSecret;
+      tls?: KafkaSourceNetTls;
+    };
+    sink?: Sink;
+  };
+}
+
+export type AnySourceKind =
+  PingSourceKind | ApiServerSourceKind | ContainerSourceKind | KafkaSourceKind;
+
+export interface KameletBindingKind extends EventSourceKind {
+  spec: {
+    source?: {
+      ref?: SinkRef;
+      properties?: {
+        [key: string]: any;
+      };
+    };
+    sink?: {
+      ref?: SinkRef;
+      properties?: {
+        [key: string]: any;
+      };
+    };
+  };
+}
+
+export interface EventSubscriptionKind extends K8sResourceCommon {
   metadata?: {
     generation?: number;
   };
@@ -87,9 +211,9 @@ export type EventSubscriptionKind = {
       subscriberURI: string;
     };
   };
-} & K8sResourceKind;
+}
 
-export type EventChannelKind = {
+export interface EventChannelKind extends K8sResourceCommon {
   metadata?: {
     generation?: number;
   };
@@ -98,13 +222,13 @@ export type EventChannelKind = {
       url: string;
     };
   };
-} & K8sResourceKind;
+}
 
 export enum ChannelConditionTypes {
   Ready = 'Ready',
 }
 
-export type EventBrokerKind = {
+export interface EventBrokerKind extends K8sResourceCommon {
   metadata?: {
     generation?: number;
   };
@@ -113,15 +237,15 @@ export type EventBrokerKind = {
       url: string;
     };
   };
-} & K8sResourceKind;
+}
 
 export enum TriggerConditionTypes {
   Ready = 'Ready',
 }
 
-type TriggerCondition = {
+interface TriggerCondition extends K8sResourceCondition {
   type: keyof typeof TriggerConditionTypes;
-} & K8sResourceCondition;
+}
 
 export enum BrokerConditionTypes {
   Ready = 'Ready',
@@ -131,7 +255,7 @@ export enum SubscriptionConditionTypes {
   Ready = 'Ready',
 }
 
-export type EventTriggerKind = {
+export interface EventTriggerKind extends K8sResourceCommon {
   metadata?: {
     generation?: number;
   };
@@ -153,12 +277,12 @@ export type EventTriggerKind = {
   status?: {
     conditions?: TriggerCondition[];
   };
-} & K8sResourceKind;
+}
 
-export type DomainMappingResponse = {
+export interface DomainMappingResponse {
   action: string;
-  resource: K8sResourceKind;
-};
+  resource: K8sResourceCommon;
+}
 
 export enum DomainMappingResponseAction {
   Create = 'Create',

--- a/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
+++ b/frontend/packages/knative-plugin/src/utils/create-eventsources-utils.ts
@@ -27,12 +27,21 @@ import { EventSources, SinkType } from '../components/add/import-types';
 import { craftResourceKey } from '../components/pub-sub/pub-sub-utils';
 import { CAMEL_K_PROVIDER_ANNOTATION } from '../const';
 import { CamelKameletModel } from '../models';
+import type {
+  KafkaSourceKind,
+  KameletBindingKind,
+  PingSourceKind,
+  ApiServerSourceKind,
+  ContainerSourceKind,
+  EventSourceKind,
+  AnySourceKind,
+} from '../types';
 import { getEventSourceIcon } from './get-knative-icon';
 
 export const isKnownEventSource = (eventSource: string): boolean =>
   Object.keys(EventSources).includes(eventSource);
 
-export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sResourceKind => {
+export const getEventSourcesDepResource = (formData: EventSourceFormData): AnySourceKind => {
   const {
     type,
     name,
@@ -47,7 +56,7 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
   const defaultLabel = getAppLabels({ name, applicationName });
   const eventSrcData = data[type];
   const { name: sinkName, kind: sinkKind, apiVersion: sinkApiVersion, uri: sinkUri } = sink;
-  const eventSourceResource: K8sResourceKind = {
+  const eventSourceResource: AnySourceKind = {
     apiVersion,
     kind: type,
     metadata: {
@@ -82,11 +91,11 @@ export const getEventSourcesDepResource = (formData: EventSourceFormData): K8sRe
 };
 
 export const isSecretKeyRefPresent = (dataObj: {
-  secretKeyRef: { name: string; key: string };
+  secretKeyRef?: { name?: string; key?: string };
 }): boolean => !!(dataObj?.secretKeyRef?.name || dataObj?.secretKeyRef?.key);
 
-export const getKafkaSourceResource = (formData: any): K8sResourceKind => {
-  const baseResource = getEventSourcesDepResource(formData);
+export const getKafkaSourceResource = (formData: EventSourceFormData): KafkaSourceKind => {
+  const baseResource = getEventSourcesDepResource(formData) as KafkaSourceKind;
   const { net } = baseResource.spec;
   baseResource.spec.net = {
     ...net,
@@ -104,7 +113,7 @@ export const getKafkaSourceResource = (formData: any): K8sResourceKind => {
         tls: { enable: true, caCert: {}, cert: {}, key: {} },
       }),
   };
-  return baseResource;
+  return baseResource satisfies KafkaSourceKind;
 };
 
 export const loadYamlData = <D extends { project?: { name: string } }>(
@@ -124,7 +133,7 @@ export const loadYamlData = <D extends { project?: { name: string } }>(
   return yamlDataObj;
 };
 
-export const getEventSourceResource = (formData: EventSourceFormData) => {
+export const getEventSourceResource = (formData: EventSourceFormData): EventSourceKind => {
   switch (formData.type) {
     case EventSources.KafkaSource:
       return getKafkaSourceResource(formData);
@@ -148,7 +157,7 @@ export const getEventSourceData = (source: string) => {
     [EventSources.PingSource]: {
       data: '',
       schedule: '',
-    },
+    } satisfies PingSourceKind['spec'],
     [EventSources.SinkBinding]: {
       subject: {
         apiVersion: '',
@@ -167,7 +176,7 @@ export const getEventSourceData = (source: string) => {
           kind: '',
         },
       ],
-    },
+    } satisfies ApiServerSourceKind['spec'],
     [EventSources.KafkaSource]: {
       bootstrapServers: [],
       topics: [],
@@ -185,7 +194,7 @@ export const getEventSourceData = (source: string) => {
           key: { secretKeyRef: { name: '', key: '' } },
         },
       },
-    },
+    } satisfies KafkaSourceKind['spec'],
     [EventSources.ContainerSource]: {
       template: {
         spec: {
@@ -198,13 +207,13 @@ export const getEventSourceData = (source: string) => {
             },
           ],
         },
-      },
+      } satisfies ContainerSourceKind['spec']['template'],
     },
   };
   return eventSourceData[source];
 };
 
-export const getKameletSourceData = (kameletData: K8sResourceKind) => ({
+export const getKameletSourceData = (kameletData: K8sResourceKind): KameletBindingKind['spec'] => ({
   source: {
     ref: {
       apiVersion: kameletData.apiVersion,


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
Types were using K8sResourceKind instead of more specific ones

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->
Add more specific types

**Test cases:**
<!-- List possible test cases to validate the changes. -->

n/a - changes do not affect runtime whatsoever

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Knative resource support with richer configuration and status details for services, revisions, routes, event sources, subscriptions, channels, brokers, and triggers.
  * Added more complete handling for source-specific settings, including Kafka, Kamelet, TLS, and secret references.

* **Bug Fixes**
  * Improved event-source resource creation and validation, including optional secret configuration.
  * Improved service status handling and readiness information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->