### PR TITLE
OCPBUGS-122384: Sanitize locale resource path segments

### DIFF
--- a/pkg/plugins/handlers.go
+++ b/pkg/plugins/handlers.go
@@ -111,6 +111,16 @@ func (p *PluginsHandler) HandleI18nResources(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if !isSinglePathSegment(lang) {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: "invalid 'lng' query parameter: value must be a single path segment"})
+		return
+	}
+
+	if !isSinglePathSegment(namespace) {
+		serverutils.SendResponse(w, http.StatusBadRequest, serverutils.ApiError{Err: "invalid 'ns' query parameter: value must be a single path segment"})
+		return
+	}
+
 	if !strings.HasPrefix(namespace, "plugin__") {
 		http.ServeFile(w, r, path.Join(p.PublicDir, "locales", lang, fmt.Sprintf("%s.json", namespace)))
 		return
@@ -225,4 +235,9 @@ func parsePluginNameAndAssetPath(urlPath string) (string, string) {
 		return nameAndAssetPath[0], ""
 	}
 	return nameAndAssetPath[0], nameAndAssetPath[1]
+}
+
+// Restrict user-controlled locale identifiers to a single path segment.
+func isSinglePathSegment(value string) bool {
+	return value != "." && value != ".." && path.Clean(value) == value && !strings.ContainsAny(value, `/\\`)
 }

--- a/pkg/plugins/handlers_test.go
+++ b/pkg/plugins/handlers_test.go
@@ -1,0 +1,133 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestHandleI18nResourcesServesStaticLocale(t *testing.T) {
+	dir := t.TempDir()
+	localesDir := path.Join(dir, "locales", "en")
+	if err := os.MkdirAll(localesDir, 0o755); err != nil {
+		t.Fatalf("failed to create locales dir: %v", err)
+	}
+
+	const expectedBody = `{"hello":"world"}`
+	if err := os.WriteFile(path.Join(localesDir, "public.json"), []byte(expectedBody), 0o644); err != nil {
+		t.Fatalf("failed to write locale file: %v", err)
+	}
+
+	handler := NewPluginsHandler(http.DefaultClient, nil, dir)
+	req := httptest.NewRequest(http.MethodGet, "/locales/resource.json?lng=en&ns=public", nil)
+	rec := httptest.NewRecorder()
+
+	handler.HandleI18nResources(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	if got := strings.TrimSpace(rec.Body.String()); got != expectedBody {
+		t.Fatalf("expected body %q, got %q", expectedBody, got)
+	}
+}
+
+func TestHandleI18nResourcesProxiesPluginLocale(t *testing.T) {
+	var requestedPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"plugin":"ok"}`))
+	}))
+	defer backend.Close()
+
+	handler := NewPluginsHandler(backend.Client(), map[string]string{
+		"demo-plugin": backend.URL + "/plugin-root",
+	}, t.TempDir())
+	req := httptest.NewRequest(http.MethodGet, "/locales/resource.json?lng=en&ns=plugin__demo-plugin", nil)
+	rec := httptest.NewRecorder()
+
+	handler.HandleI18nResources(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	if requestedPath != "/plugin-root/locales/en/plugin__demo-plugin.json" {
+		t.Fatalf("expected backend request path %q, got %q", "/plugin-root/locales/en/plugin__demo-plugin.json", requestedPath)
+	}
+
+	if got := rec.Body.String(); got != `{"plugin":"ok"}` {
+		t.Fatalf("expected body %q, got %q", `{"plugin":"ok"}`, got)
+	}
+}
+
+func TestHandleI18nResourcesRejectsInvalidLocalePathSegments(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantErr    string
+		setupProxy bool
+	}{
+		{
+			name:    "rejects language traversal for static locale",
+			url:     "/locales/resource.json?lng=../../..&ns=public",
+			wantErr: "invalid 'lng' query parameter",
+		},
+		{
+			name:    "rejects namespace traversal for static locale",
+			url:     "/locales/resource.json?lng=en&ns=../public",
+			wantErr: "invalid 'ns' query parameter",
+		},
+		{
+			name:       "rejects language traversal for plugin locale before proxying",
+			url:        "/locales/resource.json?lng=../../..&ns=plugin__demo-plugin",
+			wantErr:    "invalid 'lng' query parameter",
+			setupProxy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backendHit := false
+			pluginsEndpointMap := map[string]string{}
+			var client *http.Client
+
+			if tt.setupProxy {
+				backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					backendHit = true
+					w.WriteHeader(http.StatusOK)
+				}))
+				defer backend.Close()
+
+				client = backend.Client()
+				pluginsEndpointMap["demo-plugin"] = backend.URL + "/plugin-root"
+			} else {
+				client = http.DefaultClient
+			}
+
+			handler := NewPluginsHandler(client, pluginsEndpointMap, t.TempDir())
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			rec := httptest.NewRecorder()
+
+			handler.HandleI18nResources(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+			}
+
+			if !strings.Contains(rec.Body.String(), tt.wantErr) {
+				t.Fatalf("expected response body to contain %q, got %q", tt.wantErr, rec.Body.String())
+			}
+
+			if backendHit {
+				t.Fatalf("expected invalid locale request to be rejected before proxying")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Analysis / Root cause**:
The locale resource handler accepted `lng` and `ns` query parameters and used them to build filesystem and proxy paths without validating that they were safe single path segments. This allowed path traversal sequences to escape the intended locale directory structure.

**Solution description**:
Validate `lng` and `ns` before using them to construct paths in `pkg/plugins/handlers.go`.

The handler now:
- accepts only single path segment values for `lng` and `ns`
- rejects traversal and nested path values with `400 Bad Request`
- applies the same validation to both static locale file serving and dynamic plugin locale proxying

This change also adds Go unit tests in `pkg/plugins/handlers_test.go` for valid requests and traversal attempts.

**Screenshots / screen recording**:
N/A, backend-only change

**Test setup:**
No special setup required.

**Test cases:**
- Request a valid built-in locale resource and verify it is served successfully
- Request a valid dynamic plugin locale resource and verify it is proxied successfully
- Request a locale resource with traversal in `lng` and verify the handler returns `400`
- Request a locale resource with traversal in `ns` and verify the handler returns `400`
- Verify invalid plugin locale requests are rejected before any proxy request is sent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security when loading locale resources by rejecting invalid or traversal-based language and namespace paths.
  - Preserved safe serving of static locale files and proxying of plugin-provided translations.

- **Tests**
  - Added coverage for static locale serving, plugin locale proxying, request path construction, and invalid path rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->