### PR TITLE
OCPBUGS-115204: Fix Namespace column hidden on Node Pods tab with active namespace

### DIFF
--- a/frontend/public/components/pod-list.tsx
+++ b/frontend/public/components/pod-list.tsx
@@ -585,6 +585,7 @@ export const PodList: FC<PodListProps> = ({
         columns={columns}
         columnLayout={columnLayout}
         columnManagementID={columnManagementID}
+        showNamespaceOverride={showNamespaceOverride}
         initialFilters={initialFilters}
         additionalFilterNodes={additionalFilterNodes}
         matchesAdditionalFilters={matchesAdditionalFilters}


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

PodList receives showNamespaceOverride as a prop and embeds it in the columnLayout object, but it was never forwarded as a direct prop to ConsoleDataView. Since showNamespaceOverride was destructured out of ...props in PodList's signature, the spread {...props} on ConsoleDataView didn't carry it through. 

ConsoleDataView only uses the direct prop (not columnLayout.showNamespaceOverride) when calling useActiveColumns to determine actual column visibility — so the Namespace column was always being filtered out whenever a specific namespace was active, despite showNamespaceOverride being set on the Node's Pods tab.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Add showNamespaceOverride={showNamespaceOverride} to the ConsoleDataView call in PodList.

**Screenshots / screen recording**:
<!-- Add screenshots or screen recordings for visual changes. Be sure to include before and after videos where relevant -->

before:
<img width="1545" height="982" alt="image" src="https://github.com/user-attachments/assets/2dc39d69-961f-44f6-8fbf-d2807d687ff3" />

after:
<img width="1545" height="982" alt="image" src="https://github.com/user-attachments/assets/64856f26-0672-46c3-9f3e-3bf85f9bd4e8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Namespace display overrides now apply consistently in pod list views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->