### PR TITLE
CONSOLE-5475: Use Segment library directly for telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,12 +518,14 @@ Console Bridge server.
 ```sh
 # https://github.com/openshift/console-operator/blob/main/manifests/05-telemetry-config.yaml
 API_HOST="console.redhat.com/connections/api/v1"
+CDN_URL="https://console.redhat.com/connections/cdn"
 JS_HOST="console.redhat.com/connections/cdn"
 PUBLIC_API_KEY="..." # Use API key from the link above
 
 # The BRIDGE_TELEMETRY variable contains a comma separated list of Console telemetry options
 export BRIDGE_TELEMETRY=\
 SEGMENT_API_HOST="${API_HOST}",\
+SEGMENT_CDN_URL="${CDN_URL}",\
 SEGMENT_JS_HOST="${JS_HOST}",\
 SEGMENT_API_KEY="${PUBLIC_API_KEY}",\
 DISABLED="false"

--- a/dynamic-demo-plugin/yarn.lock
+++ b/dynamic-demo-plugin/yarn.lock
@@ -418,6 +418,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lukeed/csprng@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@lukeed/csprng@npm:1.1.0"
+  checksum: 10c0/5d6dcf478af732972083ab2889c294b57f1028fa13c2c240d7a4aaa079c2c75df7ef0dcbdda5419147fc6704b4adf96b2de92f1a9a72ac21c6350c4014fffe6c
+  languageName: node
+  linkType: hard
+
+"@lukeed/uuid@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@lukeed/uuid@npm:2.0.1"
+  dependencies:
+    "@lukeed/csprng": "npm:^1.1.0"
+  checksum: 10c0/f9cc0385021f352f444d96dd101afd2a0efd3b2e85a61ac67deb8220409f75a6a426ed6525d297d97746f7931e3079ac6218777551a7c82686de7d292220cb1f
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:1.1.6":
   version: 1.1.6
   resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
@@ -462,6 +478,7 @@ __metadata:
   dependencies:
     "@openshift/api-types": "npm:^1.0.0"
     "@openshift/dynamic-plugin-sdk": "npm:^9.1.0"
+    "@segment/analytics-next": "npm:1.84.1"
     lodash: "npm:^4.18.1"
     reselect: "npm:^5.1.1"
     typesafe-actions: "npm:^5.1.0"
@@ -779,6 +796,92 @@ __metadata:
   version: 0.4.1
   resolution: "@sec-ant/readable-stream@npm:0.4.1"
   checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-core@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@segment/analytics-core@npm:1.8.3"
+  dependencies:
+    "@lukeed/uuid": "npm:^2.0.0"
+    "@segment/analytics-generic-utils": "npm:1.2.0"
+    dset: "npm:^3.1.4"
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/ae1a807a093b6e20a429e80b95fc3869ddcf7e8c4e37751d607476835df82a331583c092bee4f7f0116ae9a3f550d687fa5478165c8c2583177249aa628eb2e1
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-generic-utils@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@segment/analytics-generic-utils@npm:1.2.0"
+  dependencies:
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/2f9aebc1027ed2d1afcb02338ed4971f774ce25250c499cac6c1c0020a7376e05b56411d38d36ee1cf0cec49cfdb82e68cd3f5d868b47b9e61b3b668bd27e122
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-next@npm:1.84.1":
+  version: 1.84.1
+  resolution: "@segment/analytics-next@npm:1.84.1"
+  dependencies:
+    "@lukeed/uuid": "npm:^2.0.0"
+    "@segment/analytics-core": "npm:1.8.3"
+    "@segment/analytics-generic-utils": "npm:1.2.0"
+    "@segment/analytics-page-tools": "npm:1.0.0"
+    "@segment/analytics.js-video-plugins": "npm:^0.2.1"
+    "@segment/facade": "npm:^3.4.9"
+    dset: "npm:^3.1.4"
+    js-cookie: "npm:^3.0.7"
+    node-fetch: "npm:^2.6.7"
+    tslib: "npm:^2.4.1"
+    unfetch: "npm:^4.1.0"
+  checksum: 10c0/fb10b9ed649055bdf72e0cc365de7f7906fa77f4c4a0ca7e0ce440b7b0821a5c2ef232c9f6d3a5dfcd252520b5f660db11c00a8cec1cc356b34e8db588002f3f
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-page-tools@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@segment/analytics-page-tools@npm:1.0.0"
+  dependencies:
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/4f9fa9489c7a299501bbbf646f6b791de97932dd55a5486e9aa8b19d182b632991defabb33b8c2914f719876591871cef85b94ee1fe1158851b21d3bd88a229a
+  languageName: node
+  linkType: hard
+
+"@segment/analytics.js-video-plugins@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@segment/analytics.js-video-plugins@npm:0.2.1"
+  dependencies:
+    unfetch: "npm:^3.1.1"
+  checksum: 10c0/6c41cb6c78f5db5bff22504dc0f6564bfc89ad0725c112d13001197ba26274fbdebac8defe51de24d1a74da3102beebd852bab884041b965b38732ceda553af5
+  languageName: node
+  linkType: hard
+
+"@segment/facade@npm:^3.4.9":
+  version: 3.4.10
+  resolution: "@segment/facade@npm:3.4.10"
+  dependencies:
+    "@segment/isodate-traverse": "npm:^1.1.1"
+    inherits: "npm:^2.0.4"
+    new-date: "npm:^1.0.3"
+    obj-case: "npm:0.2.1"
+  checksum: 10c0/bfbde4e3270a9d47f50b6bc764ae145fbb9d35e6d9cb6a969af95da94fd33ec5c9952d6c9b9105a087d9a96e2c0a304f0ec86281e8fce40f49c3b32ab58f188c
+  languageName: node
+  linkType: hard
+
+"@segment/isodate-traverse@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@segment/isodate-traverse@npm:1.1.1"
+  dependencies:
+    "@segment/isodate": "npm:^1.0.3"
+  checksum: 10c0/37f78eb7b8e2b57715bd4a7b396961b7d19d1be9e5c02bec539da8643ddd34dbcc223f08c2924e882a43ca149fe3f2f0586a8d6a53f418829068549404b21981
+  languageName: node
+  linkType: hard
+
+"@segment/isodate@npm:1.0.3, @segment/isodate@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@segment/isodate@npm:1.0.3"
+  checksum: 10c0/0b2e9e580fe505e617d7dfbd2d046a3f3bcc7f1f1d1fbaba7728ad1c9da9e47d13a60ec344e2d80b0694d3ed93129d168108e91d4ce2f48012f87dbb40925e8d
   languageName: node
   linkType: hard
 
@@ -1775,6 +1878,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dset@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "dset@npm:3.1.4"
+  checksum: 10c0/b67bbd28dd8a539e90c15ffb61100eb64ef995c5270a124d4f99bbb53f4d82f55a051b731ba81f3215dd9dce2b4c8d69927dc20b3be1c5fc88bab159467aa438
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -2392,6 +2502,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inherits@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
 "inquirer@npm:^13.3.2":
   version: 13.4.3
   resolution: "inquirer@npm:13.4.3"
@@ -2526,6 +2643,13 @@ __metadata:
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10c0/1b1e2310a490dce1aeea3da5f5dfe18273516c20ce48be2e98eb8ea452d5f3dcc8fd0cfd6d28b4052a24c5dbab6e3089b2d7e79f0bce7915b10d750929563c42
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^3.0.7":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 
@@ -2785,6 +2909,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"new-date@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "new-date@npm:1.0.3"
+  dependencies:
+    "@segment/isodate": "npm:1.0.3"
+  checksum: 10c0/0f26626c65e80bf8e99db7ecffa02741d7d053880bd014ef5c6ef6ebbbb8268e8d91b3a67a7bffbfeb8f6726adc703385373853abbff2cbf52bff258d4e79a22
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.27":
   version: 2.0.27
   resolution: "node-releases@npm:2.0.27"
@@ -2818,6 +2965,13 @@ __metadata:
     path-key: "npm:^4.0.0"
     unicorn-magic: "npm:^0.3.0"
   checksum: 10c0/b223c8a0dcd608abf95363ea5c3c0ccc3cd877daf0102eaf1b0f2390d6858d8337fbb7c443af2403b067a7d2c116d10691ecd22ab3c5273c44da1ff8d07753bd
+  languageName: node
+  linkType: hard
+
+"obj-case@npm:0.2.1":
+  version: 0.2.1
+  resolution: "obj-case@npm:0.2.1"
+  checksum: 10c0/754247bb3e355d274bc349667ef9115158f7a78fd62957e722dd00c9a674a6068feeb923bb267be9801bb98a42ee5876f1287e9c5ffdc407d449ed51719d0477
   languageName: node
   linkType: hard
 
@@ -3688,6 +3842,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
+  languageName: node
+  linkType: hard
+
 "ts-loader@npm:^9.5.4":
   version: 9.5.4
   resolution: "ts-loader@npm:9.5.4"
@@ -3742,7 +3903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.7.0, tslib@npm:^2.8.1":
+"tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.7.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -3794,6 +3955,20 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+  languageName: node
+  linkType: hard
+
+"unfetch@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "unfetch@npm:3.1.2"
+  checksum: 10c0/bc3480cfe03d41ca0f1caea05d909ebf0b25d144923e2d46782faf27617e1023d2585f08be6936ab700c5b79c01985bb97673054007ae64b623d49f3585666db
+  languageName: node
+  linkType: hard
+
+"unfetch@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "unfetch@npm:4.2.0"
+  checksum: 10c0/a5c0a896a6f09f278b868075aea65652ad185db30e827cb7df45826fe5ab850124bf9c44c4dafca4bf0c55a0844b17031e8243467fcc38dd7a7d435007151f1b
   languageName: node
   linkType: hard
 
@@ -3893,6 +4068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
 "webpack-cli@npm:^6.0.1":
   version: 6.0.1
   resolution: "webpack-cli@npm:6.0.1"
@@ -3985,6 +4167,16 @@ __metadata:
   dependencies:
     iconv-lite: "npm:0.6.3"
   checksum: 10c0/91b90a49f312dc751496fd23a7e68981e62f33afe938b97281ad766235c4872fc4e66319f925c5e9001502b3040dd25a33b02a9c693b73a4cbbfdc4ad10c3e3e
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 

--- a/frontend/@types/console/window.d.ts
+++ b/frontend/@types/console/window.d.ts
@@ -44,7 +44,20 @@ declare interface Window {
     controlPlaneTopology: string;
     telemetry?: Partial<{
       /** All of the following should be always available on prod env. */
-      SEGMENT_API_HOST: string;
+      /**
+       * The API host to which the Segment script will talk to. Defaults to
+       * "api.segment.io/v1" if undefined.
+       */
+      SEGMENT_API_HOST?: string;
+      /**
+       * Segment's CDN url setting, which must include "https://" and no
+       * trailing slashes. Defaults to "https://cdn.segment.com" if undefined.
+       */
+      SEGMENT_CDN_URL?: string;
+      /**
+       * Legacy way of specifying Segment's CDN host.
+       * @deprecated Use `SEGMENT_CDN_URL` instead.
+       */
       SEGMENT_JS_HOST: string;
       /** One of the following should be always available on prod env. */
       SEGMENT_API_KEY: string;
@@ -52,7 +65,14 @@ declare interface Window {
       // DevSandbox-specific configuration
       DEVSANDBOX_SEGMENT_API_KEY: string;
       DEVSANDBOX: 'true' | 'false';
-      /** Optional override for analytics.min.js script URL */
+      /**
+       * Legacy way of specifying the full URL from which the Segment script
+       * would be loaded.
+       * @deprecated Use `SEGMENT_CDN_URL` instead because the Segment
+       * script is now bundled in the UI. Given a full URL like "https://example.redhat.com/cdn/analytics.js/v1/segmentKey/analytics.min.js",
+       * only the part of the URL until "/analytics.js/v1" is used, excluding
+       * that part.
+       */
       SEGMENT_JS_URL: string;
       // Additional telemetry options passed to Console frontend
       DEBUG: 'true' | 'false';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,6 +81,7 @@
     "@patternfly/react-user-feedback": "~6.4.0",
     "@patternfly/react-virtualized-extension": "~6.2.0",
     "@rjsf/core": "^4.2.3",
+    "@segment/analytics-next": "1.84.1",
     "@xterm/addon-fit": "0.10.0",
     "@xterm/xterm": "^5.5.0",
     "ajv": "^6.12.3",

--- a/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
+++ b/frontend/packages/console-dynamic-plugin-sdk/CHANGELOG-core.md
@@ -16,7 +16,13 @@ table in [Console dynamic plugins README](./README.md).
 
 ## 4.23.0-prerelease.6 - TBD
 
-- Add an `onCancel` prop to `ResourceYAMLEditor` to allow overriding the default cancel behavior ([CONSOLE-5438], [#16941])
+- Replace the hand-rolled Segment snippet with `@segment/analytics-next` (`AnalyticsBrowser`). The library is bundled into the Console frontend and initialized at module load time ([#XXXX], [JIRA-KEY])
+- **Type change**: `GetSegmentAnalytics` now types `analytics` as `AnalyticsBrowser | undefined` instead of `Record<string, ...>`. Re-export `AnalyticsBrowser` from `@openshift-console/dynamic-plugin-sdk` for explicit typing ([#XXXX], [JIRA-KEY])
+- **Dependency**: `@openshift-console/dynamic-plugin-sdk` now lists `@segment/analytics-next` as a runtime dependency ([#XXXX], [JIRA-KEY])
+- **Configuration**: add `SEGMENT_CDN_URL` as the preferred way to override Segment's CDN endpoint. `SEGMENT_JS_HOST` and `SEGMENT_JS_URL` remain supported for backward compatibility but are deprecated ([#XXXX], [JIRA-KEY])
+- **Deprecated**: `SEGMENT_JS_URL` and `SEGMENT_JS_HOST` as CDN configuration. `SEGMENT_JS_URL` values that do not match the `/analytics.js/v1` path pattern are no longer used; configure `SEGMENT_CDN_URL` instead ([#XXXX], [JIRA-KEY])
+- **Behavior change**: remove the automatic `analytics.page()` call on Segment initialization. Page events are now sent only through Console's telemetry flow (after user identification and routing), preventing unidentified page events ([#XXXX], [JIRA-KEY])
+- **Behavior change**: `analyticsEnabled` is set to `false` if Segment initialization fails ([#XXXX], [JIRA-KEY])
 
 ## 4.23.0-prerelease.5 - 2026-08-04
 

--- a/frontend/packages/console-dynamic-plugin-sdk/package.json
+++ b/frontend/packages/console-dynamic-plugin-sdk/package.json
@@ -27,5 +27,8 @@
     "fs-extra": "9.x",
     "ts-json-schema-generator": "2.3.0",
     "tsutils": "3.21.0"
+  },
+  "dependencies": {
+    "@segment/analytics-next": "1.84.1"
   }
 }

--- a/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/scripts/package-definitions.ts
@@ -130,7 +130,13 @@ export const getCorePackage: GetPackageDefinition = (
     dependencies: {
       ...parseDeps(
         rootPackage,
-        ['@openshift/api-types', '@openshift/dynamic-plugin-sdk', 'reselect', 'typesafe-actions'],
+        [
+          '@openshift/api-types',
+          '@openshift/dynamic-plugin-sdk',
+          '@segment/analytics-next',
+          'reselect',
+          'typesafe-actions',
+        ],
         missingDepCallback,
       ),
       ...parseDepsAs(rootPackage, { 'lodash-es': 'lodash' }, missingDepCallback),

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/__tests__/segment-analytics.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/__tests__/segment-analytics.spec.ts
@@ -1,0 +1,354 @@
+import { AnalyticsBrowser } from '@segment/analytics-next';
+
+const mockLoad = jest.fn();
+const mockAnalyticsInstance = { load: mockLoad };
+
+type SegmentAnalyticsModule = {
+  getSegmentAnalytics: () => {
+    analytics: typeof mockAnalyticsInstance | undefined;
+    analyticsEnabled: boolean;
+  };
+  isSegmentDisabled: boolean;
+  isSegmentDebugModeEnabled: boolean;
+};
+
+jest.mock('@segment/analytics-next', () => ({
+  AnalyticsBrowser: jest.fn(() => mockAnalyticsInstance),
+}));
+
+const MockAnalyticsBrowser = AnalyticsBrowser as jest.MockedClass<typeof AnalyticsBrowser>;
+
+const loadSegmentAnalyticsModule = (): SegmentAnalyticsModule => {
+  let moduleExports: SegmentAnalyticsModule | undefined;
+  jest.isolateModules(() => {
+    moduleExports = jest.requireActual('../segment-analytics') as SegmentAnalyticsModule;
+  });
+  if (!moduleExports) {
+    throw new Error('Failed to load segment-analytics module');
+  }
+  return moduleExports;
+};
+
+describe('segment-analytics', () => {
+  let originalServerFlags: typeof window.SERVER_FLAGS;
+  let randomSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    originalServerFlags = window.SERVER_FLAGS;
+    mockLoad.mockReset();
+    mockLoad.mockReturnValue({ catch: jest.fn() });
+    MockAnalyticsBrowser.mockClear();
+    randomSpy = jest.spyOn(Math, 'random');
+  });
+
+  afterEach(() => {
+    window.SERVER_FLAGS = originalServerFlags;
+    randomSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  const setTelemetry = (telemetry: Record<string, string>) => {
+    window.SERVER_FLAGS = { ...originalServerFlags, telemetry };
+  };
+
+  const loadWithTelemetry = (
+    telemetry: Record<string, string>,
+    randomValue = 0.1,
+  ): SegmentAnalyticsModule => {
+    setTelemetry(telemetry);
+    randomSpy.mockReturnValue(randomValue);
+    return loadSegmentAnalyticsModule();
+  };
+
+  describe('isSegmentDisabled', () => {
+    it('is true when no API key is configured', () => {
+      const { isSegmentDisabled } = loadWithTelemetry({});
+
+      expect(isSegmentDisabled).toBe(true);
+    });
+
+    it('is true when DISABLED is "true"', () => {
+      const { isSegmentDisabled } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        DISABLED: 'true',
+      });
+
+      expect(isSegmentDisabled).toBe(true);
+    });
+
+    it('is true when DEVSANDBOX_DISABLED is "true"', () => {
+      const { isSegmentDisabled } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        DEVSANDBOX_DISABLED: 'true',
+      });
+
+      expect(isSegmentDisabled).toBe(true);
+    });
+
+    it('is true when TELEMETER_CLIENT_DISABLED is "true"', () => {
+      const { isSegmentDisabled } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        TELEMETER_CLIENT_DISABLED: 'true',
+      });
+
+      expect(isSegmentDisabled).toBe(true);
+    });
+
+    it('is false when an API key is present and disable flags are not set', () => {
+      const { isSegmentDisabled } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+      });
+
+      expect(isSegmentDisabled).toBe(false);
+    });
+  });
+
+  describe('isSegmentDebugModeEnabled', () => {
+    it('is true when DEBUG is "true"', () => {
+      const { isSegmentDebugModeEnabled } = loadWithTelemetry({ DEBUG: 'true' });
+
+      expect(isSegmentDebugModeEnabled).toBe(true);
+    });
+
+    it('is false when DEBUG is not "true"', () => {
+      const { isSegmentDebugModeEnabled } = loadWithTelemetry({ DEBUG: 'false' });
+
+      expect(isSegmentDebugModeEnabled).toBe(false);
+    });
+  });
+
+  describe('API key resolution', () => {
+    it('prefers the DevSandbox API key when DEVSANDBOX is "true"', () => {
+      loadWithTelemetry({
+        DEVSANDBOX: 'true',
+        DEVSANDBOX_SEGMENT_API_KEY: 'devsandbox-key',
+        SEGMENT_API_KEY: 'prod-key',
+        SEGMENT_PUBLIC_API_KEY: 'public-key',
+      });
+
+      expect(MockAnalyticsBrowser).toHaveBeenCalled();
+      expect(mockLoad).toHaveBeenCalledWith(
+        expect.objectContaining({ writeKey: 'devsandbox-key' }),
+        expect.any(Object),
+      );
+    });
+
+    it('falls back to SEGMENT_API_KEY', () => {
+      loadWithTelemetry({ SEGMENT_API_KEY: 'segment-key' });
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        expect.objectContaining({ writeKey: 'segment-key' }),
+        expect.any(Object),
+      );
+    });
+
+    it('falls back to SEGMENT_PUBLIC_API_KEY when SEGMENT_API_KEY is absent', () => {
+      loadWithTelemetry({ SEGMENT_PUBLIC_API_KEY: 'public-key' });
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        expect.objectContaining({ writeKey: 'public-key' }),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('session sampling', () => {
+    it('enables analytics when the session is sampled', () => {
+      const { getSegmentAnalytics } = loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' }, 0.1);
+
+      expect(getSegmentAnalytics()).toEqual({
+        analytics: mockAnalyticsInstance,
+        analyticsEnabled: true,
+      });
+    });
+
+    it('disables analytics when the session is not sampled', () => {
+      const { getSegmentAnalytics } = loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' }, 0.9);
+
+      expect(getSegmentAnalytics()).toEqual({
+        analytics: undefined,
+        analyticsEnabled: false,
+      });
+      expect(MockAnalyticsBrowser).not.toHaveBeenCalled();
+    });
+
+    it('treats a random value of 0.2 as not sampled', () => {
+      const { getSegmentAnalytics } = loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' }, 0.2);
+
+      expect(getSegmentAnalytics().analyticsEnabled).toBe(false);
+    });
+  });
+
+  describe('AnalyticsBrowser initialization', () => {
+    it('does not initialize Segment when telemetry is disabled', () => {
+      loadWithTelemetry({ DISABLED: 'true', SEGMENT_API_KEY: 'test-key' });
+
+      expect(MockAnalyticsBrowser).not.toHaveBeenCalled();
+      expect(mockLoad).not.toHaveBeenCalled();
+    });
+
+    it('loads Segment with the default CDN URL when no override is configured', () => {
+      loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' });
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        {
+          cdnURL: undefined,
+          writeKey: 'test-key',
+        },
+        {},
+      );
+    });
+
+    it('loads Segment with the resolved CDN URL and write key', () => {
+      loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_CDN_URL: 'https://example.com/cdn',
+      });
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        {
+          cdnURL: 'https://example.com/cdn',
+          writeKey: 'test-key',
+        },
+        {},
+      );
+    });
+
+    it('does not initialize Segment when a CDN override resolves to undefined', () => {
+      const { getSegmentAnalytics } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_CDN_URL: 'http://example.com/cdn',
+      });
+
+      expect(getSegmentAnalytics()).toEqual({
+        analytics: undefined,
+        analyticsEnabled: false,
+      });
+      expect(MockAnalyticsBrowser).not.toHaveBeenCalled();
+      expect(mockLoad).not.toHaveBeenCalled();
+    });
+
+    it('does not initialize Segment when a protocol-relative CDN override is configured', () => {
+      const { getSegmentAnalytics } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_CDN_URL: '//example.com/cdn',
+      });
+
+      expect(getSegmentAnalytics()).toEqual({
+        analytics: undefined,
+        analyticsEnabled: false,
+      });
+      expect(MockAnalyticsBrowser).not.toHaveBeenCalled();
+      expect(mockLoad).not.toHaveBeenCalled();
+    });
+
+    it('does not initialize Segment when a legacy CDN override does not match', () => {
+      const { getSegmentAnalytics } = loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_JS_URL: 'https://example.redhat.com/custom/analytics.min.js',
+      });
+
+      expect(getSegmentAnalytics()).toEqual({
+        analytics: undefined,
+        analyticsEnabled: false,
+      });
+      expect(MockAnalyticsBrowser).not.toHaveBeenCalled();
+      expect(mockLoad).not.toHaveBeenCalled();
+    });
+
+    it('logs a warning when DEBUG is enabled and a CDN override is invalid', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      loadWithTelemetry({
+        DEBUG: 'true',
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_CDN_URL: 'http://example.com/cdn',
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Segment CDN URL override is invalid; disabling analytics',
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('passes the API host in load options when configured', () => {
+      loadWithTelemetry({
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_API_HOST: 'console.redhat.com/connections/api/v1',
+      });
+
+      expect(mockLoad).toHaveBeenCalledWith(expect.any(Object), {
+        integrations: {
+          'Segment.io': { apiHost: 'console.redhat.com/connections/api/v1' },
+        },
+      });
+    });
+
+    it('does not pass integrations when the API host is not configured', () => {
+      loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' });
+
+      expect(mockLoad).toHaveBeenCalledWith(expect.any(Object), {});
+    });
+
+    it('logs initialization details when DEBUG is enabled', () => {
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+      loadWithTelemetry({
+        DEBUG: 'true',
+        SEGMENT_API_KEY: 'test-key',
+        SEGMENT_CDN_URL: 'https://example.com/cdn',
+        SEGMENT_API_HOST: 'console.redhat.com/connections/api/v1',
+      });
+
+      expect(infoSpy).toHaveBeenCalledWith('Initialize Segment Analytics', {
+        apiHost: 'console.redhat.com/connections/api/v1',
+        apiKey: 'test-key',
+        cdnURL: 'https://example.com/cdn',
+      });
+
+      infoSpy.mockRestore();
+    });
+
+    it('logs a debug message when DEBUG is enabled and the session is not sampled', () => {
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+
+      loadWithTelemetry({ DEBUG: 'true', SEGMENT_API_KEY: 'test-key' }, 0.9);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        'Analytics session is not being sampled, telemetry events will be ignored',
+      );
+
+      debugSpy.mockRestore();
+    });
+
+    it('does not log an unsampled-session debug message when DEBUG is disabled', () => {
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+
+      loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' }, 0.9);
+
+      expect(debugSpy).not.toHaveBeenCalled();
+
+      debugSpy.mockRestore();
+    });
+
+    it('logs an error when Segment initialization fails', () => {
+      const loadError = new Error('Unable to load Segment');
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockLoad.mockReturnValue({
+        catch: jest.fn((handler: (error: Error) => void) => {
+          handler(loadError);
+        }),
+      });
+
+      loadWithTelemetry({ SEGMENT_API_KEY: 'test-key' });
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Unable to initialize Segment analytics script',
+        loadError,
+      );
+
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/__tests__/segment-utils.spec.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/__tests__/segment-utils.spec.ts
@@ -1,0 +1,242 @@
+import { hasSegmentCdnOverride, resolveSegmentCdnUrl } from '../segment-utils';
+
+describe('hasSegmentCdnOverride', () => {
+  let originalServerFlags: typeof window.SERVER_FLAGS;
+
+  beforeEach(() => {
+    originalServerFlags = window.SERVER_FLAGS;
+  });
+
+  afterEach(() => {
+    window.SERVER_FLAGS = originalServerFlags;
+  });
+
+  const setTelemetry = (telemetry: Record<string, string> | undefined) => {
+    window.SERVER_FLAGS = { ...originalServerFlags, telemetry };
+  };
+
+  it('returns false when telemetry is missing', () => {
+    window.SERVER_FLAGS = { ...originalServerFlags };
+    delete window.SERVER_FLAGS.telemetry;
+
+    expect(hasSegmentCdnOverride()).toBe(false);
+  });
+
+  it('returns false when no CDN override keys are configured', () => {
+    setTelemetry({ SEGMENT_API_KEY: 'test-key' });
+
+    expect(hasSegmentCdnOverride()).toBe(false);
+  });
+
+  it('returns true when SEGMENT_CDN_URL is configured', () => {
+    setTelemetry({ SEGMENT_CDN_URL: 'https://example.com/cdn' });
+
+    expect(hasSegmentCdnOverride()).toBe(true);
+  });
+
+  it('returns true when SEGMENT_JS_URL is configured', () => {
+    setTelemetry({
+      SEGMENT_JS_URL: 'https://example.redhat.com/cdn/analytics.js/v1/abcde/analytics.min.js',
+    });
+
+    expect(hasSegmentCdnOverride()).toBe(true);
+  });
+
+  it('returns true when SEGMENT_JS_HOST is configured', () => {
+    setTelemetry({ SEGMENT_JS_HOST: 'console.redhat.com/connections/cdn' });
+
+    expect(hasSegmentCdnOverride()).toBe(true);
+  });
+});
+
+describe('resolveSegmentCdnUrl', () => {
+  let originalServerFlags: typeof window.SERVER_FLAGS;
+
+  beforeEach(() => {
+    originalServerFlags = window.SERVER_FLAGS;
+  });
+
+  afterEach(() => {
+    window.SERVER_FLAGS = originalServerFlags;
+  });
+
+  const setTelemetry = (telemetry: Record<string, string> | undefined) => {
+    window.SERVER_FLAGS = { ...originalServerFlags, telemetry };
+  };
+
+  describe('when telemetry is not configured', () => {
+    it('returns undefined when telemetry is missing', () => {
+      window.SERVER_FLAGS = { ...originalServerFlags };
+      delete window.SERVER_FLAGS.telemetry;
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('returns undefined when telemetry is empty', () => {
+      setTelemetry({});
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+  });
+
+  describe('SEGMENT_CDN_URL', () => {
+    it('returns the CDN URL with https protocol unchanged', () => {
+      setTelemetry({ SEGMENT_CDN_URL: 'https://console.redhat.com/connections/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://console.redhat.com/connections/cdn');
+    });
+
+    it('rejects the CDN URL when http protocol is used', () => {
+      setTelemetry({ SEGMENT_CDN_URL: 'http://example.com/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('rejects protocol-relative CDN URLs', () => {
+      setTelemetry({ SEGMENT_CDN_URL: '//example.com/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('prepends https when the CDN URL has no protocol', () => {
+      setTelemetry({ SEGMENT_CDN_URL: 'console.redhat.com/connections/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://console.redhat.com/connections/cdn');
+    });
+
+    it('strips trailing slashes', () => {
+      setTelemetry({ SEGMENT_CDN_URL: 'https://example.com/cdn///' });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://example.com/cdn');
+    });
+
+    it('takes precedence over SEGMENT_JS_URL and SEGMENT_JS_HOST', () => {
+      setTelemetry({
+        SEGMENT_CDN_URL: 'https://preferred.example.com/cdn',
+        SEGMENT_JS_URL: 'https://ignored.example.com/cdn/analytics.js/v1/key/analytics.min.js',
+        SEGMENT_JS_HOST: 'ignored.example.com',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://preferred.example.com/cdn');
+    });
+  });
+
+  describe('SEGMENT_JS_URL', () => {
+    it('strips the /analytics.js/v1/... suffix from a legacy full script URL', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://example.redhat.com/cdn/analytics.js/v1/abcde/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://example.redhat.com/cdn');
+    });
+
+    it('normalizes the stripped base URL when it has no protocol', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'example.redhat.com/cdn/analytics.js/v1/abcde/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://example.redhat.com/cdn');
+    });
+
+    it('strips trailing slashes from the stripped base URL', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://example.redhat.com/cdn///analytics.js/v1/abcde/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://example.redhat.com/cdn');
+    });
+
+    it('returns undefined when the legacy URL does not match /analytics.js/v1', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://example.redhat.com/custom/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('returns undefined when the legacy URL contains /analytics.js/v10', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://example.redhat.com/cdn/analytics.js/v10/abcde/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('returns undefined when the legacy URL contains /analytics.js/v1-old', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://example.redhat.com/cdn/analytics.js/v1-old/abcde/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('logs a debug message when DEBUG is true and the legacy URL does not match', () => {
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+      setTelemetry({
+        DEBUG: 'true',
+        SEGMENT_JS_URL: 'https://example.redhat.com/custom/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+      expect(debugSpy).toHaveBeenCalledWith(
+        'A legacy "SEGMENT_JS_URL" was provided, but no "/analytics.js/v1" was matched',
+        'https://example.redhat.com/custom/analytics.min.js',
+      );
+
+      debugSpy.mockRestore();
+    });
+
+    it('does not log when DEBUG is not true and the legacy URL does not match', () => {
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://example.redhat.com/custom/analytics.min.js',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+      expect(debugSpy).not.toHaveBeenCalled();
+
+      debugSpy.mockRestore();
+    });
+
+    it('takes precedence over SEGMENT_JS_HOST when SEGMENT_CDN_URL is not set', () => {
+      setTelemetry({
+        SEGMENT_JS_URL: 'https://preferred.example.com/cdn/analytics.js/v1/key/analytics.min.js',
+        SEGMENT_JS_HOST: 'ignored.example.com',
+      });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://preferred.example.com/cdn');
+    });
+  });
+
+  describe('SEGMENT_JS_HOST', () => {
+    it('prepends https when only a hostname is provided', () => {
+      setTelemetry({ SEGMENT_JS_HOST: 'console.redhat.com/connections/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://console.redhat.com/connections/cdn');
+    });
+
+    it('returns the host URL unchanged when https is already present', () => {
+      setTelemetry({ SEGMENT_JS_HOST: 'https://console.redhat.com/connections/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://console.redhat.com/connections/cdn');
+    });
+
+    it('rejects the host URL when http is already present', () => {
+      setTelemetry({ SEGMENT_JS_HOST: 'http://example.com/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('rejects protocol-relative host URLs', () => {
+      setTelemetry({ SEGMENT_JS_HOST: '//example.com/cdn' });
+
+      expect(resolveSegmentCdnUrl()).toBeUndefined();
+    });
+
+    it('strips trailing slashes from the host URL', () => {
+      setTelemetry({ SEGMENT_JS_HOST: 'https://example.com/cdn/' });
+
+      expect(resolveSegmentCdnUrl()).toBe('https://example.com/cdn');
+    });
+  });
+});

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-console-api.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/internal-console-api.ts
@@ -6,7 +6,11 @@ import { GetSegmentAnalytics } from '../extensions/console-types';
  *
  * This API is meant to be used by Red Hat plugins only.
  *
- * Console application takes care of loading the analytics.min.js script.
+ * The client is initialized at module load time. `analytics.load()` is
+ * asynchronous, but `@segment/analytics-next` buffers calls made before load
+ * completes. Check `analyticsEnabled` before sending events which is `false`
+ * when telemetry is disabled, the session is not sampled, or initialization
+ * failed.
  *
  * @example
  * ```ts
@@ -19,5 +23,5 @@ import { GetSegmentAnalytics } from '../extensions/console-types';
  *
  * @see https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/
  */
-export const getSegmentAnalytics: GetSegmentAnalytics = require('@console/dynamic-plugin-sdk/src/api/segment-analytics')
-  .getSegmentAnalytics;
+export const getSegmentAnalytics: GetSegmentAnalytics =
+  require('@console/dynamic-plugin-sdk/src/api/segment-analytics').getSegmentAnalytics;

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-analytics.ts
@@ -1,127 +1,107 @@
+import type { InitOptions } from '@segment/analytics-next';
+import { AnalyticsBrowser } from '@segment/analytics-next';
 import type { GetSegmentAnalytics } from '../extensions/console-types';
+import { hasSegmentCdnOverride, resolveSegmentCdnUrl } from './segment-utils';
 
-// Segment API key. Must be present for telemetry to be enabled.
-// When running in DevSandbox mode, prefer the DevSandbox-specific key.
-const TELEMETRY_API_KEY =
+// Segment's API key. When the cluster is running in the Developer Sandbox
+// environment, use their API key instead.
+const apiKey =
   (window.SERVER_FLAGS.telemetry?.DEVSANDBOX === 'true' &&
     window.SERVER_FLAGS.telemetry?.DEVSANDBOX_SEGMENT_API_KEY) ||
   window.SERVER_FLAGS.telemetry?.SEGMENT_API_KEY ||
   window.SERVER_FLAGS.telemetry?.SEGMENT_PUBLIC_API_KEY ||
   '';
 
-// Segment "apiHost" parameter, should be like "api.segment.io/v1"
-const TELEMETRY_API_HOST = window.SERVER_FLAGS.telemetry?.SEGMENT_API_HOST || '';
+// Overrideable Segment's API host. The Segment client falls back to its
+// default value "api.segment.io/v1" if none defined.
+const apiHost = window.SERVER_FLAGS.telemetry?.SEGMENT_API_HOST;
 
-// Segment JS host, defaults to "cdn.segment.com" if not defined
-const TELEMETRY_JS_HOST = window.SERVER_FLAGS.telemetry?.SEGMENT_JS_HOST || 'cdn.segment.com';
+// Overrideable Segment's CDN URL. The Segment client falls back to its
+// default value "https://cdn.segment.com" if no overrides have been given.
+const cdnURL = resolveSegmentCdnUrl();
+const hasCdnOverride = hasSegmentCdnOverride();
 
-// Segment analytics.min.js script URL
-const TELEMETRY_JS_URL =
-  window.SERVER_FLAGS.telemetry?.SEGMENT_JS_URL ||
-  `https://${TELEMETRY_JS_HOST}/analytics.js/v1/${encodeURIComponent(
-    TELEMETRY_API_KEY,
-  )}/analytics.min.js`;
+// Flag whether we want the debug logs for our telemetry code.
+const isDebugModeEnabled = window.SERVER_FLAGS.telemetry?.DEBUG === 'true';
 
-export const TELEMETRY_DISABLED =
-  !TELEMETRY_API_KEY ||
+// Sample 20% of sessions
+const isSessionBeingSampled = Math.random() < 0.2;
+
+if (!isSessionBeingSampled && isDebugModeEnabled) {
+  console.debug('Analytics session is not being sampled, telemetry events will be ignored');
+}
+
+// Make sure that we have the required configuration bits to enable the
+// Segment integration.
+const isDisabled =
+  !apiKey ||
   window.SERVER_FLAGS.telemetry?.DISABLED === 'true' ||
   window.SERVER_FLAGS.telemetry?.DEVSANDBOX_DISABLED === 'true' ||
   window.SERVER_FLAGS.telemetry?.TELEMETER_CLIENT_DISABLED === 'true';
 
-export const TELEMETRY_DEBUG = window.SERVER_FLAGS.telemetry?.DEBUG === 'true';
-
-// Sample 20% of sessions
-const SAMPLE_SESSION = Math.random() < 0.2;
-
-// TODO: replace this copy-pasted Segment init snippet with proper use of Segment package
-// https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-2-install-segment-to-your-site
-const initSegmentAnalytics = () => {
-  if (TELEMETRY_DEBUG) {
-    console.info('Initialize Segment Analytics', {
-      TELEMETRY_API_HOST,
-      TELEMETRY_API_KEY,
-      TELEMETRY_JS_HOST,
-      TELEMETRY_JS_URL,
-    });
-  }
-  // eslint-disable-next-line no-multi-assign
-  const analytics = ((window as any).analytics = (window as any).analytics || []);
-  if (analytics.initialize) {
-    return;
-  }
-  if (analytics.invoked) {
-    console.error('Analytics snippet included twice');
-    return;
-  }
-  analytics.invoked = true;
-  analytics.methods = [
-    'trackSubmit',
-    'trackClick',
-    'trackLink',
-    'trackForm',
-    'pageview',
-    'identify',
-    'reset',
-    'group',
-    'track',
-    'ready',
-    'alias',
-    'debug',
-    'page',
-    'once',
-    'off',
-    'on',
-    'addSourceMiddleware',
-    'addIntegrationMiddleware',
-    'setAnonymousId',
-    'addDestinationMiddleware',
-  ];
-  analytics.factory = function (e: string) {
-    return function () {
-      // eslint-disable-next-line prefer-rest-params
-      const t = Array.prototype.slice.call(arguments);
-      t.unshift(e);
-      analytics.push(t);
-      return analytics;
-    };
-  };
-  for (const key of analytics.methods) {
-    analytics[key] = analytics.factory(key);
-  }
-  analytics.load = function (key: string, e: Event) {
-    const t = document.createElement('script');
-    t.type = 'text/javascript';
-    t.async = true;
-    t.src = TELEMETRY_JS_URL;
-    const n = document.getElementsByTagName('script')[0];
-    if (n.parentNode) {
-      n.parentNode.insertBefore(t, n);
-    }
-    // eslint-disable-next-line no-underscore-dangle
-    analytics._loadOptions = e;
-  };
-  analytics.SNIPPET_VERSION = '4.13.1';
-  const options: Record<string, any> = {};
-  if (TELEMETRY_API_HOST) {
-    options.integrations = { 'Segment.io': { apiHost: TELEMETRY_API_HOST } };
-  }
-  analytics.load(TELEMETRY_API_KEY, options);
-  analytics.page(); // Make the first page call to load the integrations
-};
-
-if (!SAMPLE_SESSION) {
-  console.debug('Analytics session is not being sampled, telemetry events will be ignored');
-}
-
-const analyticsEnabled = !TELEMETRY_DISABLED && SAMPLE_SESSION;
+// We only want the Segment integration enabled for the sessions that are
+// being sampled.
+let isEnabled = !isDisabled && isSessionBeingSampled;
 
 // Initialize Segment Analytics as soon as possible, outside of React useEffect.
 // This ensures that analytics.load method is invoked before any other methods.
-if (analyticsEnabled) {
-  initSegmentAnalytics();
+let analytics: AnalyticsBrowser | undefined;
+if (isEnabled) {
+  if (hasCdnOverride && cdnURL === undefined) {
+    if (isDebugModeEnabled) {
+      console.warn('Segment CDN URL override is invalid; disabling analytics');
+    }
+    isEnabled = false;
+  } else {
+    if (isDebugModeEnabled) {
+      console.info('Initialize Segment Analytics', {
+        apiHost,
+        apiKey,
+        cdnURL,
+      });
+    }
+
+    const options: InitOptions = {};
+    if (apiHost) {
+      options.integrations = { 'Segment.io': { apiHost } };
+    }
+
+    analytics = new AnalyticsBrowser();
+    analytics
+      .load(
+        {
+          cdnURL,
+          writeKey: apiKey,
+        },
+        options,
+      )
+      .catch((error) => {
+        console.error('Unable to initialize Segment analytics script', error);
+        isEnabled = false;
+      });
+  }
 }
 
+/**
+ * Segment analytics client returned by `getSegmentAnalytics`.
+ * @see getSegmentAnalytics in `@openshift-console/dynamic-plugin-sdk-internal`.
+ */
+export type SegmentAnalyticsClient = AnalyticsBrowser;
+
 export const getSegmentAnalytics: GetSegmentAnalytics = () => ({
-  analytics: (window as any).analytics,
-  analyticsEnabled,
+  analytics,
+  analyticsEnabled: isEnabled,
 });
+
+/**
+ * Whether telemetry is disabled by cluster configuration. Use
+ * `getSegmentAnalytics().analyticsEnabled` to determine if the current
+ * session is being sampled and if we are actively sending events to Segment.
+ */
+export { isDisabled as isSegmentDisabled };
+
+/**
+ * Whether debug mode is enabled to report any extra information that we might
+ * want to log.
+ */
+export { isDebugModeEnabled as isSegmentDebugModeEnabled };

--- a/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-utils.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/api/segment-utils.ts
@@ -1,0 +1,126 @@
+/**
+ * Whether the given URL uses the HTTPS protocol.
+ * @param url the URL to validate. Callers must handle an undefined URL separately.
+ * @returns `true` when the URL uses HTTPS, `false` otherwise.
+ */
+export const isHttpsCdnUrl = (url: string): boolean => {
+  try {
+    return new URL(url).protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Normalizes the given URL.
+ * @param url the URL to be normalized.
+ * @returns the given URL with the `https` protocol prepended and no trailing
+ * slashes, or `undefined` when the URL is not HTTPS.
+ */
+const normalizeCdnUrl = function (url: string): string | undefined {
+  let sanitizedUrl: string;
+
+  if (url.startsWith('//')) {
+    return undefined;
+  }
+
+  if (url.startsWith('https://')) {
+    sanitizedUrl = url;
+  } else if (url.startsWith('http://')) {
+    return undefined;
+  } else {
+    sanitizedUrl = `https://${url}`;
+  }
+
+  const normalized = sanitizedUrl.replace(/\/+$/, '');
+  if (!isHttpsCdnUrl(normalized)) {
+    return undefined;
+  }
+
+  return normalized;
+};
+
+/**
+ * Whether a Segment CDN override is configured in telemetry settings.
+ * @returns `true` when any CDN override key is present.
+ */
+export const hasSegmentCdnOverride = function (): boolean {
+  const { telemetry } = window.SERVER_FLAGS;
+  return !!(telemetry?.SEGMENT_CDN_URL || telemetry?.SEGMENT_JS_URL || telemetry?.SEGMENT_JS_HOST);
+};
+
+/**
+ * Resolve the CDN URL for Segment.
+ * @returns `undefined` for when the `telemetry` segment is not present, no CDN
+ * override is configured, or a configured override cannot be normalized to a
+ * valid HTTPS URL. Otherwise, it returns one of the following three in the
+ * following order: the `SEGMENT_CDN_URL`, the `SEGMENT_JS_URL` by stripping
+ * anything that goes after the "/analytics.js/v1" part, or the `SEGMENT_JS_HOST`
+ * by making sure that it has an `https` protocol defined.
+ */
+export const resolveSegmentCdnUrl = function (): string | undefined {
+  const { telemetry } = window.SERVER_FLAGS;
+  if (!telemetry) {
+    return undefined;
+  }
+
+  // The newly defined CDN URL takes preference if it is set.
+  if (telemetry.SEGMENT_CDN_URL) {
+    const normalizedCdnUrl = normalizeCdnUrl(telemetry.SEGMENT_CDN_URL);
+    if (!normalizedCdnUrl) {
+      return undefined;
+    }
+
+    return normalizedCdnUrl;
+  }
+
+  // If present, take the "SEGMENT_JS_URL" and strip the "/analytics.js/v1"
+  // part which is not required for the CDN URL. The old code either took the
+  // "SEGMENT_JS_URL" if present directly and used in the Segment's script
+  // "src" tag or it constructed a URL with the following format:
+  //
+  // - https://${TELEMETRY_JS_HOST}/analytics.js/v1/${encodeURIComponent(TELEMETRY_API_KEY)}/analytics.min.js
+  //
+  // Therefore we are assuming that the URLs will have these formats too if
+  // specified.
+  //
+  // The following example shows what we end up with if the variable is set,
+  // after parsing it with regex:
+  //
+  // - https://example.redhat.com/cdn/analytics.js/v1/abcde/analytics.min.js
+  // - https://example.redhat.com/cdn
+  if (telemetry.SEGMENT_JS_URL) {
+    const match = telemetry.SEGMENT_JS_URL.match(/^(.+?)\/analytics\.js\/v1(?:[/?#].*)?$/);
+    if (match) {
+      const normalizedCdnUrl = normalizeCdnUrl(match[1]);
+      if (!normalizedCdnUrl) {
+        return undefined;
+      }
+
+      return normalizedCdnUrl;
+    }
+    if (window.SERVER_FLAGS.telemetry?.DEBUG === 'true') {
+      // eslint-disable-next-line no-console
+      console.debug(
+        'A legacy "SEGMENT_JS_URL" was provided, but no "/analytics.js/v1" was matched',
+        telemetry.SEGMENT_JS_URL,
+      );
+    }
+
+    return undefined;
+  }
+
+  // Ultimately, if the "SEGMENT_JS_HOST" is set, simply make sure that it has
+  // the proper "https" protocol set, because the Segment library expects a
+  // URL, not just a hostname.
+  if (telemetry.SEGMENT_JS_HOST) {
+    const normalizedCdnUrl = normalizeCdnUrl(telemetry.SEGMENT_JS_HOST);
+    if (!normalizedCdnUrl) {
+      return undefined;
+    }
+
+    return normalizedCdnUrl;
+  }
+
+  return undefined;
+};

--- a/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
+++ b/frontend/packages/console-dynamic-plugin-sdk/src/extensions/console-types.ts
@@ -1,11 +1,11 @@
 import type {
   ComponentType,
-  ReactNode,
-  ReactText,
-  ReactNodeArray,
-  SetStateAction,
   Dispatch,
   ElementType,
+  ReactNode,
+  ReactNodeArray,
+  ReactText,
+  SetStateAction,
 } from 'react';
 import type { K8sResourceCommon, ObjectMetadata } from '@openshift/api-types';
 import type {
@@ -35,14 +35,15 @@ import type {
   PrometheusValue,
   Selector,
 } from '../api/common-types';
+import type { SegmentAnalyticsClient } from '../api/segment-analytics';
 import type { CustomDataSource } from './dashboard-data-source';
 
 /* eslint-disable no-barrel-files/no-barrel-files */
 export type {
-  ManagedFieldsEntry,
-  OwnerReference,
-  ObjectMetadata,
   K8sResourceCommon,
+  ManagedFieldsEntry,
+  ObjectMetadata,
+  OwnerReference,
 } from '@openshift/api-types';
 /* eslint-enable no-barrel-files/no-barrel-files */
 
@@ -270,8 +271,7 @@ export type UseResolvedExtensions = <E extends Extension>(
 ) => [LoadedAndResolvedExtension<E>[], boolean, any[]];
 
 export type GetSegmentAnalytics = () => {
-  // TODO: use proper Segment Analytics API type
-  analytics: Record<string, (...args: any) => any>;
+  analytics: SegmentAnalyticsClient | undefined;
   analyticsEnabled: boolean;
 };
 

--- a/frontend/packages/console-telemetry-plugin/src/flags/detect-telemetry.ts
+++ b/frontend/packages/console-telemetry-plugin/src/flags/detect-telemetry.ts
@@ -1,10 +1,10 @@
 import {
-  TELEMETRY_DEBUG,
-  TELEMETRY_DISABLED,
+  isSegmentDebugModeEnabled,
+  isSegmentDisabled,
 } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
 import type { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
 
 export const detectTelemetry = (setFeatureFlag: SetFeatureFlag) => {
-  setFeatureFlag('TELEMETRY_DEBUG', TELEMETRY_DEBUG);
-  setFeatureFlag('TELEMETRY', !TELEMETRY_DISABLED);
+  setFeatureFlag('TELEMETRY_DEBUG', isSegmentDebugModeEnabled);
+  setFeatureFlag('TELEMETRY', !isSegmentDisabled);
 };

--- a/frontend/packages/console-telemetry-plugin/src/listeners/debug.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/debug.ts
@@ -1,8 +1,8 @@
-import { TELEMETRY_DEBUG } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
+import { isSegmentDebugModeEnabled } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
 import type { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src/extensions/telemetry';
 
 export const eventListener: TelemetryEventListener = (eventType: string, properties?: any) => {
-  if (TELEMETRY_DEBUG) {
+  if (isSegmentDebugModeEnabled) {
     console.debug('console-telemetry-plugin: received telemetry event:', eventType, properties);
   }
 };

--- a/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
+++ b/frontend/packages/console-telemetry-plugin/src/listeners/segment.ts
@@ -1,6 +1,6 @@
 import {
-  TELEMETRY_DEBUG,
   getSegmentAnalytics,
+  isSegmentDebugModeEnabled,
 } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
 import type { TelemetryEventListener } from '@console/dynamic-plugin-sdk/src/extensions/telemetry';
 import type { TelemetryEventProperties } from '@console/shared/src/hooks/useTelemetry';
@@ -30,8 +30,8 @@ export const eventListener: TelemetryEventListener = async (
 ) => {
   const { analytics, analyticsEnabled } = getSegmentAnalytics();
 
-  if (!analyticsEnabled) {
-    if (TELEMETRY_DEBUG) {
+  if (!analytics || !analyticsEnabled) {
+    if (isSegmentDebugModeEnabled) {
       console.debug(
         'console-telemetry-plugin: analytics is disabled, ignoring telemetry event',
         eventType,
@@ -69,7 +69,7 @@ export const eventListener: TelemetryEventListener = async (
             processedUserId = await anonymizeId(userId);
           }
 
-          if (TELEMETRY_DEBUG) {
+          if (isSegmentDebugModeEnabled) {
             console.debug(
               'console-telemetry-plugin: use anonymized user identifier to group events',
               { username, clusterId, organizationId, userId, processedUserId },
@@ -86,7 +86,7 @@ export const eventListener: TelemetryEventListener = async (
       }
       break;
     case 'page':
-      analytics.page(undefined, properties, anonymousIP);
+      analytics.page(undefined, undefined, properties, anonymousIP);
       break;
     default:
       analytics.track(eventType, properties, anonymousIP);

--- a/frontend/packages/console-telemetry-plugin/src/providers/telemetry-provider.ts
+++ b/frontend/packages/console-telemetry-plugin/src/providers/telemetry-provider.ts
@@ -1,4 +1,4 @@
-import { TELEMETRY_DISABLED } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
+import { isSegmentDisabled } from '@console/dynamic-plugin-sdk/src/api/segment-analytics';
 import type { SetFeatureFlag } from '@console/dynamic-plugin-sdk/src/extensions/feature-flags';
 import { CLUSTER_TELEMETRY_ANALYTICS } from '@console/shared/src/constants/common';
 import { FLAG_TELEMETRY_ENABLED, FLAG_TELEMETRY_USER_PREFERENCE } from '../const';
@@ -8,6 +8,6 @@ const isTelemetryUserPreferenceEnabled = () =>
   window.SERVER_FLAGS.telemetry?.STATE === CLUSTER_TELEMETRY_ANALYTICS.OPTOUT;
 
 export const useTelemetryProvider = (setFeatureFlag: SetFeatureFlag) => {
-  setFeatureFlag(FLAG_TELEMETRY_ENABLED, !TELEMETRY_DISABLED);
+  setFeatureFlag(FLAG_TELEMETRY_ENABLED, !isSegmentDisabled);
   setFeatureFlag(FLAG_TELEMETRY_USER_PREFERENCE, isTelemetryUserPreferenceEnabled());
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1486,6 +1486,7 @@ __metadata:
   resolution: "@console/dynamic-plugin-sdk@workspace:packages/console-dynamic-plugin-sdk"
   dependencies:
     "@microsoft/tsdoc": "npm:0.14.2"
+    "@segment/analytics-next": "npm:1.84.1"
     "@types/ejs": "npm:3.x"
     "@types/fs-extra": "npm:9.x"
     ejs: "npm:3.x"
@@ -3251,6 +3252,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lukeed/csprng@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@lukeed/csprng@npm:1.1.0"
+  checksum: 10c0/5d6dcf478af732972083ab2889c294b57f1028fa13c2c240d7a4aaa079c2c75df7ef0dcbdda5419147fc6704b4adf96b2de92f1a9a72ac21c6350c4014fffe6c
+  languageName: node
+  linkType: hard
+
+"@lukeed/uuid@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@lukeed/uuid@npm:2.0.1"
+  dependencies:
+    "@lukeed/csprng": "npm:^1.1.0"
+  checksum: 10c0/f9cc0385021f352f444d96dd101afd2a0efd3b2e85a61ac67deb8220409f75a6a426ed6525d297d97746f7931e3079ac6218777551a7c82686de7d292220cb1f
+  languageName: node
+  linkType: hard
+
 "@microsoft/tsdoc-config@npm:0.17.1":
   version: 0.17.1
   resolution: "@microsoft/tsdoc-config@npm:0.17.1"
@@ -4702,6 +4719,92 @@ __metadata:
   version: 0.4.1
   resolution: "@sec-ant/readable-stream@npm:0.4.1"
   checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-core@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@segment/analytics-core@npm:1.8.3"
+  dependencies:
+    "@lukeed/uuid": "npm:^2.0.0"
+    "@segment/analytics-generic-utils": "npm:1.2.0"
+    dset: "npm:^3.1.4"
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/ae1a807a093b6e20a429e80b95fc3869ddcf7e8c4e37751d607476835df82a331583c092bee4f7f0116ae9a3f550d687fa5478165c8c2583177249aa628eb2e1
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-generic-utils@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@segment/analytics-generic-utils@npm:1.2.0"
+  dependencies:
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/2f9aebc1027ed2d1afcb02338ed4971f774ce25250c499cac6c1c0020a7376e05b56411d38d36ee1cf0cec49cfdb82e68cd3f5d868b47b9e61b3b668bd27e122
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-next@npm:1.84.1":
+  version: 1.84.1
+  resolution: "@segment/analytics-next@npm:1.84.1"
+  dependencies:
+    "@lukeed/uuid": "npm:^2.0.0"
+    "@segment/analytics-core": "npm:1.8.3"
+    "@segment/analytics-generic-utils": "npm:1.2.0"
+    "@segment/analytics-page-tools": "npm:1.0.0"
+    "@segment/analytics.js-video-plugins": "npm:^0.2.1"
+    "@segment/facade": "npm:^3.4.9"
+    dset: "npm:^3.1.4"
+    js-cookie: "npm:^3.0.7"
+    node-fetch: "npm:^2.6.7"
+    tslib: "npm:^2.4.1"
+    unfetch: "npm:^4.1.0"
+  checksum: 10c0/fb10b9ed649055bdf72e0cc365de7f7906fa77f4c4a0ca7e0ce440b7b0821a5c2ef232c9f6d3a5dfcd252520b5f660db11c00a8cec1cc356b34e8db588002f3f
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-page-tools@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@segment/analytics-page-tools@npm:1.0.0"
+  dependencies:
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/4f9fa9489c7a299501bbbf646f6b791de97932dd55a5486e9aa8b19d182b632991defabb33b8c2914f719876591871cef85b94ee1fe1158851b21d3bd88a229a
+  languageName: node
+  linkType: hard
+
+"@segment/analytics.js-video-plugins@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@segment/analytics.js-video-plugins@npm:0.2.1"
+  dependencies:
+    unfetch: "npm:^3.1.1"
+  checksum: 10c0/6c41cb6c78f5db5bff22504dc0f6564bfc89ad0725c112d13001197ba26274fbdebac8defe51de24d1a74da3102beebd852bab884041b965b38732ceda553af5
+  languageName: node
+  linkType: hard
+
+"@segment/facade@npm:^3.4.9":
+  version: 3.4.10
+  resolution: "@segment/facade@npm:3.4.10"
+  dependencies:
+    "@segment/isodate-traverse": "npm:^1.1.1"
+    inherits: "npm:^2.0.4"
+    new-date: "npm:^1.0.3"
+    obj-case: "npm:0.2.1"
+  checksum: 10c0/bfbde4e3270a9d47f50b6bc764ae145fbb9d35e6d9cb6a969af95da94fd33ec5c9952d6c9b9105a087d9a96e2c0a304f0ec86281e8fce40f49c3b32ab58f188c
+  languageName: node
+  linkType: hard
+
+"@segment/isodate-traverse@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@segment/isodate-traverse@npm:1.1.1"
+  dependencies:
+    "@segment/isodate": "npm:^1.0.3"
+  checksum: 10c0/37f78eb7b8e2b57715bd4a7b396961b7d19d1be9e5c02bec539da8643ddd34dbcc223f08c2924e882a43ca149fe3f2f0586a8d6a53f418829068549404b21981
+  languageName: node
+  linkType: hard
+
+"@segment/isodate@npm:1.0.3, @segment/isodate@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@segment/isodate@npm:1.0.3"
+  checksum: 10c0/0b2e9e580fe505e617d7dfbd2d046a3f3bcc7f1f1d1fbaba7728ad1c9da9e47d13a60ec344e2d80b0694d3ed93129d168108e91d4ce2f48012f87dbb40925e8d
   languageName: node
   linkType: hard
 
@@ -9931,6 +10034,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dset@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "dset@npm:3.1.4"
+  checksum: 10c0/b67bbd28dd8a539e90c15ffb61100eb64ef995c5270a124d4f99bbb53f4d82f55a051b731ba81f3215dd9dce2b4c8d69927dc20b3be1c5fc88bab159467aa438
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:^1.0.0, dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -14294,6 +14404,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-cookie@npm:^3.0.7":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
+  languageName: node
+  linkType: hard
+
 "js-string-escape@npm:^1.0.1":
   version: 1.0.1
   resolution: "js-string-escape@npm:1.0.1"
@@ -16060,6 +16177,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"new-date@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "new-date@npm:1.0.3"
+  dependencies:
+    "@segment/isodate": "npm:1.0.3"
+  checksum: 10c0/0f26626c65e80bf8e99db7ecffa02741d7d053880bd014ef5c6ef6ebbbb8268e8d91b3a67a7bffbfeb8f6726adc703385373853abbff2cbf52bff258d4e79a22
+  languageName: node
+  linkType: hard
+
 "next-tick@npm:~1.0.0":
   version: 1.0.0
   resolution: "next-tick@npm:1.0.0"
@@ -16119,7 +16245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.3.0, node-fetch@npm:^2.7.0":
+"node-fetch@npm:^2.3.0, node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -16286,6 +16412,13 @@ __metadata:
   version: 3.8.6
   resolution: "oauth4webapi@npm:3.8.6"
   checksum: 10c0/479810716702c5616e4a0eb80d4f1c264a6a2b63b04061a62a59375e195d2726e947507ede98e41ee3f9ca800f159621ea371c36f5c4346d015b6ec03e477440
+  languageName: node
+  linkType: hard
+
+"obj-case@npm:0.2.1":
+  version: 0.2.1
+  resolution: "obj-case@npm:0.2.1"
+  checksum: 10c0/754247bb3e355d274bc349667ef9115158f7a78fd62957e722dd00c9a674a6068feeb923bb267be9801bb98a42ee5876f1287e9c5ffdc407d449ed51719d0477
   languageName: node
   linkType: hard
 
@@ -16518,6 +16651,7 @@ __metadata:
     "@rspack/core": "npm:^2.1.10"
     "@rspack/dev-server": "npm:^2.2.0"
     "@rspack/plugin-react-refresh": "npm:^2.0.2"
+    "@segment/analytics-next": "npm:1.84.1"
     "@swc/core": "npm:^1.15.47"
     "@swc/jest": "npm:^0.2.39"
     "@testing-library/dom": "npm:^10.4.1"
@@ -20391,7 +20525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.2, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.5.2, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -20669,6 +20803,20 @@ __metadata:
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
   checksum: 10c0/08d0f2596553aa0a54ca6e8e9c7f45aef7d042c60918564e3a142d449eda165a80196f6ef19ea2ef2e6446959e293095d8e40af1236f0d67223b06afac5ecad7
+  languageName: node
+  linkType: hard
+
+"unfetch@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "unfetch@npm:3.1.2"
+  checksum: 10c0/bc3480cfe03d41ca0f1caea05d909ebf0b25d144923e2d46782faf27617e1023d2585f08be6936ab700c5b79c01985bb97673054007ae64b623d49f3585666db
+  languageName: node
+  linkType: hard
+
+"unfetch@npm:^4.1.0":
+  version: 4.2.0
+  resolution: "unfetch@npm:4.2.0"
+  checksum: 10c0/a5c0a896a6f09f278b868075aea65652ad185db30e827cb7df45826fe5ab850124bf9c44c4dafca4bf0c55a0844b17031e8243467fcc38dd7a7d435007151f1b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
We were using a copy-pasted snippet which downloaded the Segment's analytics script, and that included an `analytics.page()` call which sent an event to Segment even if the user has not been identified yet. That added some noise to Segment's reporting, because an event was being fired on page load even if the user then was immediately redirected to SSO for login.

**Solution description**:
Bundle @segment/analytics-next" instead of loading the analytics script via the copy-pasted snippet.

Use a SEGMENT_CDN_URL as the preferred CDN override and keep the old SEGMENT_JS_HOST/SEGMENT_JS_URL for backwards compatibility, although the latter one significantly changes its behavior now: we do not fetch the script from anywhere, so we attempt extracting the CDN's URL from it instead to give it to the bundled library's settings. There is no need to download the script anymore, so the goal is to make it easier to configure Segment.

Stop calling analytics.page(), which was included in the copy-pasted snippet, upon telemtry load. The goal of it is to only send events to Segment if the user is identified, which it happens at a later stage in the UI.

Type getSegmentAnalytics as "AnalyticsBrowser | undefined" for a proper type for the Segment object.

**Screenshots / screen recording**:
N/A

**Test setup:**
N/A

**Test cases:**
<!-- List possible test cases to validate the changes. -->
1. Load a Console unauthenticated and make sure that no event is fired towards Segment.

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable Segment CDN endpoint support with HTTPS URL normalization and legacy setting fallback.
  - Analytics integrations now use typed clients with asynchronous loading and buffered events.

- **Bug Fixes**
  - Telemetry now disables cleanly when initialization fails, telemetry is disabled, or sessions are not sampled.
  - Debug logging and telemetry status detection are more consistent across the console.

- **Documentation**
  - Updated telemetry configuration guidance with the new CDN setting and deprecation of legacy JavaScript host settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->