### PR TITLE
[release-4.21] OCPBUGS-122212: Wait for demo plugin deployment readiness

### DIFF
--- a/dynamic-demo-plugin/oc-manifest.yaml
+++ b/dynamic-demo-plugin/oc-manifest.yaml
@@ -31,6 +31,11 @@ spec:
             - containerPort: 9001
               protocol: TCP
           imagePullPolicy: Always
+          readinessProbe:
+            tcpSocket:
+              port: 9001
+            initialDelaySeconds: 5
+            periodSeconds: 5
           args:
             - '--ssl'
             - '--cert=/var/serving-cert/tls.crt'

--- a/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
+++ b/frontend/packages/integration-tests-cypress/tests/app/demo-dynamic-plugin.cy.ts
@@ -94,14 +94,20 @@ if (!Cypress.env('OPENSHIFT_CI') || Cypress.env('PLUGIN_PULL_SPEC')) {
           deployment.spec.template.spec.containers[0].image = PLUGIN_PULL_SPEC;
           const service = yamlManifest.find(({ kind }) => kind === 'Service');
           const consolePlugin = yamlManifest.find(({ kind }) => kind === 'ConsolePlugin');
-          cy.exec(` echo '${JSON.stringify(deployment)}' | oc create -f -`, {
+          // Create the Service first so its serving-cert annotation creates the
+          // TLS secret before the Deployment tries to mount it.
+          cy.exec(` echo '${JSON.stringify(service)}' | oc create -f -`, {
             failOnNonZeroExit: false,
           })
+            .then((result) => {
+              console.log('Error: ', result.stderr);
+              console.log('Success: ', result.stdout);
+            })
             .its('stdout')
             .should('contain', 'created')
             .then(() =>
               cy
-                .exec(` echo '${JSON.stringify(service)}' | oc create -f -`, {
+                .exec(` echo '${JSON.stringify(deployment)}' | oc create -f -`, {
                   failOnNonZeroExit: false,
                 })
                 .then((result) => {
@@ -110,6 +116,12 @@ if (!Cypress.env('OPENSHIFT_CI') || Cypress.env('PLUGIN_PULL_SPEC')) {
                 })
                 .its('stdout')
                 .should('contain', 'created'),
+            )
+            .then(() =>
+              cy.exec(
+                `oc rollout status deployment/${PLUGIN_NAME} -n ${PLUGIN_NAME} --timeout=2m`,
+                { timeout: 180000 },
+              ),
             )
             .then(() =>
               cy


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>

https://redhat.atlassian.net/browse/OCPBUGS-122212

<h2 id="solution-description">Solution description</h2>

Create the demo plugin Service before its Deployment so the serving certificate is available, add a TCP readiness probe, and wait for rollout completion before creating and enabling the ConsolePlugin.

<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>

N/A

<h2 id="test-cases">Test cases:</h2>

- Ran the demo dynamic plugin Cypress suite locally with the plugin server and console bridge: 12/12 passed.
- Verified on an OpenShift 4.21 cluster that the Service/certificate existed before the Deployment became available and the ConsolePlugin was created.

<h2 id="additional-info">Additional info:</h2>

Local validation only; repeated Prow runs are still required to confirm the intermittent CI failure is resolved.

<h2 id="screenshots">Screen shots / gifs / design review:</h2>

N/A — test-only change.